### PR TITLE
fix typo in add_nodes

### DIFF
--- a/graphix/sim/statevec.py
+++ b/graphix/sim/statevec.py
@@ -56,7 +56,7 @@ class StatevectorBackend:
         sv_to_add = Statevec(nqubit=n)
         self.state.tensor(sv_to_add)
         self.node_index.extend(nodes)
-        self.Nqubit += 1
+        self.Nqubit += n
         if self.Nqubit == self.max_qubit_num:
             self.trace_out()
 


### PR DESCRIPTION
Before submitting, please check the following:
- Make sure you have tests for the new code and that test passes (run `pytest`)
- format added code and tests by `black -l 120 <filename>`
- If applicable, add a line to the [unreleased] part of CHANGELOG.md, following [keep-a-changelog](https://keepachangelog.com/en/1.0.0/).
 
Then, please fill in below:

**Context (if applicable):**


**Description of the change:**
-  `self.Nqubit += 1` is incorrect. Fixed it into `self.Nqubit += n`.

**Related issue:**


also see that checks (github actions) pass.
If lint check keeps failing, try installing black==22.8.0 as behavior seems to vary across versions.



