### PR TITLE
Support extraction of clusters from graph state

### DIFF
--- a/docs/source/device_interface.rst
+++ b/docs/source/device_interface.rst
@@ -2,7 +2,7 @@ Device Interface
 ==================
 
 :mod:`graphix.device_interface` module
-+++++++++++++++++++++++++++++++++++
+++++++++++++++++++++++++++++++++++++++
 
 .. currentmodule:: graphix.device_interface
 
@@ -14,4 +14,3 @@ Device Interface
 
     .. automethod:: retrieve_result
 
-    .. automethod:: format_result

--- a/docs/source/extraction.rst
+++ b/docs/source/extraction.rst
@@ -1,0 +1,18 @@
+Graph state generation
+======================
+
+:mod:`graphix.extraction` module
+++++++++++++++++++++++++++++++++
+
+This provides functions to extract clusters from a given the graph state.
+
+.. currentmodule:: graphix.extraction
+
+.. autoclass:: Cluster
+    :members:
+
+.. autofunction:: extract_clusters_from_graph
+
+.. autofunction:: create_cluster
+
+.. autofunction:: get_fusion_nodes

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -8,6 +8,7 @@ Module reference
     modifier
     simulator
     graphsim
+    extraction
     flow
     clifford
     device_interface

--- a/examples/extraction.py
+++ b/examples/extraction.py
@@ -1,0 +1,42 @@
+"""
+Extract clusters from :class:`~graphix.GraphState`.
+=======================================================
+
+In this example, we extract GHZ clusters and linear clusters from :class:`~graphix.GraphState`.
+The extraction algorithm is based on [1].
+
+[1] Zilk et al., A compiler for universal photonic quantum computers, 2022 `arXiv:2210.09251 <https://arxiv.org/abs/2210.09251>`_
+
+"""
+
+import itertools
+import graphix
+from graphix.extraction import extract_clusters_from_graph
+
+# %%
+# Here we create a graph state with 9 nodes and 12 edges.
+gs = graphix.GraphState()
+nodes = [0, 1, 2, 3, 4, 5, 6, 7, 8]
+edges = [(0, 1), (1, 2), (2, 3), (3, 0), (3, 4), (0, 5), (4, 5), (5, 6), (6, 7), (7, 0), (7, 8), (8, 1)]
+gs.add_nodes_from(nodes)
+gs.add_edges_from(edges)
+gs.draw()
+
+# %%
+# Extracted GHZ clusters and linear clusters from the graph state are shown below.
+extract_clusters_from_graph(gs)
+
+# %%
+# If you want to know what nodes are fused in each clusters, you can use :func:`~graphix.extraction.get_fusion_nodes` function.
+# Currently, we consider only type-I fusion. See [2] for the definition of fusion.
+#
+# [2] Daniel E. Browne and Terry Rudolph. Resource-efficient linear optical quantum computation. Physical Review Letters, 95(1):010501, 2005.
+clusters = extract_clusters_from_graph(gs)
+for idx1, idx2 in itertools.combinations(range(len(clusters)), 2):
+    print(
+        f"fusion nodes between cluster {idx1} and cluster {idx2}: {graphix.extraction.get_fusion_nodes(clusters[idx1], clusters[idx2])}"
+    )
+
+# %%
+# You can also specify the maximum size of GHZ clusters and linear clusters.
+extract_clusters_from_graph(gs, max_ghz=4, max_lin=4)

--- a/examples/qft.py
+++ b/examples/qft.py
@@ -1,4 +1,6 @@
 """
+.. _gallery:qft:
+
 Minimizing the pattern space
 ============================
 
@@ -11,7 +13,7 @@ for any quantum algorithms running on MBQC.
 We will demonstrate this by simulating QFT on three qubits.
 First, import relevant modules and define additional gates we'll use:
 """
-#%%
+# %%
 import numpy as np
 from graphix import Circuit
 import networkx as nx
@@ -34,7 +36,7 @@ def swap(circuit, a, b):
     circuit.cnot(a, b)
 
 
-#%%
+# %%
 # Now let us define a circuit to apply QFT to three-qubit |011> state (input=6).
 
 
@@ -66,7 +68,7 @@ nx.draw(g)
 plt.show()
 print(len(nodes))
 
-#%%
+# %%
 # This is a graph with 49 qubits, whose statevector is very hard to simulate in ordinary computers.
 # As such, instead of preparing the graph state at the start of the compuation, we opt to prepare
 # qubits as late as possible, so that (destructive) measurements will reduce the burden while we wait.
@@ -78,14 +80,14 @@ pattern.shift_signals()
 pattern.print_pattern(lim=20)
 print(pattern.max_space())
 
-#%%
+# %%
 # now compare with below:
 
 pattern.minimize_space()
 pattern.print_pattern(lim=20)
 print(pattern.max_space())
 
-#%%
+# %%
 # The maximum space has gone down to 4 which should be very easily simulated on laptops.
 # Let us check the answer is correct, by comparing with statevector simulation.
 
@@ -93,7 +95,7 @@ out_state = pattern.simulate_pattern()
 state = circuit.simulate_statevector()
 print("overlap of states: ", np.abs(np.dot(state.psi.flatten().conjugate(), out_state.psi.flatten())))
 
-#%%
+# %%
 # Finally, check the output state:
 st_expected = [np.exp(2 * np.pi * 1j * 3 * i / 8) / np.sqrt(8) for i in range(8)]
 out_stv = out_state.flatten()

--- a/graphix/extraction.py
+++ b/graphix/extraction.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+from enum import Enum
+
+import graphix
+import numpy as np
+import networkx as nx
+
+
+class ClusterType(Enum):
+    GHZ = "GHZ"
+    LINEAR = "LINEAR"
+    NONE = "99"
+
+    def __str__(self):
+        return self.name
+
+
+class Cluster:
+    def __init__(self, type: ClusterType, graph: graphix.GraphState = None):
+        self.graph = graph
+        self.type = type
+
+    def __str__(self):
+        return str(self.type) + str(self.graph.nodes)
+
+    def __repr__(self):
+        return str(self.type) + str(self.graph.nodes)
+
+    def __eq__(self, other):
+        if not isinstance(other, Cluster):
+            raise TypeError("cannot compare Cluster with non-Cluster object")
+
+        return nx.utils.graphs_equal(self.graph, other.graph) and self.type == other.type
+
+
+def extract_clusters_from_graph(
+    graph: graphix.GraphState,
+    max_ghz: int | float = np.inf,
+    max_lin: int | float = np.inf,
+) -> list[Cluster]:
+    """Extract GHZ clusters and Linear clusters circuit from MBQC pattern.
+
+    Parameters
+    ----------
+    graph : :class:`graphix.GraphState` object
+        Graph state corresponding to the pattern.
+    phasedict : dict
+        Dictionary of phases for each node.
+    max_ghz:
+        Maximum size of ghz clusters
+    max_lin:
+        Maximum size of linear clusters
+    """
+    adjdict = nx.to_dict_of_dicts(graph)
+    number_of_edges = graph.number_of_edges()
+    cluster_list = []
+    neighbors_list = []
+
+    # Prepare a list sorted by number of neighbors to get the largest GHZ clusters first.
+    for v in adjdict.keys():
+        if len(adjdict[v]) > 2:
+            neighbors_list.append((v, len(adjdict[v])))
+
+    # Find GHZ clusters in the graph and remove their edges from the graph.
+    # All nodes that have more than 2 edges become the roots of the GHZ clusters.
+    for v, _ in sorted(neighbors_list, key=lambda tup: tup[1], reverse=True):
+        if len(adjdict[v]) > 2:
+            nodes = [v]
+            while len(adjdict[v]) > 0 and len(nodes) < max_ghz:
+                n, _ = adjdict[v].popitem()
+                nodes.append(n)
+                del adjdict[n][v]
+                number_of_edges -= 1
+            cluster_list.append(create_cluster(nodes, root=v))
+
+    # Find Linear clusters in the remaining graph and remove their edges from the graph.
+    while number_of_edges != 0:
+        for v in adjdict.keys():
+            if len(adjdict[v]) == 1:
+                n = v
+                nodes = [n]
+                while len(adjdict[n]) > 0 and len(nodes) < max_lin:
+                    n2, _ = adjdict[n].popitem()
+                    nodes.append(n2)
+                    del adjdict[n2][n]
+                    number_of_edges -= 1
+                    n = n2
+
+                # We define any cluster whose size is smaller than 4, a GHZ cluster
+                if len(nodes) == 3:
+                    cluster_list.append(create_cluster([nodes[1], nodes[0], nodes[2]], root=nodes[1]))
+                elif len(nodes) == 2:
+                    cluster_list.append(create_cluster(nodes, root=nodes[0]))
+                else:
+                    cluster_list.append(create_cluster(nodes))
+
+        # If a cycle exists in the graph, extract one 3-qubit ghz cluster from the cycle.
+        for v in adjdict.keys():
+            if len(adjdict[v]) == 2:
+                neighbors = list(adjdict[v].keys())
+                nodes = [v] + neighbors
+                del adjdict[neighbors[0]][v]
+                del adjdict[neighbors[1]][v]
+                del adjdict[v][neighbors[0]]
+                del adjdict[v][neighbors[1]]
+                number_of_edges -= 2
+
+                cluster_list.append(create_cluster(nodes, root=v))
+                break
+    return cluster_list
+
+
+def create_cluster(node_ids: list[int], root: int | None = None) -> Cluster:
+    """Create a cluster from node ids.
+
+    Parameters
+    ----------
+    node_ids : list
+        List of node ids.
+    root : int
+        Root of the ghz cluster. If None, it's a linear cluster.
+    """
+    cluster_type = None
+    edges = []
+    if root is not None:
+        edges = [(root, i) for i in node_ids if i != root]
+        cluster_type = ClusterType.GHZ
+    else:
+        edges = [(node_ids[i], node_ids[i + 1]) for i in range(len(node_ids)) if i + 1 < len(node_ids)]
+        cluster_type = ClusterType.LINEAR
+    tmp_graph = graphix.GraphState()
+    tmp_graph.add_nodes_from(node_ids)
+    tmp_graph.add_edges_from(edges)
+    return Cluster(type=cluster_type, graph=tmp_graph)
+
+
+def get_fusion_nodes(c1: Cluster, c2: Cluster):
+    """Get the nodes that are fused between two clusters.
+
+    Parameters
+    ----------
+    c1 : :class:`Cluster` object
+        First cluster.
+    c2 : :class:`Cluster` object
+        Second cluster.
+
+    Returns
+    -------
+    list
+        List of nodes that are fused between the two clusters.
+    """
+    if not isinstance(c1, Cluster) or not isinstance(c2, Cluster):
+        raise TypeError("c1 and c2 must be Cluster objects")
+
+    if c1 == c2:
+        return []
+    return [n for n in c1.graph.nodes if n in c2.graph.nodes]

--- a/graphix/extraction.py
+++ b/graphix/extraction.py
@@ -49,6 +49,7 @@ def extract_clusters_from_graph(
     max_lin: int | float = np.inf,
 ) -> list[Cluster]:
     """Extract GHZ clusters and Linear clusters circuit from :class:`graphix.GraphState`.
+    Extraction algorithm is based on https://arxiv.org/abs/2210.09251.
 
     Parameters
     ----------

--- a/graphix/extraction.py
+++ b/graphix/extraction.py
@@ -49,7 +49,9 @@ def extract_clusters_from_graph(
     max_lin: int | float = np.inf,
 ) -> list[Cluster]:
     """Extract GHZ clusters and Linear clusters circuit from :class:`graphix.GraphState`.
-    Extraction algorithm is based on https://arxiv.org/abs/2210.09251.
+    Extraction algorithm is based on [1].
+
+    [1] Zilk et al., A compiler for universal photonic quantum computers, 2022 `arXiv:2210.09251 <https://arxiv.org/abs/2210.09251>`_
 
     Parameters
     ----------

--- a/graphix/extraction.py
+++ b/graphix/extraction.py
@@ -48,7 +48,7 @@ def extract_clusters_from_graph(
     max_ghz: int | float = np.inf,
     max_lin: int | float = np.inf,
 ) -> list[Cluster]:
-    """Extract GHZ clusters and Linear clusters circuit from :class:`graphix.GraphState`.
+    """Extract GHZ clusters and linear clusters circuit from :class:`graphix.GraphState`.
     Extraction algorithm is based on [1].
 
     [1] Zilk et al., A compiler for universal photonic quantum computers, 2022 `arXiv:2210.09251 <https://arxiv.org/abs/2210.09251>`_

--- a/graphix/extraction.py
+++ b/graphix/extraction.py
@@ -11,7 +11,7 @@ class ClusterType(Enum):
     LINEAR = "LINEAR"
     NONE = "99"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
 
@@ -30,13 +30,13 @@ class Cluster:
         self.graph = graph
         self.type = type
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.type) + str(self.graph.nodes)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(self.type) + str(self.graph.nodes)
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if not isinstance(other, Cluster):
             raise TypeError("cannot compare Cluster with non-Cluster object")
 
@@ -154,7 +154,7 @@ def create_cluster(node_ids: list[int], root: int | None = None) -> Cluster:
     return Cluster(type=cluster_type, graph=tmp_graph)
 
 
-def get_fusion_nodes(c1: Cluster, c2: Cluster):
+def get_fusion_nodes(c1: Cluster, c2: Cluster) -> list[int]:
     """Get the nodes that are fused between two clusters.
 
     Parameters

--- a/graphix/extraction.py
+++ b/graphix/extraction.py
@@ -16,6 +16,16 @@ class ClusterType(Enum):
 
 
 class Cluster:
+    """Cluster object.
+
+    Parameters
+    ----------
+    type : :class:`ClusterType` object
+        Type of the cluster.
+    graph : :class:`graphix.GraphState` object
+        Graph state of the cluster.
+    """
+
     def __init__(self, type: ClusterType, graph: graphix.GraphState = None):
         self.graph = graph
         self.type = type
@@ -50,6 +60,11 @@ def extract_clusters_from_graph(
         Maximum size of ghz clusters
     max_lin:
         Maximum size of linear clusters
+
+    Returns
+    -------
+    list
+        List of :class:`Cluster` objects.
     """
     adjdict = nx.to_dict_of_dicts(graph)
     number_of_edges = graph.number_of_edges()
@@ -119,6 +134,11 @@ def create_cluster(node_ids: list[int], root: int | None = None) -> Cluster:
         List of node ids.
     root : int
         Root of the ghz cluster. If None, it's a linear cluster.
+
+    Returns
+    -------
+    :class:`Cluster` object
+        Cluster object.
     """
     cluster_type = None
     edges = []

--- a/graphix/extraction.py
+++ b/graphix/extraction.py
@@ -161,7 +161,10 @@ def create_cluster(node_ids: list[int], root: int | None = None) -> Cluster:
 
 
 def get_fusion_nodes(c1: Cluster, c2: Cluster) -> list[int]:
-    """Get the nodes that are fused between two clusters.
+    """Get the nodes that are fused between two clusters. Currently, we consider only type-I fusion.
+    See [2] for the definition of fusion.
+
+    [2] Daniel E. Browne and Terry Rudolph. Resource-efficient linear optical quantum computation. Physical Review Letters, 95(1):010501, 2005.
 
     Parameters
     ----------

--- a/graphix/extraction.py
+++ b/graphix/extraction.py
@@ -9,9 +9,9 @@ import networkx as nx
 class ClusterType(Enum):
     GHZ = "GHZ"
     LINEAR = "LINEAR"
-    NONE = "99"
+    NONE = None
 
-    def __str__(self) -> str:
+    def __str__(self):
         return self.name
 
 
@@ -78,6 +78,9 @@ def extract_clusters_from_graph(
     for v in adjdict.keys():
         if len(adjdict[v]) > 2:
             neighbors_list.append((v, len(adjdict[v])))
+        # If there is an isolated node, add it to the list.
+        if len(adjdict[v]) == 0:
+            cluster_list.append(create_cluster([v], root=v))
 
     # Find GHZ clusters in the graph and remove their edges from the graph.
     # All nodes that have more than 2 edges become the roots of the GHZ clusters.

--- a/graphix/extraction.py
+++ b/graphix/extraction.py
@@ -38,12 +38,12 @@ def extract_clusters_from_graph(
     max_ghz: int | float = np.inf,
     max_lin: int | float = np.inf,
 ) -> list[Cluster]:
-    """Extract GHZ clusters and Linear clusters circuit from MBQC pattern.
+    """Extract GHZ clusters and Linear clusters circuit from :class:`graphix.GraphState`.
 
     Parameters
     ----------
     graph : :class:`graphix.GraphState` object
-        Graph state corresponding to the pattern.
+        Graph state.
     phasedict : dict
         Dictionary of phases for each node.
     max_ghz:

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -16,7 +16,7 @@ class TestExtraction(unittest.TestCase):
         self.assertEqual(len(clusters), 1)
         self.assertEqual(clusters[0] == Cluster(type=ClusterType.GHZ, graph=gs), True)
 
-    # we consider everything smaller than 4, a GHZ
+    # We define any cluster whose size is smaller than 4, a GHZ cluster
     def test_cluster_extraction_small_ghz_cluster_1(self):
         gs = graphix.GraphState()
         nodes = [0, 1, 2]
@@ -28,7 +28,7 @@ class TestExtraction(unittest.TestCase):
         self.assertEqual(len(clusters), 1)
         self.assertEqual(clusters[0] == Cluster(type=ClusterType.GHZ, graph=gs), True)
 
-    # we consider everything smaller than 4, a GHZ
+    # We define any cluster whose size is smaller than 4, a GHZ cluster
     def test_cluster_extraction_small_ghz_cluster_2(self):
         gs = graphix.GraphState()
         nodes = [0, 1]

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -1,7 +1,7 @@
 import unittest
 
 import graphix
-from graphix.extraction import Cluster, ClusterType, extract_clusters_from_graph
+from graphix import extraction
 
 
 class TestExtraction(unittest.TestCase):
@@ -11,34 +11,34 @@ class TestExtraction(unittest.TestCase):
         edges = [(0, 1), (0, 2), (0, 3), (0, 4)]
         gs.add_nodes_from(nodes)
         gs.add_edges_from(edges)
-        clusters = extract_clusters_from_graph(gs)
+        clusters = extraction.extract_clusters_from_graph(gs)
 
         self.assertEqual(len(clusters), 1)
-        self.assertEqual(clusters[0] == Cluster(type=ClusterType.GHZ, graph=gs), True)
+        self.assertEqual(clusters[0] == extraction.Cluster(type=extraction.ClusterType.GHZ, graph=gs), True)
 
-    # We define any cluster whose size is smaller than 4, a GHZ cluster
+    # we consider everything smaller than 4, a GHZ
     def test_cluster_extraction_small_ghz_cluster_1(self):
         gs = graphix.GraphState()
         nodes = [0, 1, 2]
         edges = [(0, 1), (1, 2)]
         gs.add_nodes_from(nodes)
         gs.add_edges_from(edges)
-        clusters = extract_clusters_from_graph(gs)
+        clusters = extraction.extract_clusters_from_graph(gs)
 
         self.assertEqual(len(clusters), 1)
-        self.assertEqual(clusters[0] == Cluster(type=ClusterType.GHZ, graph=gs), True)
+        self.assertEqual(clusters[0] == extraction.Cluster(type=extraction.ClusterType.GHZ, graph=gs), True)
 
-    # We define any cluster whose size is smaller than 4, a GHZ cluster
+    # we consider everything smaller than 4, a GHZ
     def test_cluster_extraction_small_ghz_cluster_2(self):
         gs = graphix.GraphState()
         nodes = [0, 1]
         edges = [(0, 1)]
         gs.add_nodes_from(nodes)
         gs.add_edges_from(edges)
-        clusters = extract_clusters_from_graph(gs)
+        clusters = extraction.extract_clusters_from_graph(gs)
 
         self.assertEqual(len(clusters), 1)
-        self.assertEqual(clusters[0] == Cluster(type=ClusterType.GHZ, graph=gs), True)
+        self.assertEqual(clusters[0] == extraction.Cluster(type=extraction.ClusterType.GHZ, graph=gs), True)
 
     def test_cluster_extraction_one_linear_cluster(self):
         gs = graphix.GraphState()
@@ -46,10 +46,10 @@ class TestExtraction(unittest.TestCase):
         edges = [(0, 1), (1, 2), (2, 3), (5, 4), (4, 6), (6, 0)]
         gs.add_nodes_from(nodes)
         gs.add_edges_from(edges)
-        clusters = extract_clusters_from_graph(gs)
+        clusters = extraction.extract_clusters_from_graph(gs)
 
         self.assertEqual(len(clusters), 1)
-        self.assertEqual(clusters[0] == Cluster(type=ClusterType.LINEAR, graph=gs), True)
+        self.assertEqual(clusters[0] == extraction.Cluster(type=extraction.ClusterType.LINEAR, graph=gs), True)
 
     def test_cluster_extraction_one_ghz_one_linear(self):
         gs = graphix.GraphState()
@@ -57,18 +57,18 @@ class TestExtraction(unittest.TestCase):
         edges = [(0, 1), (0, 2), (0, 3), (0, 4), (4, 5), (5, 6), (6, 7), (7, 8), (8, 9)]
         gs.add_nodes_from(nodes)
         gs.add_edges_from(edges)
-        clusters = extract_clusters_from_graph(gs)
+        clusters = extraction.extract_clusters_from_graph(gs)
         self.assertEqual(len(clusters), 2)
 
         clusters_expected = []
         lin_cluster = graphix.GraphState()
         lin_cluster.add_nodes_from([4, 5, 6, 7, 8, 9])
         lin_cluster.add_edges_from([(4, 5), (5, 6), (6, 7), (7, 8), (8, 9)])
-        clusters_expected.append(Cluster(ClusterType.LINEAR, lin_cluster))
+        clusters_expected.append(extraction.Cluster(extraction.ClusterType.LINEAR, lin_cluster))
         ghz_cluster = graphix.GraphState()
         ghz_cluster.add_nodes_from([0, 1, 2, 3, 4])
         ghz_cluster.add_edges_from([(0, 1), (0, 2), (0, 3), (0, 4)])
-        clusters_expected.append(Cluster(ClusterType.GHZ, ghz_cluster))
+        clusters_expected.append(extraction.Cluster(extraction.ClusterType.GHZ, ghz_cluster))
 
         self.assertEqual(
             (clusters[0] == clusters_expected[0] and clusters[1] == clusters_expected[1])
@@ -82,15 +82,33 @@ class TestExtraction(unittest.TestCase):
         edges = [(0, 1), (1, 2), (2, 3), (3, 4), (4, 0)]
         gs.add_nodes_from(nodes)
         gs.add_edges_from(edges)
-        clusters = extract_clusters_from_graph(gs)
+        clusters = extraction.extract_clusters_from_graph(gs)
         self.assertEqual(len(clusters), 2)
         self.assertEqual(
-            (clusters[0].type == ClusterType.GHZ and clusters[1].type == ClusterType.LINEAR)
-            or (clusters[0].type == ClusterType.LINEAR and clusters[1].type == ClusterType.GHZ),
+            (clusters[0].type == extraction.ClusterType.GHZ and clusters[1].type == extraction.ClusterType.LINEAR)
+            or (clusters[0].type == extraction.ClusterType.LINEAR and clusters[1].type == extraction.ClusterType.GHZ),
             True,
         )
         self.assertEqual(
             (len(clusters[0].graph.nodes) == 3 and len(clusters[1].graph.nodes) == 4)
             or (len(clusters[0].graph.nodes) == 4 and len(clusters[1].graph.nodes) == 3),
+            True,
+        )
+
+    def test_cluster_extraction_one_plus_two(self):
+        gs = graphix.GraphState()
+        nodes = [0, 1, 2]
+        edges = [(0, 1)]
+        gs.add_nodes_from(nodes)
+        gs.add_edges_from(edges)
+        clusters = extraction.extract_clusters_from_graph(gs)
+        self.assertEqual(len(clusters), 2)
+        self.assertEqual(
+            (clusters[0].type == extraction.ClusterType.GHZ and clusters[1].type == extraction.ClusterType.GHZ),
+            True,
+        )
+        self.assertEqual(
+            (len(clusters[0].graph.nodes) == 2 and len(clusters[1].graph.nodes) == 1)
+            or (len(clusters[0].graph.nodes) == 1 and len(clusters[1].graph.nodes) == 2),
             True,
         )

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -1,9 +1,7 @@
 import unittest
 
-import numpy as np
-import networkx as nx
 import graphix
-from graphix_perceval import extraction
+from graphix.extraction import Cluster, ClusterType, extract_clusters_from_graph
 
 
 class TestExtraction(unittest.TestCase):
@@ -13,10 +11,10 @@ class TestExtraction(unittest.TestCase):
         edges = [(0, 1), (0, 2), (0, 3), (0, 4)]
         gs.add_nodes_from(nodes)
         gs.add_edges_from(edges)
-        clusters = extraction.extract_clusters_from_graph(gs)
+        clusters = extract_clusters_from_graph(gs)
 
         self.assertEqual(len(clusters), 1)
-        self.assertEqual(clusters[0] == extraction.Cluster(type=extraction.ClusterType.GHZ, graph=gs), True)
+        self.assertEqual(clusters[0] == Cluster(type=ClusterType.GHZ, graph=gs), True)
 
     # we consider everything smaller than 4, a GHZ
     def test_cluster_extraction_small_ghz_cluster_1(self):
@@ -25,10 +23,10 @@ class TestExtraction(unittest.TestCase):
         edges = [(0, 1), (1, 2)]
         gs.add_nodes_from(nodes)
         gs.add_edges_from(edges)
-        clusters = extraction.extract_clusters_from_graph(gs)
+        clusters = extract_clusters_from_graph(gs)
 
         self.assertEqual(len(clusters), 1)
-        self.assertEqual(clusters[0] == extraction.Cluster(type=extraction.ClusterType.GHZ, graph=gs), True)
+        self.assertEqual(clusters[0] == Cluster(type=ClusterType.GHZ, graph=gs), True)
 
     # we consider everything smaller than 4, a GHZ
     def test_cluster_extraction_small_ghz_cluster_2(self):
@@ -37,10 +35,10 @@ class TestExtraction(unittest.TestCase):
         edges = [(0, 1)]
         gs.add_nodes_from(nodes)
         gs.add_edges_from(edges)
-        clusters = extraction.extract_clusters_from_graph(gs)
+        clusters = extract_clusters_from_graph(gs)
 
         self.assertEqual(len(clusters), 1)
-        self.assertEqual(clusters[0] == extraction.Cluster(type=extraction.ClusterType.GHZ, graph=gs), True)
+        self.assertEqual(clusters[0] == Cluster(type=ClusterType.GHZ, graph=gs), True)
 
     def test_cluster_extraction_one_linear_cluster(self):
         gs = graphix.GraphState()
@@ -48,10 +46,10 @@ class TestExtraction(unittest.TestCase):
         edges = [(0, 1), (1, 2), (2, 3), (5, 4), (4, 6), (6, 0)]
         gs.add_nodes_from(nodes)
         gs.add_edges_from(edges)
-        clusters = extraction.extract_clusters_from_graph(gs)
+        clusters = extract_clusters_from_graph(gs)
 
         self.assertEqual(len(clusters), 1)
-        self.assertEqual(clusters[0] == extraction.Cluster(type=extraction.ClusterType.LINEAR, graph=gs), True)
+        self.assertEqual(clusters[0] == Cluster(type=ClusterType.LINEAR, graph=gs), True)
 
     def test_cluster_extraction_one_ghz_one_linear(self):
         gs = graphix.GraphState()
@@ -59,18 +57,18 @@ class TestExtraction(unittest.TestCase):
         edges = [(0, 1), (0, 2), (0, 3), (0, 4), (4, 5), (5, 6), (6, 7), (7, 8), (8, 9)]
         gs.add_nodes_from(nodes)
         gs.add_edges_from(edges)
-        clusters = extraction.extract_clusters_from_graph(gs)
+        clusters = extract_clusters_from_graph(gs)
         self.assertEqual(len(clusters), 2)
 
         clusters_expected = []
         lin_cluster = graphix.GraphState()
         lin_cluster.add_nodes_from([4, 5, 6, 7, 8, 9])
         lin_cluster.add_edges_from([(4, 5), (5, 6), (6, 7), (7, 8), (8, 9)])
-        clusters_expected.append(extraction.Cluster(extraction.ClusterType.LINEAR, lin_cluster))
+        clusters_expected.append(Cluster(ClusterType.LINEAR, lin_cluster))
         ghz_cluster = graphix.GraphState()
         ghz_cluster.add_nodes_from([0, 1, 2, 3, 4])
         ghz_cluster.add_edges_from([(0, 1), (0, 2), (0, 3), (0, 4)])
-        clusters_expected.append(extraction.Cluster(extraction.ClusterType.GHZ, ghz_cluster))
+        clusters_expected.append(Cluster(ClusterType.GHZ, ghz_cluster))
 
         self.assertEqual(
             (clusters[0] == clusters_expected[0] and clusters[1] == clusters_expected[1])
@@ -84,11 +82,11 @@ class TestExtraction(unittest.TestCase):
         edges = [(0, 1), (1, 2), (2, 3), (3, 4), (4, 0)]
         gs.add_nodes_from(nodes)
         gs.add_edges_from(edges)
-        clusters = extraction.extract_clusters_from_graph(gs)
+        clusters = extract_clusters_from_graph(gs)
         self.assertEqual(len(clusters), 2)
         self.assertEqual(
-            (clusters[0].type == extraction.ClusterType.GHZ and clusters[1].type == extraction.ClusterType.LINEAR)
-            or (clusters[0].type == extraction.ClusterType.LINEAR and clusters[1].type == extraction.ClusterType.GHZ),
+            (clusters[0].type == ClusterType.GHZ and clusters[1].type == ClusterType.LINEAR)
+            or (clusters[0].type == ClusterType.LINEAR and clusters[1].type == ClusterType.GHZ),
             True,
         )
         self.assertEqual(

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -1,0 +1,98 @@
+import unittest
+
+import numpy as np
+import networkx as nx
+import graphix
+from graphix_perceval import extraction
+
+
+class TestExtraction(unittest.TestCase):
+    def test_cluster_extraction_one_ghz_cluster(self):
+        gs = graphix.GraphState()
+        nodes = [0, 1, 2, 3, 4]
+        edges = [(0, 1), (0, 2), (0, 3), (0, 4)]
+        gs.add_nodes_from(nodes)
+        gs.add_edges_from(edges)
+        clusters = extraction.extract_clusters_from_graph(gs)
+
+        self.assertEqual(len(clusters), 1)
+        self.assertEqual(clusters[0] == extraction.Cluster(type=extraction.ClusterType.GHZ, graph=gs), True)
+
+    # we consider everything smaller than 4, a GHZ
+    def test_cluster_extraction_small_ghz_cluster_1(self):
+        gs = graphix.GraphState()
+        nodes = [0, 1, 2]
+        edges = [(0, 1), (1, 2)]
+        gs.add_nodes_from(nodes)
+        gs.add_edges_from(edges)
+        clusters = extraction.extract_clusters_from_graph(gs)
+
+        self.assertEqual(len(clusters), 1)
+        self.assertEqual(clusters[0] == extraction.Cluster(type=extraction.ClusterType.GHZ, graph=gs), True)
+
+    # we consider everything smaller than 4, a GHZ
+    def test_cluster_extraction_small_ghz_cluster_2(self):
+        gs = graphix.GraphState()
+        nodes = [0, 1]
+        edges = [(0, 1)]
+        gs.add_nodes_from(nodes)
+        gs.add_edges_from(edges)
+        clusters = extraction.extract_clusters_from_graph(gs)
+
+        self.assertEqual(len(clusters), 1)
+        self.assertEqual(clusters[0] == extraction.Cluster(type=extraction.ClusterType.GHZ, graph=gs), True)
+
+    def test_cluster_extraction_one_linear_cluster(self):
+        gs = graphix.GraphState()
+        nodes = [0, 1, 2, 3, 4, 5, 6]
+        edges = [(0, 1), (1, 2), (2, 3), (5, 4), (4, 6), (6, 0)]
+        gs.add_nodes_from(nodes)
+        gs.add_edges_from(edges)
+        clusters = extraction.extract_clusters_from_graph(gs)
+
+        self.assertEqual(len(clusters), 1)
+        self.assertEqual(clusters[0] == extraction.Cluster(type=extraction.ClusterType.LINEAR, graph=gs), True)
+
+    def test_cluster_extraction_one_ghz_one_linear(self):
+        gs = graphix.GraphState()
+        nodes = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        edges = [(0, 1), (0, 2), (0, 3), (0, 4), (4, 5), (5, 6), (6, 7), (7, 8), (8, 9)]
+        gs.add_nodes_from(nodes)
+        gs.add_edges_from(edges)
+        clusters = extraction.extract_clusters_from_graph(gs)
+        self.assertEqual(len(clusters), 2)
+
+        clusters_expected = []
+        lin_cluster = graphix.GraphState()
+        lin_cluster.add_nodes_from([4, 5, 6, 7, 8, 9])
+        lin_cluster.add_edges_from([(4, 5), (5, 6), (6, 7), (7, 8), (8, 9)])
+        clusters_expected.append(extraction.Cluster(extraction.ClusterType.LINEAR, lin_cluster))
+        ghz_cluster = graphix.GraphState()
+        ghz_cluster.add_nodes_from([0, 1, 2, 3, 4])
+        ghz_cluster.add_edges_from([(0, 1), (0, 2), (0, 3), (0, 4)])
+        clusters_expected.append(extraction.Cluster(extraction.ClusterType.GHZ, ghz_cluster))
+
+        self.assertEqual(
+            (clusters[0] == clusters_expected[0] and clusters[1] == clusters_expected[1])
+            or (clusters[0] == clusters_expected[1] and clusters[1] == clusters_expected[0]),
+            True,
+        )
+
+    def test_cluster_extraction_pentagonal_cluster(self):
+        gs = graphix.GraphState()
+        nodes = [0, 1, 2, 3, 4]
+        edges = [(0, 1), (1, 2), (2, 3), (3, 4), (4, 0)]
+        gs.add_nodes_from(nodes)
+        gs.add_edges_from(edges)
+        clusters = extraction.extract_clusters_from_graph(gs)
+        self.assertEqual(len(clusters), 2)
+        self.assertEqual(
+            (clusters[0].type == extraction.ClusterType.GHZ and clusters[1].type == extraction.ClusterType.LINEAR)
+            or (clusters[0].type == extraction.ClusterType.LINEAR and clusters[1].type == extraction.ClusterType.GHZ),
+            True,
+        )
+        self.assertEqual(
+            (len(clusters[0].graph.nodes) == 3 and len(clusters[1].graph.nodes) == 4)
+            or (len(clusters[0].graph.nodes) == 4 and len(clusters[1].graph.nodes) == 3),
+            True,
+        )


### PR DESCRIPTION
Before submitting, please check the following:
- Make sure you have tests for the new code and that test passes (run `tox`)
- format added code by `black -l 120 <filename>`
- If applicable, add a line to the [unreleased] part of CHANGELOG.md, following [keep-a-changelog](https://keepachangelog.com/en/1.0.0/).

Then, please fill in below:

**Context (if applicable):**
#86 

**Description of the change:**
- Add `Cluster` class to define extracted cluster.
- Add function `extract_clusters_from_graph` which will extract GHZ and linear clusters from `graphix.GraphState`.


**Related issue:**
Related to #86 

also see that checks (github actions) pass.
If lint check keeps failing, try installing black==22.8.0 as behavior seems to vary across versions.



