### PR TITLE
40 improve pattern minimize space method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix QFT circuits in examples (#38)
 - Improve `Pattern.minimize_space` method because it sometimes returned incorrect results when applied to graphs with flow, as compared to the theoretical values (#40)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Move `generate_from_pattern` method from `gflow.py` to `generator.py` (#40)
+- Modify `Pattern.get_meas_plane` method to be adaptable for general cases (#40)
+
+### Fixed
+
+- Improve `Pattern.minimize_space` method because it sometimes returned incorrect results when applied to graphs with flow, as compared to the theoretical values (#40)
+
+
+## [0.2.0] - 2023-03-16
+
+### Added
+
+- Fast circuit translation for selected types gates and circuits (#16)
+- Additional required modules: `quimb` and `autoray` for more performant TN backend (#32)
+
+### Changed
+
+- Restructured tensor-network simulator backend for more optimized contraction (#32)
+
+### Fixed
+
+- Treatment of isolated node in `perform_pauli_measurements()` method (#36)
+
+
+## [0.1.2] - 2022-12-21
+
+### Added
+
+- added QAOA demo to documentation and improved readme
+
+### Fixed
+
+- Fix manual input pattern (#11)
+
+
+## [0.1.1] - 2022-12-19
+
+### Fixed
+
+- nested array error in numpy 1.24 (deprecated from 1.23.*) fixed and numpy version changed in requirements.txt (#7)
+- circuit.standardize_and_transpile() error fixed (#9)
+
+
+## [0.1.0] - 2022-12-15

--- a/docs/source/flow.rst
+++ b/docs/source/flow.rst
@@ -7,8 +7,6 @@ flow and gflow
 
 .. currentmodule:: graphix.gflow
 
-.. autofunction:: generate_from_graph
-
 .. autofunction:: gflow
 
 .. autofunction:: flow

--- a/docs/source/generator.rst
+++ b/docs/source/generator.rst
@@ -34,7 +34,9 @@ Pattern Generation
 
     .. automethod:: rz
 
-Flow-based pattern generation
+:mod:`graphix.generator` module
 +++++++++++++++++++++++++++++
 
-.. autofunction:: graphix.gflow.generate_from_graph
+.. currentmodule:: graphix.generator
+
+.. autofunction:: graphix.generator.generate_from_graph

--- a/graphix/__init__.py
+++ b/graphix/__init__.py
@@ -1,5 +1,5 @@
 from graphix.transpiler import Circuit
-from graphix.gflow import generate_from_graph
+from graphix.generator import generate_from_graph
 from graphix.pattern import Pattern
 from graphix.sim.statevec import Statevec
 from graphix.graphsim import GraphState

--- a/graphix/generator.py
+++ b/graphix/generator.py
@@ -1,0 +1,107 @@
+"""
+MBQC pattern generator
+
+"""
+
+
+import numpy as np
+from graphix.pattern import Pattern
+from graphix.gflow import flow, gflow, get_layers, find_odd_neighbor
+
+
+def generate_from_graph(graph, angles, inputs, outputs, timeout=100):
+    r"""Generate the measurement pattern from open graph and measurement angles.
+
+    This function takes an open graph G = (nodes, edges, input, outputs),
+    specified by networks.Graph and two lists specifying input and output nodes.
+    Currently we support XY-plane measurements.
+
+    Searches for the flow in the open graph using :func:`flow` and if found,
+    construct the measurement pattern according to the theorem 1 of [NJP 9, 250 (2007)].
+
+    Then, if no flow was found, searches for gflow using :func:`gflow`,
+    from which measurement pattern can be constructed from theorem 2 of [NJP 9, 250 (2007)].
+
+    The constructed measurement pattern deterministically realize the unitary embedding
+
+    .. math::
+
+        U = \left( \prod_i \langle +_{\alpha_i} |_i \right) E_G N_{I^C},
+
+    where the measurements (bras) with always :math:`\langle+|` bases determined by the measurement
+    angles :math:`\alpha_i` are applied to the measuring nodes,
+    i.e. the randomness of the measurement is eliminated by the added byproduct commands.
+
+    .. seealso:: :func:`flow` :func:`gflow` :class:`graphix.pattern.Pattern`
+
+    Parameters
+    ----------
+    graph : networkx.Graph
+        graph on which MBQC should be performed
+    angles : dict
+        measurement angles for each nodes on the graph (unit of pi), except output nodes
+    inputs : list
+        list of node indices for input nodes
+    outputs : list
+        list of node indices for output nodes
+    timeout : int
+        optional argument for flow and gflow search depth
+
+    Returns
+    -------
+    pattern : graphix.pattern.Pattern object
+        constructed pattern.
+    """
+    assert len(inputs) == len(outputs)
+    measuring_nodes = list(set(graph.nodes) - set(outputs) - set(inputs))
+
+    # search for flow first
+    f, l_k = flow(graph, set(inputs), set(outputs), timeout=timeout)
+    if f:
+        # flow found
+        depth, layers = get_layers(l_k)
+        pattern = Pattern(len(inputs))
+        pattern.seq = [["N", i] for i in inputs]
+        for i in set(graph.nodes) - set(inputs):
+            pattern.seq.append(["N", i])
+        for e in graph.edges:
+            pattern.seq.append(["E", e])
+        measured = []
+        for i in range(depth, 0, -1):  # i from depth, depth-1, ... 1
+            for j in layers[i]:
+                measured.append(j)
+                pattern.seq.append(["M", j, "XY", angles[j], [], []])
+                for k in set(graph.neighbors(f[j])) - set([j]):
+                    if k not in measured:
+                        pattern.seq.append(["Z", k, [j]])
+                pattern.seq.append(["X", f[j], [j]])
+        pattern.output_nodes = outputs
+        pattern.Nnode = len(graph.nodes)
+    else:
+        # no flow found - we try gflow
+        g, l_k = gflow(graph, set(inputs), set(outputs), timeout=timeout)
+        if g:
+            # gflow found
+            depth, layers = get_layers(l_k)
+            pattern = Pattern(len(inputs))
+            pattern.seq = [["N", i] for i in inputs]
+            for i in set(graph.nodes) - set(inputs):
+                pattern.seq.append(["N", i])
+            for e in graph.edges:
+                pattern.seq.append(["E", e])
+            remaining = set(measuring_nodes)
+            for i in range(depth, 0, -1):  # i from depth, depth-1, ... 1
+                for j in layers[i]:
+                    pattern.seq.append(["M", j, "XY", angles[j], [], []])
+                    remaining = remaining - set([j])
+                    odd_neighbors = find_odd_neighbor(graph, remaining, set(g[j]))
+                    for k in odd_neighbors:
+                        pattern.seq.append(["Z", k, [j]])
+                    for k in set(g[j]) - set([j]):
+                        pattern.seq.append(["X", k, [j]])
+            pattern.output_nodes = outputs
+            pattern.Nnode = len(graph.nodes)
+        else:
+            raise ValueError("no flow or gflow found")
+
+    return pattern

--- a/graphix/gflow.py
+++ b/graphix/gflow.py
@@ -15,105 +15,6 @@ import networkx as nx
 import numpy as np
 import z3
 import copy
-from graphix.pattern import Pattern
-
-
-def generate_from_graph(graph, angles, inputs, outputs, timeout=100):
-    r"""Generate the measurement pattern from open graph and measurement angles.
-
-    This function takes an open graph G = (nodes, edges, input, outputs),
-    specified by networks.Graph and two lists specifying input and output nodes.
-    Currently we support XY-plane measurements.
-
-    Searches for the flow in the open graph using :func:`flow` and if found,
-    construct the measurement pattern according to the theorem 1 of [NJP 9, 250 (2007)].
-
-    Then, if no flow was found, searches for gflow using :func:`gflow`,
-    from which measurement pattern can be constructed from theorem 2 of [NJP 9, 250 (2007)].
-
-    The constructed measurement pattern deterministically realize the unitary embedding
-
-    .. math::
-
-        U = \left( \prod_i \langle +_{\alpha_i} |_i \right) E_G N_{I^C},
-
-    where the measurements (bras) with always :math:`\langle+|` bases determined by the measurement
-    angles :math:`\alpha_i` are applied to the measuring nodes,
-    i.e. the randomness of the measurement is eliminated by the added byproduct commands.
-
-    .. seealso:: :func:`flow` :func:`gflow` :class:`graphix.pattern.Pattern`
-
-    Parameters
-    ----------
-    graph : networkx.Graph
-        graph on which MBQC should be performed
-    angles : dict
-        measurement angles for each nodes on the graph (unit of pi), except output nodes
-    inputs : list
-        list of node indices for input nodes
-    outputs : list
-        list of node indices for output nodes
-    timeout : int
-        optional argument for flow and gflow search depth
-
-    Returns
-    -------
-    pattern : graphix.pattern.Pattern object
-        constructed pattern.
-    """
-    assert len(inputs) == len(outputs)
-    measuring_nodes = list(set(graph.nodes) - set(outputs) - set(inputs))
-
-    # search for flow first
-    f, l_k = flow(graph, set(inputs), set(outputs), timeout=timeout)
-    if f:
-        # flow found
-        depth, layers = get_layers(l_k)
-        pattern = Pattern(len(inputs))
-        pattern.seq = [["N", i] for i in inputs]
-        for i in set(graph.nodes) - set(inputs):
-            pattern.seq.append(["N", i])
-        for e in graph.edges:
-            pattern.seq.append(["E", e])
-        measured = []
-        for i in range(depth, 0, -1):  # i from depth, depth-1, ... 1
-            for j in layers[i]:
-                measured.append(j)
-                pattern.seq.append(["M", j, "XY", angles[j], [], []])
-                for k in set(graph.neighbors(f[j])) - set([j]):
-                    if k not in measured:
-                        pattern.seq.append(["Z", k, [j]])
-                pattern.seq.append(["X", f[j], [j]])
-        pattern.output_nodes = outputs
-        pattern.Nnode = len(graph.nodes)
-    else:
-        # no flow found - we try gflow
-        g, l_k = gflow(graph, set(inputs), set(outputs), timeout=timeout)
-        if g:
-            # gflow found
-            depth, layers = get_layers(l_k)
-            pattern = Pattern(len(inputs))
-            pattern.seq = [["N", i] for i in inputs]
-            for i in set(graph.nodes) - set(inputs):
-                pattern.seq.append(["N", i])
-            for e in graph.edges:
-                pattern.seq.append(["E", e])
-            remaining = set(measuring_nodes)
-            for i in range(depth, 0, -1):  # i from depth, depth-1, ... 1
-                for j in layers[i]:
-                    pattern.seq.append(["M", j, "XY", angles[j], [], []])
-                    remaining = remaining - set([j])
-                    odd_neighbors = find_odd_neighbor(graph, remaining, set(g[j]))
-                    for k in odd_neighbors:
-                        pattern.seq.append(["Z", k, [j]])
-                    for k in set(g[j]) - set([j]):
-                        pattern.seq.append(["X", k, [j]])
-            pattern.output_nodes = outputs
-            pattern.Nnode = len(graph.nodes)
-        else:
-            raise ValueError("no flow or gflow found")
-
-    return pattern
 
 
 def solvebool(A, b):
@@ -172,7 +73,7 @@ def solvebool(A, b):
         return False
 
 
-def gflow(g, v_in, v_out, meas_plane=None, timeout=100):
+def gflow(g, v_in, v_out, meas_plane=None, timeout=1000):
     """Optimum generalized flow finding algorithm
 
     For open graph g with input and output, this returns optimum gflow.
@@ -286,7 +187,6 @@ def gflowaux(v, gamma, index_list, v_in, v_out, g, l_k, k, meas_plane):
 
     # if index_0 or index_1 is blank, skip the calculation below
     if len(index_0) * len(index_1):
-
         gamma_sub = gamma[index_0, index_1]
 
         for u in iter(v_rem):
@@ -322,7 +222,7 @@ def gflowaux(v, gamma, index_list, v_in, v_out, g, l_k, k, meas_plane):
     return v_out | c_set, g, l_k, finished, exist
 
 
-def flow(g, v_in, v_out, meas_plane=None, timeout=100):
+def flow(g, v_in, v_out, meas_plane=None, timeout=10000):
     """Causal flow finding algorithm
 
     For open graph g with input and output, this returns causal flow.
@@ -561,67 +461,3 @@ def get_layers(l_k):
     for i in l_k.keys():
         layers[l_k[i]].append(i)
     return d, layers
-
-
-def get_meas_plane(pattern):
-    """get measurement plane from the pattern.
-    Parameter
-    -------
-    pattern: graphix.pattern.Pattern object
-
-    Return
-    -------
-    meas_plane: dict of str
-        list of strs representing measurement plane for each node.
-    """
-    meas_plane = dict()
-    XYtoXZ_list = [
-        6,
-        8,
-        11,
-        12,
-        20,
-        21,
-        22,
-        23,
-    ]  # clifford indices that change meas plane from xy to xz
-    for cmd in pattern.seq:
-        if cmd[0] == "M":
-            if len(cmd) == 7:
-                if cmd[6] in XYtoXZ_list:
-                    meas_plane[cmd[1]] = "XZ"
-                else:
-                    meas_plane[cmd[1]] = cmd[2]
-            else:
-                meas_plane[cmd[1]] = cmd[2]
-    return meas_plane
-
-
-def get_measurement_order_from_gflow(pattern):
-    """Returns a list containing the node indices,
-    in the order of measurements which can be performed with minimum depth.
-    Input must be a simple connected graph for the gflow-finding algorithm to work.
-
-    Returns
-    -------
-    meas_order : list
-        list of node indices in the order of measurements
-    """
-    nodes, edges = pattern.get_graph()
-    G = nx.Graph()
-    G.add_nodes_from(nodes)
-    G.add_edges_from(edges)
-    isolated = list(nx.isolates(G))
-    if isolated:
-        raise ValueError("The input graph must be connected")
-    meas_plane = get_meas_plane(pattern)
-    g, l_k = gflow(G, set(), set(pattern.output_nodes), meas_plane=meas_plane)
-    if not g:
-        raise ValueError("No gflow found")
-    k, layers = get_layers(l_k)
-    meas_order = []
-    while k > 0:
-        for node in layers[k]:
-            meas_order.append(node)
-        k -= 1
-    return meas_order

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -6,6 +6,42 @@ from graphix.generator import generate_from_graph
 
 
 class TestGenerator(unittest.TestCase):
+    def test_pattern_generation_determinism_flow(self):
+        graph = nx.Graph([(0, 3), (1, 4), (2, 5), (1, 3), (2, 4), (3, 6), (4, 7), (5, 8)])
+        inputs = {0, 1, 2}
+        outputs = {6, 7, 8}
+        angles = np.random.randn(6)
+        results = []
+        repeats = 3  # for testing the determinism of a pattern
+        for _ in range(repeats):
+            pattern = generate_from_graph(graph, angles, inputs, outputs)
+            pattern.standardize()
+            pattern.minimize_space()
+            state = pattern.simulate_pattern()
+            results.append(state)
+        combinations = [(0, 1), (0, 2), (1, 2)]
+        for i, j in combinations:
+            inner_product = np.dot(results[i].flatten(), results[j].flatten().conjugate())
+            np.testing.assert_almost_equal(abs(inner_product), 1)
+
+    def test_pattern_generation_determinism_gflow(self):
+        graph = nx.Graph([(1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (3, 6), (1, 6)])
+        inputs = {1, 3, 5}
+        outputs = {2, 4, 6}
+        angles = np.random.randn(11)
+        results = []
+        repeats = 3  # for testing the determinism of a pattern
+        for _ in range(repeats):
+            pattern = generate_from_graph(graph, angles, inputs, outputs)
+            pattern.standardize()
+            pattern.minimize_space()
+            state = pattern.simulate_pattern()
+            results.append(state)
+        combinations = [(0, 1), (0, 2), (1, 2)]
+        for i, j in combinations:
+            inner_product = np.dot(results[i].flatten(), results[j].flatten().conjugate())
+            np.testing.assert_almost_equal(abs(inner_product), 1)
+
     def test_pattern_generation_flow(self):
         nqubits = 3
         depth = 2

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,38 @@
+import unittest
+import numpy as np
+import networkx as nx
+import tests.random_circuit as rc
+from graphix.generator import generate_from_graph
+
+
+class TestGenerator(unittest.TestCase):
+    def test_pattern_generation_flow(self):
+        nqubits = 3
+        depth = 2
+        pairs = [(0, 1), (1, 2)]
+        circuit = rc.generate_gate(nqubits, depth, pairs)
+        # transpile into graph
+        pattern = circuit.transpile()
+        pattern.standardize()
+        pattern.shift_signals()
+        # get the graph and generate pattern again with flow algorithm
+        nodes, edges = pattern.get_graph()
+        g = nx.Graph()
+        g.add_nodes_from(nodes)
+        g.add_edges_from(edges)
+        input = [0, 1, 2]
+        angles = dict()
+        for cmd in pattern.get_measurement_order():
+            angles[cmd[1]] = cmd[3]
+        pattern2 = generate_from_graph(g, angles, input, pattern.output_nodes)
+        # check that the new one runs and returns correct result
+        pattern2.standardize()
+        pattern2.shift_signals()
+        pattern2.minimize_space()
+        state = circuit.simulate_statevector()
+        state_mbqc = pattern2.simulate_pattern()
+        np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -22,7 +22,7 @@ class TestGenerator(unittest.TestCase):
         g.add_edges_from(edges)
         input = [0, 1, 2]
         angles = dict()
-        for cmd in pattern.get_measurement_order():
+        for cmd in pattern.get_measurement_commands():
             angles[cmd[1]] = cmd[3]
         pattern2 = generate_from_graph(g, angles, input, pattern.output_nodes)
         # check that the new one runs and returns correct result

--- a/tests/test_gflow.py
+++ b/tests/test_gflow.py
@@ -1,7 +1,6 @@
 import unittest
 import networkx as nx
 from graphix.gflow import gflow, flow
-import tests.random_circuit as rc
 import numpy as np
 
 
@@ -51,7 +50,7 @@ class TestGflow(unittest.TestCase):
             (8, 10),
             (10, 12),
         ]
-        input = set()
+        input = {1, 2}
         output = {11, 12}
         G = nx.Graph()
         G.add_nodes_from(nodes)

--- a/tests/test_gflow.py
+++ b/tests/test_gflow.py
@@ -1,6 +1,6 @@
 import unittest
 import networkx as nx
-from graphix.gflow import gflow, flow, generate_from_graph
+from graphix.gflow import gflow, flow
 import tests.random_circuit as rc
 import numpy as np
 
@@ -85,33 +85,6 @@ class TestGflow(unittest.TestCase):
         g, l_k = gflow(G, input, output)
         self.assertIsNone(g)
         self.assertIsNone(l_k)
-
-    def test_pattern_generation_flow(self):
-        nqubits = 3
-        depth = 2
-        pairs = [(0, 1), (1, 2)]
-        circuit = rc.generate_gate(nqubits, depth, pairs)
-        # transpile into graph
-        pattern = circuit.transpile()
-        pattern.standardize()
-        pattern.shift_signals()
-        # get the graph and generate pattern again with flow algorithm
-        nodes, edges = pattern.get_graph()
-        g = nx.Graph()
-        g.add_nodes_from(nodes)
-        g.add_edges_from(edges)
-        input = [0, 1, 2]
-        angles = dict()
-        for cmd in pattern.get_measurement_order():
-            angles[cmd[1]] = cmd[3]
-        pattern2 = generate_from_graph(g, angles, input, pattern.output_nodes)
-        # check that the new one runs and returns correct result
-        pattern2.standardize()
-        pattern2.shift_signals()
-        pattern2.minimize_space()
-        state = circuit.simulate_statevector()
-        state_mbqc = pattern2.simulate_pattern()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -27,6 +27,29 @@ class TestPattern(unittest.TestCase):
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
+    def test_minimize_space_with_gflow(self):
+        nqubits = 5
+        depth = 5
+        pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
+        circuit = rc.generate_gate(nqubits, depth, pairs)
+        pattern = circuit.transpile()
+        pattern.shift_signals()
+        pattern.perform_pauli_measurements()
+        pattern.minimize_space()
+        state = circuit.simulate_statevector()
+        state_mbqc = pattern.simulate_pattern()
+        np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+
+    def test_minimize_space_graph_maxspace_with_flow(self):
+        max_qubits = 20
+        for nqubits in range(2, max_qubits):
+            depth = 5
+            pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
+            circuit = rc.generate_gate(nqubits, depth, pairs)
+            pattern = circuit.transpile()
+            pattern.minimize_space()
+            np.testing.assert_equal(pattern.max_space(), nqubits + 1)
+
     def test_parallelize_pattern(self):
         nqubits = 2
         depth = 1

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -2,6 +2,7 @@ import unittest
 import numpy as np
 import tests.random_circuit as rc
 from graphix.transpiler import Circuit
+from graphix.pattern import Pattern
 
 
 class TestPattern(unittest.TestCase):
@@ -153,6 +154,27 @@ class TestPattern(unittest.TestCase):
         isolated_nodes_ref = {48}
 
         np.testing.assert_equal(isolated_nodes, isolated_nodes_ref)
+
+    def test_get_meas_plane(self):
+        preset_meas_plane = ["XY", "XY", "XY", "YZ", "YZ", "YZ", "XZ", "XZ", "XZ"]
+        vop_list = [0, 5, 6]  # [identity, S gate, H gate]
+        pattern = Pattern(len(preset_meas_plane))
+        pattern.set_output_nodes([i for i in range(len(preset_meas_plane))])
+        for i in range(len(preset_meas_plane)):
+            pattern.add(["M", i, preset_meas_plane[i], 0, [], [], vop_list[i % 3]])
+        ref_meas_plane = {
+            0: "XY",
+            1: "XY",
+            2: "YZ",
+            3: "YZ",
+            4: "XZ",
+            5: "XY",
+            6: "XZ",
+            7: "YZ",
+            8: "XZ",
+        }
+        meas_plane = pattern.get_meas_plane()
+        np.testing.assert_equal(meas_plane, ref_meas_plane)
 
 
 def cp(circuit, theta, control, target):


### PR DESCRIPTION
Before submitting, please check the following:
- Make sure you have tests for the new code and that test passes (run `pytest`)
- format added code and tests by `black -l 120 <filename>`

Then, please fill in below:

**Context (if applicable):**

na

**Description of the change:**

Reversed the dependency structure between gflow and pattern. In the original version, gflow.py dependes on the Pattern. However, gflow is purely a graph theory concept, so this structure is not preferable.
An improved `minimize_space` method was implemented which ensures `max_space` equals (width+1) if a graph has flow and after the `minimize_space` method applied. See `Pattern.get_measurement_order_from_flow()` for details.


**Related issue:**

#40 


also see that checks (github actions) pass.
If lint check keeps failing, try installing black==22.8.0 as behavior seems to vary across versions.



