### PR TITLE
patch: treatment of local Clifford after Pauli measurement preprocessing

### DIFF
--- a/examples/qft.py
+++ b/examples/qft.py
@@ -11,7 +11,7 @@ for any quantum algorithms running on MBQC.
 We will demonstrate this by simulating QFT on three qubits.
 First, import relevant modules and define additional gates we'll use:
 """
-
+#%%
 import numpy as np
 from graphix import Circuit
 import networkx as nx
@@ -95,6 +95,9 @@ print("overlap of states: ", np.abs(np.dot(state.psi.flatten().conjugate(), out_
 
 #%%
 # Finally, check the output state:
+st_expected = [np.exp(2 * np.pi * 1j * 3 * i / 8) / np.sqrt(8) for i in range(8)]
+out_stv = out_state.flatten()
+print(np.round(st_expected, 3))
+print(np.round(out_stv * st_expected[0] / out_stv[0], 3))  # global phase is arbitrary
 
-print(np.round([np.exp(2 * np.pi * 1j * 3 * i / 8) / np.sqrt(8) for i in range(8)], 3))
-print(np.round(out_state.flatten() * -1j, 3))  # global phase is arbitrary
+# %%

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -1668,7 +1668,7 @@ def measure_pauli(pattern, copy=False):
         if cmd[0] == "M":
             if cmd[1] in list(graph_state.nodes):
                 cmd_new = deepcopy(cmd)
-                new_clifford_ = CLIFFORD_CONJ[vops[cmd[1]]]
+                new_clifford_ = vops[cmd[1]]
                 if cmd[1] in vop_init.keys():
                     new_clifford_ = CLIFFORD_MUL[vop_init[cmd[1]], new_clifford_]
                 if len(cmd_new) == 7:


### PR DESCRIPTION
Before submitting, please check the following:
- Make sure you have tests for the new code and that test passes (run `pytest`)
- format added code and tests by `black -l 120 <filename>`
- If applicable, add a line to the [unreleased] part of CHANGELOG.md, following [keep-a-changelog](https://keepachangelog.com/en/1.0.0/).
 
Then, please fill in below:

**Context (if applicable):**
#49, #54

**Description of the change:**
removed CLIFFORD_CONJ operation before inserting measurement commands back to pattern.


also see that checks (github actions) pass.
If lint check keeps failing, try installing black==22.8.0 as behavior seems to vary across versions.



