### PR TITLE
remove_qubit method for faster statevec simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Fast alternative to partial trace (`Statevec.remove_qubit`) for a separable (post-measurement) qubit (#73)
+
 ### Changed
 
-## [0.2.5] - 2023-07-26
-### Added
+- `StatevectorBackend` now uses `Statevec.remove_qubit` after each measurement, instead of performing `ptrace` after multiple measurements, for better performance. This keeps the result exactly the same (#73)
 
-- Fast qubit removing method (`Statevec.remove_qubit`) for qubit in separable state (#73)
 
 ## [0.2.4] - 2023-07-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
+## [0.2.5] - 2023-07-26
+### Added
+
+- Fast qubit removing method (`Statevec.remove_qubit`) for qubit in separable state (#73)
+
 ## [0.2.4] - 2023-07-06
 ### Added
 
 - Interface to run patterns on the IBMQ devices. (see PR) (#44)
-
 
 ## [0.2.3] - 2023-06-25
 ### Changed

--- a/graphix/sim/statevec.py
+++ b/graphix/sim/statevec.py
@@ -259,10 +259,9 @@ class Statevec:
             qarg (int): qubit index
         """
         # extract |***0_{qarg}***> components if not zero else |***1_{qarg}***>
+        assert not np.isclose(norm(self.psi), 0)
         psi = self.psi.take(indices=0, axis=qarg)
-        if np.isclose(norm(psi), 0):
-            psi = self.psi.take(indices=1, axis=qarg)
-        self.psi = psi
+        self.psi = psi if not np.isclose(norm(psi), 0) else self.psi.take(indices=1, axis=qarg)
         self.normalize()
 
     def entangle(self, edge):

--- a/graphix/sim/statevec.py
+++ b/graphix/sim/statevec.py
@@ -278,8 +278,8 @@ class Statevec:
         Note this does not exactly perform the partial trace: see :meth:`~graphix.sim.statevec.Statevec.ptrace`
         and warning therein.
 
-        For a statevector :math:`\ket{\psi} = \sum c_i \ket{i}` with :math:`\ket{i} = \ket{0 \dots 0}, \dots,
-        \ket{1 \dots 1}`, this method returns
+        For a statevector :math:`\ket{\psi} = \sum c_i \ket{i}` with sum taken over :math:`i \in 0 \dots 00,\ 0\dots 01,\ \dots,\
+        1 \dots 11`, this method returns
 
         .. math::
             \begin{align}
@@ -291,7 +291,7 @@ class Statevec:
            \end{align}
 
         after normalization, for :math:`k =` qarg. If the :math:`k` th qubit is in :math:`1` state,
-        above will be zero, so in such a case the returned state will be the one above with :math:`0_{\mathrm{k}}`
+        above will not work, and in such a case the returned state will be the one above with :math:`0_{\mathrm{k}}`
         replaced with :math:`1_{\mathrm{k}}` .
 
         .. warning::

--- a/graphix/sim/statevec.py
+++ b/graphix/sim/statevec.py
@@ -297,9 +297,9 @@ class Statevec:
             qubit index
         """
         # extract |***0_{qarg}***> components if not zero else |***1_{qarg}***>
-        assert not np.isclose(get_norm(self.psi), 0)
+        assert not np.isclose(_get_statevec_norm(self.psi), 0)
         psi = self.psi.take(indices=0, axis=qarg)
-        self.psi = psi if not np.isclose(get_norm(psi), 0) else self.psi.take(indices=1, axis=qarg)
+        self.psi = psi if not np.isclose(_get_statevec_norm(psi), 0) else self.psi.take(indices=1, axis=qarg)
         self.normalize()
 
     def entangle(self, edge):
@@ -357,7 +357,7 @@ class Statevec:
 
     def normalize(self):
         """normalize the state"""
-        norm = get_norm(self.psi)
+        norm = _get_statevec_norm(self.psi)
         self.psi = self.psi / norm
 
     def flatten(self):
@@ -405,6 +405,6 @@ class Statevec:
         return np.dot(st2.psi.flatten().conjugate(), st1.psi.flatten())
 
 
-def get_norm(psi):
+def _get_statevec_norm(psi):
     """returns norm of the state"""
     return np.sqrt(np.sum(psi.flatten().conj() * psi.flatten()))

--- a/graphix/sim/statevec.py
+++ b/graphix/sim/statevec.py
@@ -260,7 +260,9 @@ class Statevec:
         """
         # extract |***0_{qarg}***> components if not zero else |***1_{qarg}***>
         psi = self.psi.take(indices=0, axis=qarg)
-        self.psi = psi if not np.isclose(psi.flat[0], 0) else self.psi.take(indices=1, axis=qarg)
+        if np.isclose(norm(psi), 0):
+            psi = self.psi.take(indices=1, axis=qarg)
+        self.psi = psi
         self.normalize()
 
     def entangle(self, edge):

--- a/graphix/sim/statevec.py
+++ b/graphix/sim/statevec.py
@@ -252,13 +252,13 @@ class Statevec:
         return self.psi.shape
 
     def ptrace(self, qargs):
-        """partial trace selected qubits
+        """Perform partial trace of the selected qubits.
 
         .. warning::
             This method currently assumes qubits in qargs to be separable from the rest
             (checks not implemented for speed).
-            Otherwise, the state returned will be forced to be pure which will result in incorrect state.
-            Correct behaviour will be implemented as soon as the densitymatrix class, currently under development (#64)
+            Otherwise, the state returned will be forced to be pure which will result in incorrect output.
+            Correct behaviour will be implemented as soon as the densitymatrix class, currently under development (PR #64),
             is merged.
 
         Parameters
@@ -275,11 +275,10 @@ class Statevec:
 
     def remove_qubit(self, qarg):
         r"""Remove a separable qubit from the system and assemble a statevector for remaining qubits.
-        Note this does not exactly perform the partial trace: see :meth:`~graphix.sim.statevec.Statevec.ptrace`
-        and warning therein.
-
-        For a statevector :math:`\ket{\psi} = \sum c_i \ket{i}` with sum taken over :math:`i \in 0 \dots 00,\ 0\dots 01,\ \dots,\
-        1 \dots 11`, this method returns
+        This results in the same result as partial trace, if the qubit `qarg` is separable from the rest.
+        
+        For a statevector :math:`\ket{\psi} = \sum c_i \ket{i}` with sum taken over :math:`i \in [ 0 \dots 00,\ 0\dots 01,\ \dots,\
+        1 \dots 11 ]`, this method returns
 
         .. math::
             \begin{align}
@@ -300,13 +299,16 @@ class Statevec:
             and is implemented as a significantly faster alternative for partial trace to
             be used after single-qubit measurements.
             Care needs to be taken when using this method.
+            Checks for separability will be implemented soon as an option.
+        
+        .. seealso::
+            :meth:`graphix.sim.statevec.Statevec.ptrace` and warning therein.
 
         Parameters
         ----------
         qarg : int
             qubit index
         """
-        # extract |***0_{qarg}***> components if not zero else |***1_{qarg}***>
         assert not np.isclose(_get_statevec_norm(self.psi), 0)
         psi = self.psi.take(indices=0, axis=qarg)
         self.psi = psi if not np.isclose(_get_statevec_norm(psi), 0) else self.psi.take(indices=1, axis=qarg)

--- a/graphix/sim/statevec.py
+++ b/graphix/sim/statevec.py
@@ -213,7 +213,7 @@ class Statevec:
             nqubit (int, optional): number of qubits. Defaults to 1.
         """
         if plus_states:
-            self.psi = np.ones((2,) * nqubit) / np.sqrt(2**nqubit)
+            self.psi = np.ones((2,) * nqubit) / 2 ** (nqubit / 2)
         else:
             self.psi = np.zeros((2,) * nqubit)
             self.psi[(0,) * nqubit] = 1
@@ -263,6 +263,17 @@ class Statevec:
         rho = np.reshape(rho, (2**nqubit_after, 2**nqubit_after))
         evals, evecs = np.linalg.eig(rho)  # back to statevector
         self.psi = np.reshape(evecs[:, np.argmax(evals)], (2,) * nqubit_after)
+
+    def truncate_one_qubit(self, qarg):
+        """truncate one qubit
+
+        Args:
+            qarg (int): qubit index
+        """
+        # extract |***0_{qarg}***> components if not zero else |***1_{qarg}***>
+        psi = self.psi.take(indices=0, axis=qarg)
+        self.psi = psi if psi[(0,) * psi.ndim] != 0.0 else self.psi.take(indices=1, axis=qarg)
+        self.normalize()
 
     def entangle(self, edge):
         """connect graph nodes

--- a/graphix/sim/statevec.py
+++ b/graphix/sim/statevec.py
@@ -98,7 +98,7 @@ class StatevectorBackend:
         loc = self.node_index.index(cmd[1])
         self.state.evolve_single(m_op, loc)
 
-        self.state.truncate_one_qubit(loc)
+        self.state.remove_qubit(loc)
         self.node_index.remove(cmd[1])
         self.Nqubit -= 1
 
@@ -250,11 +250,12 @@ class Statevec:
         return self.psi.shape
 
     def ptrace(self, qargs):
-        """partial trace
+        """partial trace selected qubits
 
-        CAUTION: This method is currently valid only for separable states.
-                 When a density matrix is implemented in the near future,
-                 this method will work completely.
+        .. warning::
+            This method currently assumes qubits in qargs to be separable from the rest (checks not implemented for speed).
+            Otherwise, the state returned will be forced to be pure which will result in incorrect state.
+            Correct behaviour will be implemented as soon as the densitymatrix class, currently under development (#64) is merged.
 
         Parameters
         ----------
@@ -268,8 +269,22 @@ class Statevec:
         evals, evecs = np.linalg.eig(rho)  # back to statevector
         self.psi = np.reshape(evecs[:, np.argmax(evals)], (2,) * nqubit_after)
 
-    def truncate_one_qubit(self, qarg):
-        """truncate one qubit. this method is only used for separable states.
+    def remove_qubit(self, qarg):
+        """ Remove a separable qubit from the system and assemble a statevector for remaining qubits.
+        Note this does not exactly perform the partial trace: see :meth:`~graphix.sim.statevec.Statevec.ptrace` and warning therein.
+
+        For a statevector $\ket{\psi} = \sum c_i \ket{i}$ with $i = 00\dots 0 \dots 11\dots 1$, this method returns
+        $\ket{\psi}' = c_{0 \dots 00_{\mathrm{k}}0 \dots 00} \ket{0 \dots 00_{\mathrm{k}}0 \dots 00} + 
+          c_{0 \dots 00_{\mathrm{k}}0 \dots 01} \ket{0 \dots 00_{\mathrm{k}}0 \dots 01} 
+          \dots c_{1 \dots 10_{\mathrm{k}}1 \dots 11} \ket{1 \dots 10_{\mathrm{k}}1 \dots 11}$
+        after normalization, for $k$ = qarg. If the $k$th qubit is in $1$ state, above will be zero, so 
+        in such a case the returned state will be the one above with $0_{\mathlim{k}}$ replaced with $1_{\mathlim{k}}$.
+        
+        .. warning::
+            This method assumes the qubit with index `qarg` to be separable from the rest,
+            and is implemented as a significantly faster alternative for partial trace to 
+            be used after single-qubit measurements. 
+            Care needs to be taken when using this method.
 
         Parameters
         ----------

--- a/graphix/sim/statevec.py
+++ b/graphix/sim/statevec.py
@@ -36,6 +36,7 @@ class StatevectorBackend:
 
     def qubit_dim(self):
         """Returns the qubit number in the internal statevector
+
         Returns
         -------
         n_qubit : int
@@ -73,6 +74,7 @@ class StatevectorBackend:
 
     def measure(self, cmd):
         """Perform measurement of a node in the internal statevector and trace out the qubit
+
         Parameters
         ----------
         cmd : list
@@ -276,14 +278,21 @@ class Statevec:
         Note this does not exactly perform the partial trace: see :meth:`~graphix.sim.statevec.Statevec.ptrace`
         and warning therein.
 
-        For a statevector :math:`\ket{\psi} = \sum c_i \ket{i}` with :math:`i = 00\dots 0 \dots 11\dots 1`,
-        this method returns
-        :math:`\ket{\psi}' = c_{0 \dots 00_{\mathrm{k}}0 \dots 00} \ket{0 \dots 00_{\mathrm{k}}0 \dots 00} +
-          c_{0 \dots 00_{\mathrm{k}}0 \dots 01} \ket{0 \dots 00_{\mathrm{k}}0 \dots 01}
-          \dots c_{1 \dots 10_{\mathrm{k}}1 \dots 11} \ket{1 \dots 10_{\mathrm{k}}1 \dots 11}`
-        after normalization, for :math:`k = ` `qarg`. If the :math:`k`th qubit is in :math:`1` state,
-        above will be zero, so in such a case the returned state will be the one above with :math:`0_{\mathlim{k}}`
-        replaced with :math:`1_{\mathlim{k}}`.
+        For a statevector :math:`\ket{\psi} = \sum c_i \ket{i}` with :math:`\ket{i} = \ket{0 \dots 0}, \dots,
+        \ket{1 \dots 1}`, this method returns
+
+        .. math::
+            \begin{align}
+                \ket{\psi}' =&
+                    c_{0 \dots 00_{\mathrm{k}}0 \dots 00} \ket{0 \dots 00_{\mathrm{k}}0 \dots 00} \\
+                    & + c_{0 \dots 00_{\mathrm{k}}0 \dots 01} \ket{0 \dots 00_{\mathrm{k}}0 \dots 01} \\
+                    & + \dots \\
+                    & + c_{1 \dots 10_{\mathrm{k}}1 \dots 11} \ket{1 \dots 10_{\mathrm{k}}1 \dots 11}
+           \end{align}
+
+        after normalization, for :math:`k =` qarg. If the :math:`k` th qubit is in :math:`1` state,
+        above will be zero, so in such a case the returned state will be the one above with :math:`0_{\mathrm{k}}`
+        replaced with :math:`1_{\mathrm{k}}` .
 
         .. warning::
             This method assumes the qubit with index `qarg` to be separable from the rest,

--- a/graphix/sim/statevec.py
+++ b/graphix/sim/statevec.py
@@ -284,14 +284,15 @@ class Statevec:
         .. math::
             \begin{align}
                 \ket{\psi}' =&
-                    c_{0 \dots 00_{\mathrm{k}}0 \dots 00} \ket{0 \dots 00_{\mathrm{k}}0 \dots 00} \\
-                    & + c_{0 \dots 00_{\mathrm{k}}0 \dots 01} \ket{0 \dots 00_{\mathrm{k}}0 \dots 01} \\
+                    c_{0 \dots 0_{\mathrm{k-1}}0_{\mathrm{k}}0_{\mathrm{k+1}} \dots 00} \ket{0 \dots 0_{\mathrm{k-1}}0_{\mathrm{k+1}} \dots 00} \\
+                    & + c_{0 \dots 0_{\mathrm{k-1}}0_{\mathrm{k}}0_{\mathrm{k+1}} \dots 01} \ket{0 \dots 0_{\mathrm{k-1}}0_{\mathrm{k+1}} \dots 01} \\
+                    & + c_{0 \dots 0_{\mathrm{k-1}}0_{\mathrm{k}}0_{\mathrm{k+1}} \dots 10} \ket{0 \dots 0_{\mathrm{k-1}}0_{\mathrm{k+1}} \dots 10} \\
                     & + \dots \\
-                    & + c_{1 \dots 10_{\mathrm{k}}1 \dots 11} \ket{1 \dots 10_{\mathrm{k}}1 \dots 11}
+                    & + c_{1 \dots 1_{\mathrm{k-1}}0_{\mathrm{k}}1_{\mathrm{k+1}} \dots 11} \ket{1 \dots 1_{\mathrm{k-1}}1_{\mathrm{k+1}} \dots 11},
            \end{align}
 
-        after normalization, for :math:`k =` qarg. If the :math:`k` th qubit is in :math:`1` state,
-        above will not work, and in such a case the returned state will be the one above with :math:`0_{\mathrm{k}}`
+        (after normalization) for :math:`k =` qarg. If the :math:`k` th qubit is in :math:`\ket{1}` state,
+        above will return zero amplitudes; in such a case the returned state will be the one above with :math:`0_{\mathrm{k}}`
         replaced with :math:`1_{\mathrm{k}}` .
 
         .. warning::

--- a/graphix/sim/statevec.py
+++ b/graphix/sim/statevec.py
@@ -13,9 +13,9 @@ class StatevectorBackend:
         """
         Parameteres
         -----------
-        pattern: :class:`graphix.pattern.Pattern` object
+        pattern : :class:`graphix.pattern.Pattern` object
             MBQC pattern to be simulated.
-        backend: str, 'statevector'
+        backend : str, 'statevector'
             optional argument for simulation.
         max_qubit_num : int
             optional argument specifying the maximum number of qubits
@@ -146,7 +146,7 @@ def meas_op(angle, vop=0, plane="XY", choice=0):
 
     Parameters
     ----------
-    angle: float
+    angle : float
         original measurement angle in radian
     vop : int
         index of local Clifford (vop), see graphq.clifford.CLIFFORD
@@ -253,9 +253,11 @@ class Statevec:
         """partial trace selected qubits
 
         .. warning::
-            This method currently assumes qubits in qargs to be separable from the rest (checks not implemented for speed).
+            This method currently assumes qubits in qargs to be separable from the rest
+            (checks not implemented for speed).
             Otherwise, the state returned will be forced to be pure which will result in incorrect state.
-            Correct behaviour will be implemented as soon as the densitymatrix class, currently under development (#64) is merged.
+            Correct behaviour will be implemented as soon as the densitymatrix class, currently under development (#64)
+            is merged.
 
         Parameters
         ----------
@@ -270,15 +272,18 @@ class Statevec:
         self.psi = np.reshape(evecs[:, np.argmax(evals)], (2,) * nqubit_after)
 
     def remove_qubit(self, qarg):
-        """Remove a separable qubit from the system and assemble a statevector for remaining qubits.
-        Note this does not exactly perform the partial trace: see :meth:`~graphix.sim.statevec.Statevec.ptrace` and warning therein.
+        r"""Remove a separable qubit from the system and assemble a statevector for remaining qubits.
+        Note this does not exactly perform the partial trace: see :meth:`~graphix.sim.statevec.Statevec.ptrace`
+        and warning therein.
 
-        For a statevector $\ket{\psi} = \sum c_i \ket{i}$ with $i = 00\dots 0 \dots 11\dots 1$, this method returns
-        $\ket{\psi}' = c_{0 \dots 00_{\mathrm{k}}0 \dots 00} \ket{0 \dots 00_{\mathrm{k}}0 \dots 00} +
+        For a statevector :math:`\ket{\psi} = \sum c_i \ket{i}` with :math:`i = 00\dots 0 \dots 11\dots 1`,
+        this method returns
+        :math:`\ket{\psi}' = c_{0 \dots 00_{\mathrm{k}}0 \dots 00} \ket{0 \dots 00_{\mathrm{k}}0 \dots 00} +
           c_{0 \dots 00_{\mathrm{k}}0 \dots 01} \ket{0 \dots 00_{\mathrm{k}}0 \dots 01}
-          \dots c_{1 \dots 10_{\mathrm{k}}1 \dots 11} \ket{1 \dots 10_{\mathrm{k}}1 \dots 11}$
-        after normalization, for $k$ = qarg. If the $k$th qubit is in $1$ state, above will be zero, so
-        in such a case the returned state will be the one above with $0_{\mathlim{k}}$ replaced with $1_{\mathlim{k}}$.
+          \dots c_{1 \dots 10_{\mathrm{k}}1 \dots 11} \ket{1 \dots 10_{\mathrm{k}}1 \dots 11}`
+        after normalization, for :math:`k = ` `qarg`. If the :math:`k`th qubit is in :math:`1` state,
+        above will be zero, so in such a case the returned state will be the one above with :math:`0_{\mathlim{k}}`
+        replaced with :math:`1_{\mathlim{k}}`.
 
         .. warning::
             This method assumes the qubit with index `qarg` to be separable from the rest,
@@ -288,7 +293,7 @@ class Statevec:
 
         Parameters
         ----------
-        qarg :int
+        qarg : int
             qubit index
         """
         # extract |***0_{qarg}***> components if not zero else |***1_{qarg}***>
@@ -302,7 +307,7 @@ class Statevec:
 
         Parameters
         ----------
-        edge :tuple of int
+        edge : tuple of int
             (control, target) qubit indices
         """
         # contraction: 2nd index - control index, and 3rd index - target index.
@@ -316,7 +321,7 @@ class Statevec:
 
         Parameters
         ----------
-        other : graphix.sim.statevec.Statevec
+        other : :class:`graphix.sim.statevec.Statevec`
             statevector to be tensored with self
         """
         psi_self = self.psi.flatten()
@@ -366,7 +371,7 @@ class Statevec:
         ----------
         op : numpy.ndarray
             2*2 operator
-        loc :int
+        loc : int
             target qubit index
 
         Returns
@@ -391,7 +396,7 @@ class Statevec:
 
         Returns
         -------
-        complex: expectation value
+        complex : expectation value
         """
         st1 = deepcopy(self)
         st1.normalize()

--- a/graphix/sim/statevec.py
+++ b/graphix/sim/statevec.py
@@ -260,7 +260,7 @@ class Statevec:
         """
         # extract |***0_{qarg}***> components if not zero else |***1_{qarg}***>
         psi = self.psi.take(indices=0, axis=qarg)
-        self.psi = psi if psi[(0,) * psi.ndim] != 0.0 else self.psi.take(indices=1, axis=qarg)
+        self.psi = psi if not np.isclose(psi.flat[0], 0) else self.psi.take(indices=1, axis=qarg)
         self.normalize()
 
     def entangle(self, edge):

--- a/graphix/sim/statevec.py
+++ b/graphix/sim/statevec.py
@@ -270,20 +270,20 @@ class Statevec:
         self.psi = np.reshape(evecs[:, np.argmax(evals)], (2,) * nqubit_after)
 
     def remove_qubit(self, qarg):
-        """ Remove a separable qubit from the system and assemble a statevector for remaining qubits.
+        """Remove a separable qubit from the system and assemble a statevector for remaining qubits.
         Note this does not exactly perform the partial trace: see :meth:`~graphix.sim.statevec.Statevec.ptrace` and warning therein.
 
         For a statevector $\ket{\psi} = \sum c_i \ket{i}$ with $i = 00\dots 0 \dots 11\dots 1$, this method returns
-        $\ket{\psi}' = c_{0 \dots 00_{\mathrm{k}}0 \dots 00} \ket{0 \dots 00_{\mathrm{k}}0 \dots 00} + 
-          c_{0 \dots 00_{\mathrm{k}}0 \dots 01} \ket{0 \dots 00_{\mathrm{k}}0 \dots 01} 
+        $\ket{\psi}' = c_{0 \dots 00_{\mathrm{k}}0 \dots 00} \ket{0 \dots 00_{\mathrm{k}}0 \dots 00} +
+          c_{0 \dots 00_{\mathrm{k}}0 \dots 01} \ket{0 \dots 00_{\mathrm{k}}0 \dots 01}
           \dots c_{1 \dots 10_{\mathrm{k}}1 \dots 11} \ket{1 \dots 10_{\mathrm{k}}1 \dots 11}$
-        after normalization, for $k$ = qarg. If the $k$th qubit is in $1$ state, above will be zero, so 
+        after normalization, for $k$ = qarg. If the $k$th qubit is in $1$ state, above will be zero, so
         in such a case the returned state will be the one above with $0_{\mathlim{k}}$ replaced with $1_{\mathlim{k}}$.
-        
+
         .. warning::
             This method assumes the qubit with index `qarg` to be separable from the rest,
-            and is implemented as a significantly faster alternative for partial trace to 
-            be used after single-qubit measurements. 
+            and is implemented as a significantly faster alternative for partial trace to
+            be used after single-qubit measurements.
             Care needs to be taken when using this method.
 
         Parameters

--- a/tests/test_graphsim.py
+++ b/tests/test_graphsim.py
@@ -37,21 +37,21 @@ class TestGraphSim(unittest.TestCase):
         g.measure_x(0)
         gstate.evolve_single(meas_op(0), [0])  # x meas
         gstate.normalize()
-        gstate.ptrace([0])
+        gstate.truncate_one_qubit(0)
         gstate2 = get_state(g)
         np.testing.assert_almost_equal(np.abs(np.dot(gstate.flatten().conjugate(), gstate2.flatten())), 1)
 
         g.measure_y(1, choice=0)
         gstate.evolve_single(meas_op(0.5 * np.pi), [0])  # y meas
         gstate.normalize()
-        gstate.ptrace([0])
+        gstate.truncate_one_qubit(0)
         gstate2 = get_state(g)
         np.testing.assert_almost_equal(np.abs(np.dot(gstate.flatten().conjugate(), gstate2.flatten())), 1)
 
         g.measure_z(3)
         gstate.evolve_single(meas_op(0.5 * np.pi, plane="YZ"), 1)  # z meas
         gstate.normalize()
-        gstate.ptrace([1])
+        gstate.truncate_one_qubit(1)
         gstate2 = get_state(g)
         np.testing.assert_almost_equal(np.abs(np.dot(gstate.flatten().conjugate(), gstate2.flatten())), 1)
 

--- a/tests/test_graphsim.py
+++ b/tests/test_graphsim.py
@@ -37,21 +37,21 @@ class TestGraphSim(unittest.TestCase):
         g.measure_x(0)
         gstate.evolve_single(meas_op(0), [0])  # x meas
         gstate.normalize()
-        gstate.truncate_one_qubit(0)
+        gstate.remove_qubit(0)
         gstate2 = get_state(g)
         np.testing.assert_almost_equal(np.abs(np.dot(gstate.flatten().conjugate(), gstate2.flatten())), 1)
 
         g.measure_y(1, choice=0)
         gstate.evolve_single(meas_op(0.5 * np.pi), [0])  # y meas
         gstate.normalize()
-        gstate.truncate_one_qubit(0)
+        gstate.remove_qubit(0)
         gstate2 = get_state(g)
         np.testing.assert_almost_equal(np.abs(np.dot(gstate.flatten().conjugate(), gstate2.flatten())), 1)
 
         g.measure_z(3)
         gstate.evolve_single(meas_op(0.5 * np.pi, plane="YZ"), 1)  # z meas
         gstate.normalize()
-        gstate.truncate_one_qubit(1)
+        gstate.remove_qubit(1)
         gstate2 = get_state(g)
         np.testing.assert_almost_equal(np.abs(np.dot(gstate.flatten().conjugate(), gstate2.flatten())), 1)
 

--- a/tests/test_graphsim.py
+++ b/tests/test_graphsim.py
@@ -1,8 +1,10 @@
 import unittest
+
+import numpy as np
+
 from graphix.graphsim import GraphState
 from graphix.ops import Ops
 from graphix.sim.statevec import Statevec, meas_op
-import numpy as np
 
 
 def get_state(g):

--- a/tests/test_statevec_backend.py
+++ b/tests/test_statevec_backend.py
@@ -8,7 +8,7 @@ from graphix.sim.statevec import Statevec, meas_op
 
 
 class TestStatevec(unittest.TestCase):
-    def test_truncate_one_qubit(self):
+    def test_remove_one_qubit(self):
         n = 10
         k = 3
 
@@ -19,7 +19,7 @@ class TestStatevec(unittest.TestCase):
         sv.evolve(m_op, [k])
         sv2 = deepcopy(sv)
 
-        sv.truncate_one_qubit(k)
+        sv.remove_qubit(k)
         sv2.ptrace([k])
         sv2.normalize()
 
@@ -33,7 +33,7 @@ class TestStatevec(unittest.TestCase):
             m_op = np.outer(state, state.T.conjugate())
             sv = Statevec(nqubit=n)
             sv.evolve(m_op, [k])
-            sv.truncate_one_qubit(k)
+            sv.remove_qubit(k)
 
             sv2 = Statevec(nqubit=n - 1)
             np.testing.assert_almost_equal(np.abs(sv.psi.flatten().dot(sv2.psi.flatten().conj())), 1)
@@ -45,7 +45,7 @@ class TestStatevec(unittest.TestCase):
         sv = Statevec(nqubit=n)
         sv.evolve(m_op, [k])
         with self.assertRaises(AssertionError):
-            sv.truncate_one_qubit(k)
+            sv.remove_qubit(k)
 
 
 if __name__ == "__main__":

--- a/tests/test_statevec_backend.py
+++ b/tests/test_statevec_backend.py
@@ -1,8 +1,8 @@
-import time
-import unittest
 from copy import deepcopy
+import unittest
 
 import numpy as np
+
 from graphix.ops import States
 from graphix.sim.statevec import Statevec, meas_op
 

--- a/tests/test_statevec_backend.py
+++ b/tests/test_statevec_backend.py
@@ -1,35 +1,27 @@
-import numpy as np
 import time
 import unittest
+from copy import deepcopy
+
+import numpy as np
 from graphix.ops import States
 from graphix.sim.statevec import Statevec, meas_op
-import tests.random_circuit as rc
 
 
-class StatevecTruncateOneQubitTest(unittest.TestCase):
+class TestStatevec(unittest.TestCase):
     def test_truncate_one_qubit(self):
         n = 10
         k = 3
 
         sv = Statevec(nqubit=n)
-        start = time.time()
         for i in range(n):
             sv.entangle([i, (i + 1) % n])
         m_op = meas_op(np.pi / 5)
         sv.evolve(m_op, [k])
-        sv.ptrace([k])
-        sv.normalize()
-        end = time.time()
-        print("time (ptrace): ", end - start)
+        sv2 = deepcopy(sv)
 
-        sv2 = Statevec(nqubit=n)
-        start = time.time()
-        for i in range(n):
-            sv2.entangle([i, (i + 1) % n])
-        sv2.evolve(m_op, [k])
-        sv2.truncate_one_qubit(k)
-        end = time.time()
-        print("time (new method): ", end - start)
+        sv.truncate_one_qubit(k)
+        sv2.ptrace([k])
+        sv2.normalize()
 
         np.testing.assert_almost_equal(np.abs(sv.psi.flatten().dot(sv2.psi.flatten().conj())), 1)
 
@@ -54,19 +46,6 @@ class StatevecTruncateOneQubitTest(unittest.TestCase):
         sv.evolve(m_op, [k])
         with self.assertRaises(AssertionError):
             sv.truncate_one_qubit(k)
-
-    def test_with_rand_circuit_sim(self):
-        n = 3
-        depth = 3
-        circuit = rc.get_rand_circuit(n, depth)
-        state = circuit.simulate_statevector()
-
-        pattern = circuit.transpile()
-        pattern.standardize()
-        pattern.shift_signals()
-        pattern.perform_pauli_measurements()
-        sv_mbqc = pattern.simulate_pattern()
-        np.testing.assert_almost_equal(np.abs(sv_mbqc.psi.flatten().dot(state.flatten().conj())), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_statevec_truncate_one_qubit.py
+++ b/tests/test_statevec_truncate_one_qubit.py
@@ -5,7 +5,7 @@ from graphix.sim.statevec import Statevec, meas_op
 
 
 class StatevecTruncateOneQubitTest(unittest.TestCase):
-    def test_atodekesu(self):
+    def test_truncate_one_qubit(self):
         n = 10
         k = 3
 

--- a/tests/test_statevec_truncate_one_qubit.py
+++ b/tests/test_statevec_truncate_one_qubit.py
@@ -36,7 +36,8 @@ class StatevecTruncateOneQubitTest(unittest.TestCase):
     def test_measurement_into_each_XYZ_basis(self):
         n = 3
         k = 0
-        for state in States.vec:
+        # for measurement into |-> returns [[0, 0], ..., [0, 0]] (whose norm is zero)
+        for state in [States.plus, States.zero, States.one, States.iplus, States.iminus]:
             m_op = np.outer(state, state.T.conjugate())
             sv = Statevec(nqubit=n)
             sv.evolve(m_op, [k])
@@ -44,6 +45,15 @@ class StatevecTruncateOneQubitTest(unittest.TestCase):
 
             sv2 = Statevec(nqubit=n - 1)
             np.testing.assert_almost_equal(np.abs(sv.psi.flatten().dot(sv2.psi.flatten().conj())), 1)
+
+    def test_measurement_into_minus_state(self):
+        n = 3
+        k = 0
+        m_op = np.outer(States.minus, States.minus.T.conjugate())
+        sv = Statevec(nqubit=n)
+        sv.evolve(m_op, [k])
+        with self.assertRaises(AssertionError):
+            sv.truncate_one_qubit(k)
 
     def test_with_rand_circuit_sim(self):
         n = 3

--- a/tests/test_statevec_truncate_one_qubit.py
+++ b/tests/test_statevec_truncate_one_qubit.py
@@ -1,6 +1,7 @@
 import numpy as np
 import time
 import unittest
+from graphix.ops import States
 from graphix.sim.statevec import Statevec, meas_op
 
 
@@ -29,7 +30,19 @@ class StatevecTruncateOneQubitTest(unittest.TestCase):
         end = time.time()
         print("time (new method): ", end - start)
 
-        np.testing.assert_almost_equal(np.abs(sv.psi.flatten().dot(sv2.psi.flatten().conj())), 1.0)
+        np.testing.assert_almost_equal(np.abs(sv.psi.flatten().dot(sv2.psi.flatten().conj())), 1)
+
+    def test_measurement_into_each_XYZ_basis(self):
+        for state in States.vec:
+            m_op = np.outer(state, state.T.conjugate())
+            n = 3
+            k = 0
+            sv = Statevec(nqubit=n)
+            sv.evolve(m_op, [k])
+            sv.truncate_one_qubit(k)
+
+            sv2 = Statevec(nqubit=n - 1)
+            np.testing.assert_almost_equal(np.abs(sv.psi.flatten().dot(sv2.psi.flatten().conj())), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_statevec_truncate_one_qubit.py
+++ b/tests/test_statevec_truncate_one_qubit.py
@@ -34,10 +34,10 @@ class StatevecTruncateOneQubitTest(unittest.TestCase):
         np.testing.assert_almost_equal(np.abs(sv.psi.flatten().dot(sv2.psi.flatten().conj())), 1)
 
     def test_measurement_into_each_XYZ_basis(self):
+        n = 3
+        k = 0
         for state in States.vec:
             m_op = np.outer(state, state.T.conjugate())
-            n = 3
-            k = 0
             sv = Statevec(nqubit=n)
             sv.evolve(m_op, [k])
             sv.truncate_one_qubit(k)
@@ -56,7 +56,7 @@ class StatevecTruncateOneQubitTest(unittest.TestCase):
         pattern.shift_signals()
         pattern.perform_pauli_measurements()
         sv_mbqc = pattern.simulate_pattern()
-        np.testing.assert_almost_equal(np.abs(np.dot(sv_mbqc.psi.flatten().conjugate(), state.flatten())), 1)
+        np.testing.assert_almost_equal(np.abs(sv_mbqc.psi.flatten().dot(state.flatten().conj())), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_statevec_truncate_one_qubit.py
+++ b/tests/test_statevec_truncate_one_qubit.py
@@ -3,6 +3,7 @@ import time
 import unittest
 from graphix.ops import States
 from graphix.sim.statevec import Statevec, meas_op
+import tests.random_circuit as rc
 
 
 class StatevecTruncateOneQubitTest(unittest.TestCase):
@@ -43,6 +44,19 @@ class StatevecTruncateOneQubitTest(unittest.TestCase):
 
             sv2 = Statevec(nqubit=n - 1)
             np.testing.assert_almost_equal(np.abs(sv.psi.flatten().dot(sv2.psi.flatten().conj())), 1)
+
+    def test_with_rand_circuit_sim(self):
+        n = 3
+        depth = 3
+        circuit = rc.get_rand_circuit(n, depth)
+        state = circuit.simulate_statevector()
+
+        pattern = circuit.transpile()
+        pattern.standardize()
+        pattern.shift_signals()
+        pattern.perform_pauli_measurements()
+        sv_mbqc = pattern.simulate_pattern()
+        np.testing.assert_almost_equal(np.abs(np.dot(sv_mbqc.psi.flatten().conjugate(), state.flatten())), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_statevec_truncate_one_qubit.py
+++ b/tests/test_statevec_truncate_one_qubit.py
@@ -1,0 +1,36 @@
+import numpy as np
+import time
+import unittest
+from graphix.sim.statevec import Statevec, meas_op
+
+
+class StatevecTruncateOneQubitTest(unittest.TestCase):
+    def test_atodekesu(self):
+        n = 10
+        k = 3
+
+        sv = Statevec(nqubit=n)
+        start = time.time()
+        for i in range(n):
+            sv.entangle([i, (i + 1) % n])
+        m_op = meas_op(np.pi / 5)
+        sv.evolve(m_op, [k])
+        sv.ptrace([k])
+        sv.normalize()
+        end = time.time()
+        print("time (ptrace): ", end - start)
+
+        sv2 = Statevec(nqubit=n)
+        start = time.time()
+        for i in range(n):
+            sv2.entangle([i, (i + 1) % n])
+        sv2.evolve(m_op, [k])
+        sv2.truncate_one_qubit(k)
+        end = time.time()
+        print("time (new method): ", end - start)
+
+        np.testing.assert_almost_equal(np.abs(sv.psi.flatten().dot(sv2.psi.flatten().conj())), 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Before submitting, please check the following:
- Make sure you have tests for the new code and that test passes (run `pytest`)
- format added code and tests by `black -l 120 <filename>`
- If applicable, add a line to the [unreleased] part of CHANGELOG.md, following [keep-a-changelog](https://keepachangelog.com/en/1.0.0/).
 
Then, please fill in below:

**Context (if applicable):**
`ptrace` method was implemented by using density matrix. But for separable states (states that measured), using DM is unnecessary. 

**Description of the change:**

 - Add `truncate_one_qubit` method to `Statevec`. 
 
directly truncate the specified qubit.

**Related issue:**
#73 

also see that checks (github actions) pass.
If lint check keeps failing, try installing black==22.8.0 as behavior seems to vary across versions.



