### PR TITLE
Performance improvement to make readthedocs build work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Changed
-
+- fixed a bug in a code snippet isn docs (#59), as pointed out by @zilkf92
+- fixed issue building docs on readthedocs (#61)
 
 ## [0.2.2] - 2023-05-25
 ### Added

--- a/docs/source/lc-mbqc.rst
+++ b/docs/source/lc-mbqc.rst
@@ -49,7 +49,7 @@ We can perform this with :class:`~graphix.graphsim.GraphState` class and then co
     state_from_graphsim = g.to_statevector()
 
     # do the same with statevector sim
-    state.evolve_single(0, meas_op(0, choice=0))
+    state.evolve_single(meas_op(0, choice=0), 0)
     state.normalize()
     state.ptrace([0])
 

--- a/examples/qft_with_tn.py
+++ b/examples/qft_with_tn.py
@@ -50,9 +50,9 @@ def qft(circuit, n):
 
 
 # %%
-# We will simulate 50-qubit QFT, which requires graph states with more than 10000 nodes.
+# We will simulate 45-qubit QFT, which requires graph states with more than 10000 nodes.
 
-n = 50
+n = 45
 print("{}-qubit QFT".format(n))
 circuit = Circuit(n)
 

--- a/examples/qnn.py
+++ b/examples/qnn.py
@@ -68,9 +68,9 @@ class QNN:
         assert n_features % 3 == 0, "n_features must be a multiple of 3"
         
         # Pauli Z operator on all qubits
-        Z = np.array([[1, 0], 
+        Z_OP = np.array([[1, 0], 
                       [0, -1]])
-        operator = [Z]*self.n_qubits
+        operator = [Z_OP]*self.n_qubits
         self.obs = reduce(np.kron, operator)
         self.cost_values = [] # to store cost values during optimization
         

--- a/examples/qnn.py
+++ b/examples/qnn.py
@@ -426,7 +426,7 @@ nx.draw(g, pos=pos, **graph_params)
 # Qubit Resource plot
 # ------------------------------------------
 
-qubits = range(1, 16, 2)
+qubits = range(10)
 n_layers = 2
 n_features = 3
 input_params = np.random.rand(n_features)

--- a/examples/qnn.py
+++ b/examples/qnn.py
@@ -180,8 +180,9 @@ class QNN:
         pattern.standardize()
         pattern.shift_signals()
         pattern.perform_pauli_measurements()
-        out_state = pattern.simulate_pattern('tensornetwork')
-        sv = out_state.to_statevector().flatten()
+        pattern.minimize_space()
+        out_state = pattern.simulate_pattern('statevector')
+        sv = out_state.flatten()
         return self.get_expectation_value(sv)
     
     def cost(self, params, x, y):

--- a/examples/qnn.py
+++ b/examples/qnn.py
@@ -179,7 +179,6 @@ class QNN:
         pattern = circuit.transpile()
         pattern.standardize()
         pattern.shift_signals()
-        pattern.perform_pauli_measurements()
         pattern.minimize_space()
         out_state = pattern.simulate_pattern('statevector')
         sv = out_state.flatten()

--- a/examples/qnn.py
+++ b/examples/qnn.py
@@ -321,7 +321,7 @@ input_params = np.random.rand(n_features)
 
 qnn = QNN(n_qubits, n_layers, n_features)
 circuit = qnn.data_reuploading_circuit(input_params, params)
-pattern = circuit.transpile(opt=True)
+pattern = circuit.transpile(opt=False)
 pattern.standardize()
 pattern.shift_signals()
 

--- a/examples/qnn.py
+++ b/examples/qnn.py
@@ -30,7 +30,7 @@ np.random.seed(0)
 # The dataset is padded with zeros to make it compatible with the quantum circuit. 
 # We want the number of features to be a multiple of 3 as the quantum circuit uses 3 features at a time with gates :math:`R_x, R_y, R_z`.
 # We also change the labels to -1 and 1 as later we will use Pauli Z operator for measurment whose expectation values are :math:`\pm 1`.
-x, y = make_circles(n_samples=200, noise=0.1, factor=0.1, random_state=32)
+x, y = make_circles(n_samples=100, noise=0.1, factor=0.1, random_state=32)
 
 # Plot the circle pattern
 plt.scatter(x[:, 0], x[:, 1], c=y)
@@ -266,7 +266,7 @@ n_features = 3
 qnn = QNN(n_qubits, n_layers, n_features)
 
 start = time()
-result = qnn.fit(x, y, maxiter=100)
+result = qnn.fit(x, y, maxiter=80)
 end = time()
 
 print("Duration:", end-start)
@@ -321,7 +321,7 @@ input_params = np.random.rand(n_features)
 
 qnn = QNN(n_qubits, n_layers, n_features)
 circuit = qnn.data_reuploading_circuit(input_params, params)
-pattern = circuit.transpile()
+pattern = circuit.transpile(opt=True)
 pattern.standardize()
 pattern.shift_signals()
 

--- a/examples/qnn.py
+++ b/examples/qnn.py
@@ -426,7 +426,7 @@ nx.draw(g, pos=pos, **graph_params)
 # Qubit Resource plot
 # ------------------------------------------
 
-qubits = range(10)
+qubits = range(1, 10)
 n_layers = 2
 n_features = 3
 input_params = np.random.rand(n_features)

--- a/examples/qnn.py
+++ b/examples/qnn.py
@@ -179,9 +179,8 @@ class QNN:
         pattern = circuit.transpile()
         pattern.standardize()
         pattern.shift_signals()
-        pattern.minimize_space()
-        out_state = pattern.simulate_pattern('statevector')
-        sv = out_state.flatten()
+        out_state = pattern.simulate_pattern('tensornetwork')
+        sv = out_state.to_statevector().flatten()
         return self.get_expectation_value(sv)
     
     def cost(self, params, x, y):
@@ -267,7 +266,7 @@ n_features = 3
 qnn = QNN(n_qubits, n_layers, n_features)
 
 start = time()
-result = qnn.fit(x, y, maxiter=50)
+result = qnn.fit(x, y, maxiter=100)
 end = time()
 
 print("Duration:", end-start)

--- a/examples/qnn.py
+++ b/examples/qnn.py
@@ -268,7 +268,7 @@ n_features = 3
 qnn = QNN(n_qubits, n_layers, n_features)
 
 start = time()
-result = qnn.fit(x, y, maxiter=100)
+result = qnn.fit(x, y, maxiter=50)
 end = time()
 
 print("Duration:", end-start)


### PR DESCRIPTION
Before submitting, please check the following:
- Make sure you have tests for the new code and that test passes (run `pytest`)
- format added code and tests by `black -l 120 <filename>`
- If applicable, add a line to the [unreleased] part of CHANGELOG.md, following [keep-a-changelog](https://keepachangelog.com/en/1.0.0/).
 
Then, please fill in below:

**Context (if applicable):**
readthedocs build failed due to memory usage exceeding 8GB. 

**Description of the change:**
reduced burden by changing some configs for the examples (to be run with sphinx-gallery during build)
Also fixed the bug in the code snippet on docs, as per #59

**Related issue:**
closes #59 

also see that checks (github actions) pass.
If lint check keeps failing, try installing black==22.8.0 as behavior seems to vary across versions.



