### PR TITLE
Fix Pauli measurement routine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Quantum classifier demo (#57) by @Gopal-Dahale
 
-
 ### Changed
 - fixed a bug in a code snippet isn docs (#59), as pointed out by @zilkf92
 - fixed issue building docs on readthedocs (#61)
+- fixed bug in pauli preprocessing routine and graph state simulator (#63)
+- Second output of `pattern.pauli_nodes` (`non_pauli_node` list) is now list of nodes, not list of lists (commands).
 
 ## [0.2.2] - 2023-05-25
 ### Added

--- a/graphix/graphsim.py
+++ b/graphix/graphsim.py
@@ -238,6 +238,8 @@ class GraphState(nx.Graph):
         """
         assert (node1, node2) in list(self.edges) or (node2, node1) in list(self.edges)
         assert not self.nodes[node1]["loop"] and not self.nodes[node2]["loop"]
+        sg1 = self.nodes[node1]["sign"]
+        sg2 = self.nodes[node2]["sign"]
         self.flip_fill(node1)
         self.flip_fill(node2)
         # local complement along edge between node1, node2
@@ -246,15 +248,14 @@ class GraphState(nx.Graph):
         self.local_complement(node1)
         for i in iter(set(self.neighbors(node1)) & set(self.neighbors(node2))):
             self.flip_sign(i)
-        if self.nodes[node1]["sign"] != self.nodes[node2]["sign"]:
-            if self.nodes[node1]["sign"]:
-                self.flip_sign(node1)
-                for i in self.neighbors(node1):
-                    self.flip_sign(i)
-            elif self.nodes[node2]["sign"]:
-                self.flip_sign(node2)
-                for i in self.neighbors(node2):
-                    self.flip_sign(i)
+        if sg1:
+            self.flip_sign(node1)
+            for i in self.neighbors(node1):
+                self.flip_sign(i)
+        if sg2:
+            self.flip_sign(node2)
+            for i in self.neighbors(node2):
+                self.flip_sign(i)
 
     def local_complement(self, node):
         """Perform local complementation of a graph

--- a/graphix/graphsim.py
+++ b/graphix/graphsim.py
@@ -176,7 +176,7 @@ class GraphState(nx.Graph):
         if self.nodes[node]["hollow"]:
             if self.nodes[node]["loop"]:
                 self.flip_fill(node)
-                self.nodes["loop"] = False
+                self.nodes[node]["loop"] = False
                 self.local_complement(node)
                 for i in self.neighbors(node):
                     self.advance(i)
@@ -320,8 +320,19 @@ class GraphState(nx.Graph):
         choice : int, 0 or 1
             choice of measurement outcome. observe (-1)^choice
         """
-        self.h(node)
-        return self.measure_z(node, choice=choice)
+        # check if isolated
+        if len(list(self.neighbors(node))) == 0:
+            if self.nodes[node]["hollow"] or self.nodes[node]["loop"]:
+                choice_ = choice
+            elif self.nodes[node]["sign"]: # isolated and state is |->
+                choice_ = 1
+            else: # isolated and state is |+>
+                choice_ = 0 
+            self.remove_node(node)
+            return choice_
+        else:
+            self.h(node)
+            return self.measure_z(node, choice=choice)
 
     def measure_y(self, node, choice=0):
         """perform measurement in Y basis

--- a/graphix/graphsim.py
+++ b/graphix/graphsim.py
@@ -325,10 +325,10 @@ class GraphState(nx.Graph):
         if len(list(self.neighbors(node))) == 0:
             if self.nodes[node]["hollow"] or self.nodes[node]["loop"]:
                 choice_ = choice
-            elif self.nodes[node]["sign"]: # isolated and state is |->
+            elif self.nodes[node]["sign"]:  # isolated and state is |->
                 choice_ = 1
-            else: # isolated and state is |+>
-                choice_ = 0 
+            else:  # isolated and state is |+>
+                choice_ = 0
             self.remove_node(node)
             return choice_
         else:

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -765,9 +765,6 @@ class Pattern:
         meas_order: list of int
             measurement order
         """
-        if self._pauli_preprocessed:
-            # do not search for flow to get order if pauli meas preprocessing was performed
-            return None
         nodes, edges = self.get_graph()
         G = nx.Graph()
         G.add_nodes_from(nodes)
@@ -794,9 +791,6 @@ class Pattern:
         meas_order : list of int
             measurement order
         """
-        if self._pauli_preprocessed:
-            # do not search for gflow to get order if pauli meas preprocessing was performed
-            return None
         nodes, edges = self.get_graph()
         G = nx.Graph()
         G.add_nodes_from(nodes)
@@ -1059,7 +1053,9 @@ class Pattern:
         """
         if not self.is_standard():
             self.standardize()
-        meas_order = self.get_measurement_order_from_flow()
+        meas_order = None
+        if not self._pauli_preprocessed:
+            meas_order = self.get_measurement_order_from_flow()
         if meas_order is None:
             meas_order = self._measurement_order_space()
         self._reorder_pattern(self.sort_measurement_commands(meas_order))
@@ -1094,6 +1090,11 @@ class Pattern:
             if cmd[0] == "N":
                 if not cmd[1] in prepared:
                     new.append(["N", cmd[1]])
+        for cmd in self.seq:
+            if cmd[0] == "E":
+                if cmd[1][0] in self.output_nodes:
+                    if cmd[1][1] in self.output_nodes:
+                        new.append(cmd)
 
         # add Clifford nodes
         for cmd in self.seq:

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -1549,7 +1549,7 @@ class LocalPattern:
             standardized global pattern
         """
         assert self.is_standard()
-        pattern = Pattern(output_nodes=self.output_nodes)
+        pattern = Pattern(output_nodes=self.output_nodes, width=len(self.output_nodes))
         Nseq = [["N", i] for i in self.nodes.keys()]
         Eseq = []
         Mseq = []

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -1631,7 +1631,7 @@ def measure_pauli(pattern, copy=False):
     results = {}
     to_measure, non_pauli_meas = pauli_nodes(pattern)
     for cmd in to_measure:
-        # extract signals for adaptive angle. 
+        # extract signals for adaptive angle.
         if np.mod(cmd[3], 2) in [0, 1]:  # \pm X Pauli measurement
             s_signal = 0  # X meaurement is not affected by s_signal
             t_signal = np.sum([results[j] for j in cmd[5]])
@@ -1639,12 +1639,12 @@ def measure_pauli(pattern, copy=False):
             s_signal = np.sum([results[j] for j in cmd[4]])
             t_signal = np.sum([results[j] for j in cmd[5]])
         else:
-            raise ValueError('unknown angle', cmd[3])
-        if int(s_signal % 2) == 1: # equivalent to X byproduct
+            raise ValueError("unknown angle", cmd[3])
+        if int(s_signal % 2) == 1:  # equivalent to X byproduct
             graph_state.h(cmd[1])
             graph_state.z(cmd[1])
             graph_state.h(cmd[1])
-        if int(t_signal % 2) == 1: # equivalent to Z byproduct
+        if int(t_signal % 2) == 1:  # equivalent to Z byproduct
             graph_state.z(cmd[1])
         # assume XY-plane measurement
         if np.mod(cmd[3], 2) == 0:  # +x measurement
@@ -1656,7 +1656,7 @@ def measure_pauli(pattern, copy=False):
         elif np.mod(cmd[3], 2) == 1.5:  # -y measurement
             results[cmd[1]] = 1 - graph_state.measure_y(cmd[1], choice=1)
         else:
-            raise ValueError('unknown angle', cmd[3])
+            raise ValueError("unknown angle", cmd[3])
 
     # measure (remove) isolated nodes. if they aren't Pauli measurements,
     # measuring one of the results with probability of 1 should not occur as was possible above for Pauli measurements,

--- a/graphix/sim/statevec.py
+++ b/graphix/sim/statevec.py
@@ -90,7 +90,7 @@ class StatevectorBackend:
         if len(cmd) == 7:
             vop = cmd[6]
         else:
-            vop = 0            
+            vop = 0
         if int(s_signal % 2) == 1:
             vop = CLIFFORD_MUL[1, vop]
         if int(t_signal % 2) == 1:

--- a/graphix/sim/statevec.py
+++ b/graphix/sim/statevec.py
@@ -1,6 +1,6 @@
 import numpy as np
 from graphix.ops import Ops
-from graphix.clifford import CLIFFORD_MEASURE, CLIFFORD
+from graphix.clifford import CLIFFORD_CONJ, CLIFFORD, CLIFFORD_MUL
 from copy import deepcopy
 from scipy.linalg import norm
 
@@ -86,11 +86,16 @@ class StatevectorBackend:
         # extract signals for adaptive angle
         s_signal = np.sum([self.results[j] for j in cmd[4]])
         t_signal = np.sum([self.results[j] for j in cmd[5]])
-        angle = cmd[3] * np.pi * (-1) ** s_signal + np.pi * t_signal
+        angle = cmd[3] * np.pi
         if len(cmd) == 7:
-            m_op = meas_op(angle, vop=cmd[6], plane=cmd[2], choice=result)
+            vop = cmd[6]
         else:
-            m_op = meas_op(angle, plane=cmd[2], choice=result)
+            vop = 0            
+        if int(s_signal % 2) == 1:
+            vop = CLIFFORD_MUL[1, vop]
+        if int(t_signal % 2) == 1:
+            vop = CLIFFORD_MUL[3, vop]
+        m_op = meas_op(angle, vop=vop, plane=cmd[2], choice=result)
         loc = self.node_index.index(cmd[1])
         self.state.evolve_single(m_op, loc)
 
@@ -178,9 +183,8 @@ def meas_op(angle, vop=0, plane="XY", choice=0):
         vec = (np.cos(angle), 0, np.sin(angle))
     op_mat = np.eye(2, dtype=np.complex128) / 2
     for i in range(3):
-        op_mat += (
-            (-1) ** (choice + CLIFFORD_MEASURE[vop][i][1]) * vec[CLIFFORD_MEASURE[vop][i][0]] * CLIFFORD[i + 1] / 2
-        )
+        op_mat += (-1) ** (choice) * vec[i] * CLIFFORD[i + 1] / 2
+    op_mat = CLIFFORD[CLIFFORD_CONJ[vop]] @ op_mat @ CLIFFORD[vop]
     return op_mat
 
 

--- a/tests/random_circuit.py
+++ b/tests/random_circuit.py
@@ -53,39 +53,39 @@ def genpair(n_qubits, count):
     return pairs
 
 
-def get_rand_circuit(nqubits, depth, use_rzz = False):
+def get_rand_circuit(nqubits, depth, use_rzz=False):
     circuit = Circuit(nqubits)
-    gate_choice = [0,1,2,3,4,5,6,7]
+    gate_choice = [0, 1, 2, 3, 4, 5, 6, 7]
     for i in range(depth):
         for j, k in genpair(nqubits, 2):
             circuit.cnot(j, k)
         if use_rzz:
             for j, k in genpair(nqubits, 1):
-                circuit.rzz(j,k, np.pi/4)
+                circuit.rzz(j, k, np.pi / 4)
         for j in range(nqubits):
             k = np.random.choice(gate_choice)
             if k == 0:
-                circuit.ry(j, np.pi/4)
+                circuit.ry(j, np.pi / 4)
                 pass
             elif k == 1:
-                circuit.rz(j, -np.pi/4)
+                circuit.rz(j, -np.pi / 4)
                 pass
             elif k == 2:
-                circuit.rx(j, -np.pi/4)
+                circuit.rx(j, -np.pi / 4)
                 pass
-            elif k == 3: # H
+            elif k == 3:  # H
                 circuit.h(j)
                 pass
-            elif k == 4: # S
+            elif k == 4:  # S
                 circuit.s(j)
                 pass
-            elif k == 5: # X
+            elif k == 5:  # X
                 circuit.x(j)
                 pass
-            elif k == 6: # Z
+            elif k == 6:  # Z
                 circuit.z(j)
                 pass
-            elif k == 7: # Y
+            elif k == 7:  # Y
                 circuit.y(j)
                 pass
             else:

--- a/tests/random_circuit.py
+++ b/tests/random_circuit.py
@@ -40,3 +40,54 @@ def generate_gate(nqubits, depth, pairs, use_rzz=False):
             entangler(circuit, pairs)
     last_rotation(circuit, nqubits)
     return circuit
+
+
+def genpair(n_qubits, count):
+    pairs = []
+    for i in range(count):
+        choice = [j for j in range(n_qubits)]
+        x = np.random.choice(choice)
+        choice.pop(x)
+        y = np.random.choice(choice)
+        pairs.append((x, y))
+    return pairs
+
+
+def get_rand_circuit(nqubits, depth, use_rzz = False):
+    circuit = Circuit(nqubits)
+    gate_choice = [0,1,2,3,4,5,6,7]
+    for i in range(depth):
+        for j, k in genpair(nqubits, 2):
+            circuit.cnot(j, k)
+        if use_rzz:
+            for j, k in genpair(nqubits, 1):
+                circuit.rzz(j,k, np.pi/4)
+        for j in range(nqubits):
+            k = np.random.choice(gate_choice)
+            if k == 0:
+                circuit.ry(j, np.pi/4)
+                pass
+            elif k == 1:
+                circuit.rz(j, -np.pi/4)
+                pass
+            elif k == 2:
+                circuit.rx(j, -np.pi/4)
+                pass
+            elif k == 3: # H
+                circuit.h(j)
+                pass
+            elif k == 4: # S
+                circuit.s(j)
+                pass
+            elif k == 5: # X
+                circuit.x(j)
+                pass
+            elif k == 6: # Z
+                circuit.z(j)
+                pass
+            elif k == 7: # Y
+                circuit.y(j)
+                pass
+            else:
+                pass
+    return circuit

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -9,8 +9,7 @@ class TestPattern(unittest.TestCase):
     def test_standardize(self):
         nqubits = 2
         depth = 1
-        pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
-        circuit = rc.generate_gate(nqubits, depth, pairs)
+        circuit = rc.get_rand_circuit(nqubits, depth)
         pattern = circuit.transpile()
         pattern.standardize(method="global")
         np.testing.assert_equal(pattern.is_standard(), True)
@@ -21,8 +20,7 @@ class TestPattern(unittest.TestCase):
     def test_minimize_space(self):
         nqubits = 5
         depth = 5
-        pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
-        circuit = rc.generate_gate(nqubits, depth, pairs)
+        circuit = rc.get_rand_circuit(nqubits, depth)
         pattern = circuit.transpile()
         pattern.standardize(method="global")
         pattern.minimize_space()
@@ -58,8 +56,7 @@ class TestPattern(unittest.TestCase):
     def test_parallelize_pattern(self):
         nqubits = 2
         depth = 1
-        pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
-        circuit = rc.generate_gate(nqubits, depth, pairs)
+        circuit = rc.get_rand_circuit(nqubits, depth)
         pattern = circuit.transpile()
         pattern.standardize(method="global")
         pattern.parallelize_pattern()
@@ -70,69 +67,69 @@ class TestPattern(unittest.TestCase):
     def test_shift_signals(self):
         nqubits = 2
         depth = 1
-        pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
-        circuit = rc.generate_gate(nqubits, depth, pairs)
-        pattern = circuit.transpile()
-        pattern.standardize(method="global")
-        pattern.shift_signals(method="global")
-        np.testing.assert_equal(pattern.is_standard(), True)
-        state = circuit.simulate_statevector()
-        state_mbqc = pattern.simulate_pattern()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+        for i in range(10):
+            circuit = rc.get_rand_circuit(nqubits, depth)
+            pattern = circuit.transpile()
+            pattern.standardize(method="global")
+            pattern.shift_signals(method="global")
+            np.testing.assert_equal(pattern.is_standard(), True)
+            state = circuit.simulate_statevector()
+            state_mbqc = pattern.simulate_pattern()
+            np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
     def test_pauli_measurment(self):
         nqubits = 3
         depth = 3
-        pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
-        circuit = rc.generate_gate(nqubits, depth, pairs)
-        pattern = circuit.transpile()
-        pattern.standardize(method="global")
-        pattern.shift_signals(method="global")
-        pattern.perform_pauli_measurements()
-        pattern.minimize_space()
-        state = circuit.simulate_statevector()
-        state_mbqc = pattern.simulate_pattern()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+        for i in range(10):
+            circuit = rc.get_rand_circuit(nqubits, depth)
+            pattern = circuit.transpile()
+            pattern.standardize(method="global")
+            pattern.shift_signals(method="global")
+            pattern.perform_pauli_measurements()
+            pattern.minimize_space()
+            state = circuit.simulate_statevector()
+            state_mbqc = pattern.simulate_pattern()
+            np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
     def test_pauli_measurment_opt_gate(self):
         nqubits = 3
         depth = 3
-        pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
-        circuit = rc.generate_gate(nqubits, depth, pairs, use_rzz=True)
-        pattern = circuit.transpile(opt=True)
-        pattern.standardize(method="global")
-        pattern.shift_signals(method="global")
-        pattern.perform_pauli_measurements()
-        pattern.minimize_space()
-        state = circuit.simulate_statevector()
-        state_mbqc = pattern.simulate_pattern()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+        for i in range(10):
+            circuit = rc.get_rand_circuit(nqubits, depth, use_rzz=True)
+            pattern = circuit.transpile(opt=True)
+            pattern.standardize(method="global")
+            pattern.shift_signals(method="global")
+            pattern.perform_pauli_measurements()
+            pattern.minimize_space()
+            state = circuit.simulate_statevector()
+            state_mbqc = pattern.simulate_pattern()
+            np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
     def test_pauli_measurment_opt_gate_transpiler(self):
         nqubits = 3
         depth = 3
-        pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
-        circuit = rc.generate_gate(nqubits, depth, pairs, use_rzz=True)
-        pattern = circuit.standardize_and_transpile(opt=True)
-        pattern.standardize(method="global")
-        pattern.shift_signals(method="global")
-        pattern.perform_pauli_measurements()
-        pattern.minimize_space()
-        state = circuit.simulate_statevector()
-        state_mbqc = pattern.simulate_pattern()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+        for i in range(10):
+            circuit = rc.get_rand_circuit(nqubits, depth, use_rzz=True)
+            pattern = circuit.standardize_and_transpile(opt=True)
+            pattern.standardize(method="global")
+            pattern.shift_signals(method="global")
+            pattern.perform_pauli_measurements()
+            pattern.minimize_space()
+            state = circuit.simulate_statevector()
+            state_mbqc = pattern.simulate_pattern()
+            np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
     def test_pauli_measurment_opt_gate_transpiler_without_signalshift(self):
         nqubits = 3
         depth = 3
-        pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
-        circuit = rc.generate_gate(nqubits, depth, pairs, use_rzz=True)
-        pattern = circuit.standardize_and_transpile(opt=True)
-        pattern.perform_pauli_measurements()
-        pattern.minimize_space()
-        state = circuit.simulate_statevector()
-        state_mbqc = pattern.simulate_pattern()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+        for i in range(10):
+            circuit = rc.get_rand_circuit(nqubits, depth, use_rzz=True)
+            pattern = circuit.standardize_and_transpile(opt=True)
+            pattern.perform_pauli_measurements()
+            pattern.minimize_space()
+            state = circuit.simulate_statevector()
+            state_mbqc = pattern.simulate_pattern()
+            np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
     def test_pauli_measurement(self):
         # test pattern is obtained from 3-qubit QFT with pauli measurement
@@ -264,46 +261,46 @@ class TestLocalPattern(unittest.TestCase):
     def test_standardize(self):
         nqubits = 5
         depth = 4
-        pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
-        circuit = rc.generate_gate(nqubits, depth, pairs)
-        pattern = circuit.transpile()
-        localpattern = pattern.get_local_pattern()
-        localpattern.standardize()
-        pattern = localpattern.get_pattern()
-        np.testing.assert_equal(pattern.is_standard(), True)
-        pattern.minimize_space()
-        state_p = pattern.simulate_pattern()
-        state_ref = circuit.simulate_statevector()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())), 1)
+        for i in range(10):
+            circuit = rc.get_rand_circuit(nqubits, depth)
+            pattern = circuit.transpile()
+            localpattern = pattern.get_local_pattern()
+            localpattern.standardize()
+            pattern = localpattern.get_pattern()
+            np.testing.assert_equal(pattern.is_standard(), True)
+            pattern.minimize_space()
+            state_p = pattern.simulate_pattern()
+            state_ref = circuit.simulate_statevector()
+            np.testing.assert_almost_equal(np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())), 1)
 
     def test_shift_signals(self):
         nqubits = 5
         depth = 4
-        pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
-        circuit = rc.generate_gate(nqubits, depth, pairs)
-        pattern = circuit.transpile()
-        localpattern = pattern.get_local_pattern()
-        localpattern.standardize()
-        localpattern.shift_signals()
-        pattern = localpattern.get_pattern()
-        np.testing.assert_equal(pattern.is_standard(), True)
-        pattern.minimize_space()
-        state_p = pattern.simulate_pattern()
-        state_ref = circuit.simulate_statevector()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())), 1)
+        for i in range(10):
+            circuit = rc.get_rand_circuit(nqubits, depth)
+            pattern = circuit.transpile()
+            localpattern = pattern.get_local_pattern()
+            localpattern.standardize()
+            localpattern.shift_signals()
+            pattern = localpattern.get_pattern()
+            np.testing.assert_equal(pattern.is_standard(), True)
+            pattern.minimize_space()
+            state_p = pattern.simulate_pattern()
+            state_ref = circuit.simulate_statevector()
+            np.testing.assert_almost_equal(np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())), 1)
 
     def test_standardize_and_shift_signals(self):
         nqubits = 5
         depth = 4
-        pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
-        circuit = rc.generate_gate(nqubits, depth, pairs)
-        pattern = circuit.transpile()
-        pattern.standardize_and_shift_signals()
-        np.testing.assert_equal(pattern.is_standard(), True)
-        pattern.minimize_space()
-        state_p = pattern.simulate_pattern()
-        state_ref = circuit.simulate_statevector()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())), 1)
+        for i in range(10):
+            circuit = rc.get_rand_circuit(nqubits, depth)
+            pattern = circuit.transpile()
+            pattern.standardize_and_shift_signals()
+            np.testing.assert_equal(pattern.is_standard(), True)
+            pattern.minimize_space()
+            state_p = pattern.simulate_pattern()
+            state_ref = circuit.simulate_statevector()
+            np.testing.assert_almost_equal(np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())), 1)
 
     def test_mixed_pattern_operations(self):
         processes = [
@@ -318,47 +315,47 @@ class TestLocalPattern(unittest.TestCase):
         ]
         nqubits = 3
         depth = 2
-        pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
-        circuit = rc.generate_gate(nqubits, depth, pairs)
-        state_ref = circuit.simulate_statevector()
-        for process in processes:
-            pattern = circuit.transpile()
-            for operation in process:
-                if operation[0] == "standardize":
-                    pattern.standardize(method=operation[1])
-                elif operation[0] == "signal":
-                    pattern.shift_signals(method=operation[1])
-            np.testing.assert_equal(pattern.is_standard(), True)
-            pattern.minimize_space()
-            state_p = pattern.simulate_pattern()
-            np.testing.assert_almost_equal(np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())), 1)
+        for i in range(3):
+            circuit = rc.get_rand_circuit(nqubits, depth)
+            state_ref = circuit.simulate_statevector()
+            for process in processes:
+                pattern = circuit.transpile()
+                for operation in process:
+                    if operation[0] == "standardize":
+                        pattern.standardize(method=operation[1])
+                    elif operation[0] == "signal":
+                        pattern.shift_signals(method=operation[1])
+                np.testing.assert_equal(pattern.is_standard(), True)
+                pattern.minimize_space()
+                state_p = pattern.simulate_pattern()
+                np.testing.assert_almost_equal(np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())), 1)
 
     def test_opt_transpile_standardize(self):
         nqubits = 5
         depth = 4
-        pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
-        circuit = rc.generate_gate(nqubits, depth, pairs)
-        pattern = circuit.transpile(opt=True)
-        pattern.standardize(method="local")
-        np.testing.assert_equal(pattern.is_standard(), True)
-        pattern.minimize_space()
-        state_p = pattern.simulate_pattern()
-        state_ref = circuit.simulate_statevector()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())), 1)
+        for i in range(10):
+            circuit = rc.get_rand_circuit(nqubits, depth)
+            pattern = circuit.transpile(opt=True)
+            pattern.standardize(method="local")
+            np.testing.assert_equal(pattern.is_standard(), True)
+            pattern.minimize_space()
+            state_p = pattern.simulate_pattern()
+            state_ref = circuit.simulate_statevector()
+            np.testing.assert_almost_equal(np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())), 1)
 
     def test_opt_transpile_shift_signals(self):
         nqubits = 5
         depth = 4
-        pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
-        circuit = rc.generate_gate(nqubits, depth, pairs)
-        pattern = circuit.transpile(opt=True)
-        pattern.standardize(method="local")
-        pattern.shift_signals(method="local")
-        np.testing.assert_equal(pattern.is_standard(), True)
-        pattern.minimize_space()
-        state_p = pattern.simulate_pattern()
-        state_ref = circuit.simulate_statevector()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())), 1)
+        for i in range(10):
+            circuit = rc.get_rand_circuit(nqubits, depth)
+            pattern = circuit.transpile(opt=True)
+            pattern.standardize(method="local")
+            pattern.shift_signals(method="local")
+            np.testing.assert_equal(pattern.is_standard(), True)
+            pattern.minimize_space()
+            state_p = pattern.simulate_pattern()
+            state_ref = circuit.simulate_statevector()
+            np.testing.assert_almost_equal(np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())), 1)
 
     def test_node_is_standardized(self):
         ref_sequence = [
@@ -375,14 +372,14 @@ class TestLocalPattern(unittest.TestCase):
     def test_localpattern_is_standard(self):
         nqubits = 5
         depth = 4
-        pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
-        circuit = rc.generate_gate(nqubits, depth, pairs)
-        localpattern = circuit.transpile().get_local_pattern()
-        result1 = localpattern.is_standard()
-        localpattern.standardize()
-        result2 = localpattern.is_standard()
-        np.testing.assert_equal(result1, False)
-        np.testing.assert_equal(result2, True)
+        for i in range(10):
+            circuit = rc.get_rand_circuit(nqubits, depth)
+            localpattern = circuit.transpile().get_local_pattern()
+            result1 = localpattern.is_standard()
+            localpattern.standardize()
+            result2 = localpattern.is_standard()
+            np.testing.assert_equal(result1, False)
+            np.testing.assert_equal(result2, True)
 
 
 def assert_equal_edge(edge, ref):

--- a/tests/test_tnsim.py
+++ b/tests/test_tnsim.py
@@ -298,95 +298,95 @@ class TestTN(unittest.TestCase):
         np.testing.assert_almost_equal(value1, value2)
 
     def test_with_graphtrans(self):
-        nqubits = 3
+        nqubits = 4
         depth = 6
-        pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
-        circuit = rc.generate_gate(nqubits, depth, pairs)
-        pattern = circuit.transpile()
-        pattern.standardize()
-        pattern.shift_signals()
-        pattern.perform_pauli_measurements()
-        state = circuit.simulate_statevector()
-        tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
-        random_op3 = random_op(3)
-        input = [0, 1, 2]
-        for qargs in itertools.permutations(input):
-            value1 = state.expectation_value(random_op3, list(qargs))
-            value2 = tn_mbqc.expectation_value(random_op3, list(qargs))
-            np.testing.assert_almost_equal(value1, value2)
+        for i in range(10):
+            circuit = rc.get_rand_circuit(nqubits, depth)
+            pattern = circuit.transpile()
+            pattern.standardize()
+            pattern.shift_signals()
+            pattern.perform_pauli_measurements()
+            state = circuit.simulate_statevector()
+            tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
+            random_op3 = random_op(3)
+            input = [0, 1, 2]
+            for qargs in itertools.permutations(input):
+                value1 = state.expectation_value(random_op3, list(qargs))
+                value2 = tn_mbqc.expectation_value(random_op3, list(qargs))
+                np.testing.assert_almost_equal(value1, value2)
 
     def test_with_graphtrans_sequential(self):
-        nqubits = 3
+        nqubits = 4
         depth = 6
-        pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
-        circuit = rc.generate_gate(nqubits, depth, pairs)
-        pattern = circuit.transpile()
-        pattern.standardize()
-        pattern.shift_signals()
-        pattern.perform_pauli_measurements()
-        state = circuit.simulate_statevector()
-        tn_mbqc = pattern.simulate_pattern(backend="tensornetwork", graph_prep="sequential")
-        random_op3 = random_op(3)
-        input = [0, 1, 2]
-        for qargs in itertools.permutations(input):
-            value1 = state.expectation_value(random_op3, list(qargs))
-            value2 = tn_mbqc.expectation_value(random_op3, list(qargs))
-            np.testing.assert_almost_equal(value1, value2)
+        for i in range(10):
+            circuit = rc.get_rand_circuit(nqubits, depth)
+            pattern = circuit.transpile()
+            pattern.standardize()
+            pattern.shift_signals()
+            pattern.perform_pauli_measurements()
+            state = circuit.simulate_statevector()
+            tn_mbqc = pattern.simulate_pattern(backend="tensornetwork", graph_prep="sequential")
+            random_op3 = random_op(3)
+            input = [0, 1, 2]
+            for qargs in itertools.permutations(input):
+                value1 = state.expectation_value(random_op3, list(qargs))
+                value2 = tn_mbqc.expectation_value(random_op3, list(qargs))
+                np.testing.assert_almost_equal(value1, value2)
 
     def test_coef_state(self):
         nqubits = 4
         depth = 2
-        pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
-        circuit = rc.generate_gate(nqubits, depth, pairs)
-        pattern = circuit.standardize_and_transpile()
+        for i in range(10):
+            circuit = rc.get_rand_circuit(nqubits, depth)
+            pattern = circuit.standardize_and_transpile()
 
-        statevec_ref = circuit.simulate_statevector()
+            statevec_ref = circuit.simulate_statevector()
 
-        tn = pattern.simulate_pattern("tensornetwork")
-        for number in range(len(statevec_ref.flatten())):
-            self.subTest(number=number)
-            coef_tn = tn.get_basis_coefficient(number)
-            coef_sv = statevec_ref.flatten()[number]
+            tn = pattern.simulate_pattern("tensornetwork")
+            for number in range(len(statevec_ref.flatten())):
+                self.subTest(number=number)
+                coef_tn = tn.get_basis_coefficient(number)
+                coef_sv = statevec_ref.flatten()[number]
 
-            np.testing.assert_almost_equal(abs(coef_tn), abs(coef_sv))
+                np.testing.assert_almost_equal(abs(coef_tn), abs(coef_sv))
 
     def test_to_statevector(self):
         nqubits_set = [i for i in range(2, 6)]
         depth = 3
         for nqubits in nqubits_set:
             self.subTest(nqubit=nqubits)
-            pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
-            circuit = rc.generate_gate(nqubits, depth, pairs)
-            pattern = circuit.standardize_and_transpile()
-            statevec_ref = circuit.simulate_statevector()
+            for i in range(5):
+                circuit = rc.get_rand_circuit(nqubits, depth)
+                pattern = circuit.standardize_and_transpile()
+                statevec_ref = circuit.simulate_statevector()
 
-            tn = pattern.simulate_pattern("tensornetwork")
-            statevec_tn = tn.to_statevector()
+                tn = pattern.simulate_pattern("tensornetwork")
+                statevec_tn = tn.to_statevector()
 
-            inner_product = np.inner(statevec_tn, statevec_ref.flatten().conjugate())
-            np.testing.assert_almost_equal(abs(inner_product), 1)
+                inner_product = np.inner(statevec_tn, statevec_ref.flatten().conjugate())
+                np.testing.assert_almost_equal(abs(inner_product), 1)
 
     def test_evolve(self):
-        nqubits = 3
+        nqubits = 4
         depth = 6
-        pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
-        circuit = rc.generate_gate(nqubits, depth, pairs)
-        pattern = circuit.transpile()
-        pattern.standardize()
-        pattern.shift_signals()
-        pattern.perform_pauli_measurements()
-        state = circuit.simulate_statevector()
-        tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
-        random_op3 = random_op(3)
-        random_op3_exp = random_op(3)
+        for i in range(10):
+            circuit = rc.get_rand_circuit(nqubits, depth)
+            pattern = circuit.transpile()
+            pattern.standardize()
+            pattern.shift_signals()
+            pattern.perform_pauli_measurements()
+            state = circuit.simulate_statevector()
+            tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
+            random_op3 = random_op(3)
+            random_op3_exp = random_op(3)
 
-        state.evolve(random_op3, [0, 1, 2])
-        tn_mbqc.evolve(random_op3, [0, 1, 2], decompose=False)
+            state.evolve(random_op3, [0, 1, 2])
+            tn_mbqc.evolve(random_op3, [0, 1, 2], decompose=False)
 
-        expval_tn = tn_mbqc.expectation_value(random_op3_exp, [0, 1, 2])
-        expval_ref = state.expectation_value(random_op3_exp, [0, 1, 2])
+            expval_tn = tn_mbqc.expectation_value(random_op3_exp, [0, 1, 2])
+            expval_ref = state.expectation_value(random_op3_exp, [0, 1, 2])
 
-        np.testing.assert_almost_equal(expval_tn, expval_ref)
+            np.testing.assert_almost_equal(expval_tn, expval_ref)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Before submitting, please check the following:
- Make sure you have tests for the new code and that test passes (run `pytest`)
- format added code and tests by `black -l 120 <filename>`
- If applicable, add a line to the [unreleased] part of CHANGELOG.md, following [keep-a-changelog](https://keepachangelog.com/en/1.0.0/).
 
Then, please fill in below:

**Context (if applicable):**

**Description of the change:**
1. Fixed bug in `GraphState` graph state simulator, specifically, 
- `equivalent_graph_E2` method
- bug in toggling 'loop' in `s` method
- behaviour of `measure_x` and `measure_z` methods for isolated nodes
2. Fixed `measure` method of `StatevectorBackend`: 
- now we apply s and t signals by Clifford gate, not change of angles.
- effect of vops in `meas_op` is now done by application of Clifford gate conjugation on measurement operator, instead of interchanging of measurement axes 
3. Fixed pauli measurement preprocessing routine in `pattern.py`
- we treat the signals by applying Clifford gates, not by the change of angles

**Related issue:**
#62 
(#56)

also see that checks (github actions) pass.
If lint check keeps failing, try installing black==22.8.0 as behavior seems to vary across versions.



