### PR TITLE
upgrade tensor network examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fast pattern standardization and signal shfiting with `pattern.LocalPattern` class (#42), performance report at #43
 - Defaulted local pattern method for `graphix.Pattern.standardize()` and `graphix.Pattern.shift_signals()`. Note the resulting pattern is equivalent to the output of original method.
+- Auto selector of tensor network graph preparation strategy `graph_prep` (#50)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fast pattern standardization and signal shfiting with `pattern.LocalPattern` class (#42), performance report at #43
 - Defaulted local pattern method for `graphix.Pattern.standardize()` and `graphix.Pattern.shift_signals()`. Note the resulting pattern is equivalent to the output of original method.
-- Automatic selection of appropriate tensor network graph state preparation strategy `graph_prep="opt"` argument for instantiation of `TensorNetworkBackend` (#50)
+- Automatic selection of appropriate tensor network graph state preparation strategy `graph_prep="auto"` argument for instantiation of `TensorNetworkBackend` (#50)
 
 ### Changed
 - option `graph_prep="opt"` for `graph_prep` kwarg of `TensorNetworkBackend` (#50) will be deprecated, and will be replaced by `graph_prep="parallel"`, as we identified that `parallel` preparation is not always optimal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fast pattern standardization and signal shfiting with `pattern.LocalPattern` class (#42), performance report at #43
 - Defaulted local pattern method for `graphix.Pattern.standardize()` and `graphix.Pattern.shift_signals()`. Note the resulting pattern is equivalent to the output of original method.
-- Auto selector of tensor network graph preparation strategy `graph_prep` (#50)
+- Automatic selection of appropriate tensor network graph state preparation strategy `graph_prep="opt"` argument for instantiation of `TensorNetworkBackend` (#50)
 
 ### Changed
-
+- option `graph_prep="opt"` for `graph_prep` kwarg of `TensorNetworkBackend` (#50) will be deprecated, and will be replaced by `graph_prep="parallel"`, as we identified that `parallel` preparation is not always optimal.
 
 ## [0.2.1] - 2023-04-25
 

--- a/examples/ghz_with_tn.py
+++ b/examples/ghz_with_tn.py
@@ -1,0 +1,59 @@
+"""
+Using Tensor Network simulator
+=============================
+
+In this example, we generate Greenberger-Horne-Zeilinger(GHZ) state with a tensor network simulator.
+It can be easily simulated with a tensor network because GHZ state has a simple entanglement structure.
+
+You can run this code on your browser with `mybinder.org <https://mybinder.org/>`_ - click the badge below.
+
+.. image:: https://mybinder.org/badge_logo.svg
+ :target: https://mybinder.org/v2/gh/TeamGraphix/graphix-examples/HEAD?labpath=ghz_with_tn.ipynb
+
+
+We will simulate 100-qubit GHZ circuit.
+Firstly, let us import relevant modules:
+"""
+# %%
+
+import numpy as np
+from graphix import Circuit
+import networkx as nx
+import matplotlib.pyplot as plt
+
+n = 100
+print(f"{n}-qubit GHZ state generation")
+circuit = Circuit(n)
+
+# initialize to |0> state.
+for i in range(n):
+    circuit.h(i)
+
+# GHZ generation
+circuit.h(0)
+for i in range(1, n):
+    circuit.cnot(i - 1, i)
+
+# %%
+# Transpile into pattern
+
+pattern = circuit.transpile()
+pattern.standardize()
+
+nodes, edges = pattern.get_graph()
+g = nx.Graph()
+g.add_nodes_from(nodes)
+g.add_edges_from(edges)
+print(f"Number of nodes: {len(nodes)}")
+print(f"Number of edges: {len(edges)}")
+np.random.seed(100)
+pos = nx.spring_layout(g)
+nx.draw(g, pos=pos, node_size=15)
+plt.show()
+
+# %%
+# Calculate the amplitudes of |00...0> and |11...1> states.
+
+tn = pattern.simulate_pattern(backend="tensornetwork")
+print(f"The amplitude of |00...0>: {tn.get_basis_amplitude(0)}")
+print(f"The amplitude of |00...0>: {tn.get_basis_amplitude(2**n-1)}")

--- a/examples/ghz_with_tn.py
+++ b/examples/ghz_with_tn.py
@@ -2,14 +2,12 @@
 Using Tensor Network simulator
 =============================
 
-In this example, we generate Greenberger-Horne-Zeilinger(GHZ) state with a tensor network simulator.
-It can be easily simulated with a tensor network because GHZ state has a simple entanglement structure.
+In this example, we simulate a circuit to create Greenberger-Horne-Zeilinger(GHZ) state with a tensor network simulator.
 
 You can run this code on your browser with `mybinder.org <https://mybinder.org/>`_ - click the badge below.
 
 .. image:: https://mybinder.org/badge_logo.svg
  :target: https://mybinder.org/v2/gh/TeamGraphix/graphix-examples/HEAD?labpath=ghz_with_tn.ipynb
-
 
 We will simulate 100-qubit GHZ circuit.
 Firstly, let us import relevant modules:

--- a/examples/ghz_with_tn.py
+++ b/examples/ghz_with_tn.py
@@ -9,7 +9,7 @@ You can run this code on your browser with `mybinder.org <https://mybinder.org/>
 .. image:: https://mybinder.org/badge_logo.svg
  :target: https://mybinder.org/v2/gh/TeamGraphix/graphix-examples/HEAD?labpath=ghz_with_tn.ipynb
 
-We will simulate 100-qubit GHZ circuit.
+We will simulate the generation of 100-qubit GHZ state.
 Firstly, let us import relevant modules:
 """
 # %%

--- a/examples/qft_with_tn.py
+++ b/examples/qft_with_tn.py
@@ -1,17 +1,15 @@
 """
-Heavy Calculation with Tensor Network Simulator
+Large-scale simulations with tensor network simulator
 ===================
 
 In this example, we demonstrate the Tensor Network (TN) simulator to simulate MBQC
-with up to ten-thousands of nodes on a laptop PC.
+with up to ten-thousands of nodes.
 
 You can also run this code on your browser with `mybinder.org <https://mybinder.org/>`_ - click the badge below.
 
 .. image:: https://mybinder.org/badge_logo.svg
  :target: https://mybinder.org/v2/gh/TeamGraphix/graphix-examples/HEAD?labpath=qft_with_tn.ipynb
 
-
-We will simulate n-qubit QFT circuit.
 Firstly, let us import relevant modules:
 """
 
@@ -56,7 +54,7 @@ def qft(circuit, n):
 
 
 # %%
-# We will simulate 50-qubit QFT, which requires more than 10000 nodes to be simulated.
+# We will simulate 50-qubit QFT, which requires graph states with more than 10000 nodes.
 
 n = 50
 print("{}-qubit QFT".format(n))
@@ -75,7 +73,7 @@ print(f"Number of nodes: {len(nodes)}")
 print(f"Number of edges: {len(edges)}")
 
 # %%
-# The above graph is too large to simulate on tensor network simulator, so we remove pauli nodes.
+# Using efficient graph state simulator `graphix.GraphSim`, we can classically preprocess Pauli measurements.
 
 pattern.shift_signals()
 pattern.perform_pauli_measurements()
@@ -92,11 +90,11 @@ nx.draw(g, pos=pos, node_size=15)
 plt.show()
 
 # %%
-# You can easily check that the below code run without much load on the computer.
+# You can easily check that the below code run without too much load on your computer.
 # Also notice that we have not used :meth:`graphix.pattern.Pattern.minimize_space()`,
 # which we know reduced the burden on the simulator.
 # To specify TN backend of the simulation, simply provide as a keyword argument.
-# here we do a very basic check that the state is what is is expected to be:
+# here we do a very basic check that the state is what it is expected to be:
 
 tn = pattern.simulate_pattern(backend="tensornetwork", graph_prep="sequential")
 value = tn.get_basis_amplitude(0)

--- a/examples/qft_with_tn.py
+++ b/examples/qft_with_tn.py
@@ -84,9 +84,7 @@ g.add_nodes_from(nodes)
 g.add_edges_from(edges)
 print(f"Number of nodes: {len(nodes)}")
 print(f"Number of edges: {len(edges)}")
-np.random.seed(100)
-pos = nx.spring_layout(g)
-nx.draw(g, pos=pos, node_size=15)
+nx.draw(g, node_size=10)
 plt.show()
 
 # %%
@@ -96,7 +94,7 @@ plt.show()
 # To specify TN backend of the simulation, simply provide as a keyword argument.
 # here we do a very basic check that the state is what it is expected to be:
 
-tn = pattern.simulate_pattern(backend="tensornetwork", graph_prep="sequential")
+tn = pattern.simulate_pattern(backend="tensornetwork")
 value = tn.get_basis_amplitude(0)
 print("amplitude of |00...0> is ", value)
 print("1/2^n (true answer) is", 1 / 2**n)

--- a/examples/qft_with_tn.py
+++ b/examples/qft_with_tn.py
@@ -2,23 +2,19 @@
 Large-scale simulations with tensor network simulator
 ===================
 
-In this example, we demonstrate the Tensor Network (TN) simulator to simulate MBQC
-with up to ten-thousands of nodes.
+In this example, we demonstrate simulation of MBQC involving 10k+ nodes.
 
 You can also run this code on your browser with `mybinder.org <https://mybinder.org/>`_ - click the badge below.
 
 .. image:: https://mybinder.org/badge_logo.svg
  :target: https://mybinder.org/v2/gh/TeamGraphix/graphix-examples/HEAD?labpath=qft_with_tn.ipynb
 
-Firstly, let us import relevant modules:
+Firstly, let us import relevant modules and define the circuit:
 """
-
+# %%
 import numpy as np
 from graphix import Circuit
 import networkx as nx
-import matplotlib.pyplot as plt
-
-plt.rc("font", family="serif")
 
 
 def cp(circuit, theta, control, target):
@@ -67,34 +63,29 @@ qft(circuit, n)
 # standardize pattern
 pattern = circuit.transpile()
 pattern.standardize()
+pattern.shift_signals()
 nodes, edges = pattern.get_graph()
-
 print(f"Number of nodes: {len(nodes)}")
 print(f"Number of edges: {len(edges)}")
 
 # %%
 # Using efficient graph state simulator `graphix.GraphSim`, we can classically preprocess Pauli measurements.
-
-pattern.shift_signals()
+# We are currently improving the speed of this process by using rust-based graph manipulation backend.
 pattern.perform_pauli_measurements()
 
-nodes, edges = pattern.get_graph()
-g = nx.Graph()
-g.add_nodes_from(nodes)
-g.add_edges_from(edges)
-print(f"Number of nodes: {len(nodes)}")
-print(f"Number of edges: {len(edges)}")
-nx.draw(g, node_size=10)
-plt.show()
 
 # %%
 # You can easily check that the below code run without too much load on your computer.
 # Also notice that we have not used :meth:`graphix.pattern.Pattern.minimize_space()`,
 # which we know reduced the burden on the simulator.
 # To specify TN backend of the simulation, simply provide as a keyword argument.
-# here we do a very basic check that the state is what it is expected to be:
+# here we do a very basic check that one of the statevector amplitudes is what it is expected to be:
 
+import time
+t1 = time.time()
 tn = pattern.simulate_pattern(backend="tensornetwork")
 value = tn.get_basis_amplitude(0)
+t2 = time.time()
 print("amplitude of |00...0> is ", value)
 print("1/2^n (true answer) is", 1 / 2**n)
+print("approximate execution time in seconds: ", t2 - t1)

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -875,6 +875,22 @@ class Pattern:
                 meas_plane[cmd[1]] = mplane
         return meas_plane
 
+    def get_max_degree(self):
+        """Get max degree of a pattern
+
+        Returns
+        -------
+        max_degree : int
+            max degree of a pattern
+        """
+        nodes, edges = self.get_graph()
+        g = nx.Graph()
+        g.add_nodes_from(nodes)
+        g.add_edges_from(edges)
+        degree = g.degree()
+        max_degree = max([i for i in dict(degree).values()])
+        return max_degree
+
     def get_graph(self):
         """returns the list of nodes and edges from the command sequence,
         extracted from 'N' and 'E' commands.

--- a/graphix/sim/tensornet.py
+++ b/graphix/sim/tensornet.py
@@ -43,9 +43,9 @@ class TensorNetworkBackend:
         elif graph_prep == "auto":
             max_degree = pattern.get_max_degree()
             if max_degree > 5:
-                self.graph_prep = "parallel"
-            else:
                 self.graph_prep = "sequential"
+            else:
+                self.graph_prep = "parallel"
         else:
             raise ValueError(f"Invalid graph preparation strategy: {graph_prep}")
 

--- a/graphix/sim/tensornet.py
+++ b/graphix/sim/tensornet.py
@@ -13,29 +13,45 @@ class TensorNetworkBackend:
     Executes the measurement pattern using TN expression of graph states.
     """
 
-    def __init__(self, pattern, graph_prep="opt", **kwargs):
+    def __init__(self, pattern, graph_prep="auto", **kwargs):
         """
 
         Parameters
         ----------
         pattern : graphix.Pattern
         graph_prep : str
-            'opt'(default) :
-                Faster and optimal method to prepare a tensornetwork representing graph state.
-                The expression of the given graph state can be obtained from its geometry.
-                See https://journals.aps.org/pra/abstract/10.1103/PhysRevA.76.052315 for example.
-                Note that the 'N' and 'E' commands in the measurement pattern are ignored.
+            'parallel' :
+                Faster method for preparing a graph state.
+                The expression of a graph state can be obtained from the graph geometry.
+                See https://journals.aps.org/pra/abstract/10.1103/PhysRevA.76.052315 for detail calculation.
+                Note that 'N' and 'E' commands in the measurement pattern are ignored.
             'sequential' :
-                Sequentially add nodes and edges, strictly following the measuremen pattern.
+                Sequentially execute N and E commands, strictly following the measurement pattern.
                 In this strategy, All N and E commands executed sequentially.
+            'auto'(default) :
+                Automatically select a preparation strategy based on the max degree of a graph
         **kwargs : Additional keyword args to be passed to quimb.tensor.TensorNetwork.
         """
         self.pattern = pattern
         self.output_nodes = pattern.output_nodes
         self.results = deepcopy(pattern.results)
-        assert graph_prep in ["opt", "sequential"]
-        self.graph_prep = graph_prep
-        if graph_prep == "opt":
+        if graph_prep in ["parallel", "sequential"]:
+            self.graph_prep = graph_prep
+        elif graph_prep == "opt":
+            self.graph_prep = "parallel"
+            print(f"graph preparation strategy '{graph_prep}' will be removed")
+        elif graph_prep == "auto":
+            max_degree = pattern.get_max_degree()
+            if max_degree > 5:
+                self.graph_prep = "parallel"
+            else:
+                self.graph_prep = "sequential"
+        else:
+            raise ValueError(f"Invalid graph preparation strategy: {graph_prep}")
+
+        if self.graph_prep == "parallel":
+            if not pattern.is_standard():
+                raise ValueError("parallel preparation strategy does not support not-standardized pattern")
             nodes, edges = pattern.get_graph()
             self.state = MBQCTensorNet(
                 graph_nodes=nodes,
@@ -43,7 +59,7 @@ class TensorNetworkBackend:
                 default_output_nodes=pattern.output_nodes,
                 **kwargs,
             )
-        elif graph_prep == "sequential":
+        elif self.graph_prep == "sequential":
             self.state = MBQCTensorNet(default_output_nodes=pattern.output_nodes, **kwargs)
             self._decomposed_cz = _get_decomposed_cz()
         self._isolated_nodes = pattern.get_isolated_nodes()

--- a/graphix/sim/tensornet.py
+++ b/graphix/sim/tensornet.py
@@ -39,7 +39,7 @@ class TensorNetworkBackend:
             self.graph_prep = graph_prep
         elif graph_prep == "opt":
             self.graph_prep = "parallel"
-            print(f"graph preparation strategy '{graph_prep}' will be removed")
+            print(f"graph preparation strategy '{graph_prep}' is deprecated and will be replaced by 'parallel'")
         elif graph_prep == "auto":
             max_degree = pattern.get_max_degree()
             if max_degree > 5:


### PR DESCRIPTION
Before submitting, please check the following:
- Make sure you have tests for the new code and that test passes (run `pytest`)
- format added code and tests by `black -l 120 <filename>`
- If applicable, add a line to the [unreleased] part of CHANGELOG.md, following [keep-a-changelog](https://keepachangelog.com/en/1.0.0/).
 
Then, please fill in below:

**Context (if applicable):**

Due to the poor capacity of the former `Pattern.standardize()` and `Pattern.shift_signals()`, the size of runnable pattern was restricted. However, with the fast pattern operations implemented in #42, more than ten-thousand of nodes can be calculated on a laptop. Therefore, the examples of tensor network simulator are updated in this PR.


**Description of the change:**

Update `examples/qft_with_tn.py`. The number of QFT logical qubits increased from 7 to 50.
Add `examples/ghz_with_tn.py`, where a 100-qubit GHZ state is generated
Add an auto-selector of tensor network graph preparation strategy.

**Related issue:**

#50 

also see that checks (github actions) pass.
If lint check keeps failing, try installing black==22.8.0 as behavior seems to vary across versions.



