### PR TITLE
bugfix gflow visualization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   By setting the `use_rustworkx` option to True while using `Pattern.perform_pauli_measurements()`,
   graphix will run pattern optimization using `rustworkx` (#98)
 
+### Fixed
+
+- Fixed gflow-based graph visualization (#107)
+
 ## [0.2.9] - 2023-11-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ this will install `graphix` and inteface for [IBMQ](https://github.com/TeamGraph
 
 ## Using graphix
 
-### Generating pattern from a circuit and inspecting the resource graph with information flow (arrows)
+### generating pattern from a circuit
 ```python
 from graphix import Circuit
 circuit = Circuit(4)
@@ -42,20 +42,21 @@ pattern.draw_graph()
 ```
 <img src="https://github.com/TeamGraphix/graphix/assets/33350509/de17c663-f607-44e2-945b-835f4082a940" alt="logo" width="750">
 
-(QAOA circuit, see [this example](examples/qaoa.py))
+(QAOA circuit, see [this example](examples/qaoa.py). Arrows indicate the [information flow](https://journals.aps.org/pra/abstract/10.1103/PhysRevA.74.052310) of MBQC and dashed lines are other edges of the graph.)
 
-### Preprocessing Pauli measurements and visualizing the resulting graph with generalized flow
+### preprocessing Pauli measurements
 ```python
 pattern.perform_pauli_measurements(leave_input=False)
 pattern.draw_graph(show_loop=False)
 ```
-<img src="https://github.com/TeamGraphix/graphix/assets/33350509/0153b704-7697-4c50-96d1-31fb82bf9b4d" alt="logo" width="140">
+<img src="https://github.com/TeamGraphix/graphix/assets/33350509/3c30a4c9-f912-4a36-925f-2ff446a07c68" alt="logo" width="140">
 
-### Simulating the pattern
+(here, the graph has [*generalized flow*](https://iopscience.iop.org/article/10.1088/1367-2630/9/8/250).)
+
+### simulating the pattern
 ```python
 state_out = pattern.simulate_pattern(backend='statevec')
 ```
-
 
 ### and more.. 
 - See [demos](https://graphix.readthedocs.io/en/latest/gallery/index.html) showing other features of `Graphix`.

--- a/README.md
+++ b/README.md
@@ -59,12 +59,14 @@ state_out = pattern.simulate_pattern(backend='statevector')
 ```
 
 ### and more.. 
-- See [demos](https://graphix.readthedocs.io/en/latest/gallery/index.html) showing other features of `Graphix`.
-- Try demos on browser with mybinder.org: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/TeamGraphix/graphix-examples/HEAD)
+- See [demos](https://graphix.readthedocs.io/en/latest/gallery/index.html) showing other features of `graphix`.
+- You can try demos on browser with mybinder.org: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/TeamGraphix/graphix-examples/HEAD)
 
 - Read the [tutorial](https://graphix.readthedocs.io/en/latest/tutorial.html) for more usage guides.
 
 - For theoretical background, read our quick introduction into [MBQC](https://graphix.readthedocs.io/en/latest/intro.html) and [LC-MBQC](https://graphix.readthedocs.io/en/latest/lc-mbqc.html).
+
+- Full API docs is [here](https://graphix.readthedocs.io/en/latest/references.html).
 
 ## Citing
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,12 @@
 ![GitHub](https://img.shields.io/github/license/TeamGraphix/graphix)
 [![Downloads](https://static.pepy.tech/badge/graphix)](https://pepy.tech/project/graphix)
 
-**Graphix** is a measurement-based quantum computing (MBQC) compiler to generate, optimize and simulate MBQC *measurement patterns*.
-
-## Feature
-
-- We integrate an efficient [graph state simulator](https://graphix.readthedocs.io/en/latest/lc-mbqc.html) as an optimization routine of MBQC *measurement pattern*, with which we can classically [preprocess all Pauli measurements](https://graphix.readthedocs.io/en/latest/tutorial.html#performing-pauli-measurements) (corresponding to the elimination of all Clifford gates in the gate network - c.f. [Gottesman-Knill theorem](https://en.wikipedia.org/wiki/Gottesman–Knill_theorem) and more general pattern rewriting method based on [ZX diagram rewriting](https://arxiv.org/abs/2003.01664)), reducing the required size of graph state to run the computation.
-- We implement tensor-network simulation backend for MBQC with which thousands of qubits (graph nodes) can be simulated with modest computing resources (e.g. laptop), without approximation.
-- We are developing density matrix simulation backend for noisy MBQC simulations with customizable noise models.
+**Graphix** is a measurement-based quantum computing (MBQC) software package, featuring
+- the measurement calculus framework with integrated graphical rewrite rules for Pauli measurement preprocessing
+- circuit-to-pattern transpiler, graph-based deterministic pattern generator and manual pattern generation
+- flow- and gflow-based graph visualization tools
+- statevector and tensornetwork pattern simulation backends
+- QPU interface and fusion network extraction tool
 
 ## Installation
 Install `graphix` with `pip`:
@@ -29,19 +28,40 @@ $ pip install graphix[extra]
 ```
 this will install `graphix` and inteface for [IBMQ](https://github.com/TeamGraphix/graphix-ibmq) and [Perceval](https://github.com/TeamGraphix/graphix-perceval) to run MBQC patterns on superconducting and optical QPUs and their simulators.
 
-<!-- We are currently adding more quantum device interface.
-Please suggest in [issues](https://github.com/TeamGraphix/graphix/issues) if you have any particular device in mind! -->
+
+## Using graphix
+
+### Generating pattern from a circuit and inspecting the resource graph with information flow (arrows)
+```python
+from graphix import Circuit
+circuit = Circuit(4)
+circuit.h(0)
+...
+pattern = circuit.transpile()
+pattern.draw_graph()
+```
+<img src="https://github.com/TeamGraphix/graphix/assets/33350509/de17c663-f607-44e2-945b-835f4082a940" alt="logo" width="750">
+
+(QAOA circuit, see [this example](examples/qaoa.py))
+
+### Preprocessing Pauli measurements and visualizing the resulting graph with generalized flow
+```python
+pattern.perform_pauli_measurements(leave_input=False)
+pattern.draw_graph(show_loop=False)
+```
+<img src="https://github.com/TeamGraphix/graphix/assets/33350509/0153b704-7697-4c50-96d1-31fb82bf9b4d" alt="logo" width="140">
+
+### Simulating the pattern
+```python
+state_out = pattern.simulate_pattern(backend='statevec')
+```
 
 
-## Next Steps
+### and more.. 
+- See [demos](https://graphix.readthedocs.io/en/latest/gallery/index.html) showing other features of `Graphix`.
+- Try demos on browser with mybinder.org: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/TeamGraphix/graphix-examples/HEAD)
 
-- We have a few [demos](https://graphix.readthedocs.io/en/latest/gallery/index.html) showing basic usages of `Graphix`.
-- You can run demos on your browser:
-  - Preprocessing Clifford gates: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/TeamGraphix/graphix-examples/HEAD?labpath=deutsch-jozsa.ipynb)
-  - Using tensor-network simulator backend: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/TeamGraphix/graphix-examples/HEAD?labpath=qft_with_tn.ipynb)
-  - QAOA circuit: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/TeamGraphix/graphix-examples/HEAD?labpath=qaoa.ipynb)
-
-- Read the [tutorial](https://graphix.readthedocs.io/en/latest/tutorial.html) for more comprehensive guide.
+- Read the [tutorial](https://graphix.readthedocs.io/en/latest/tutorial.html) for more usage guides.
 
 - For theoretical background, read our quick introduction into [MBQC](https://graphix.readthedocs.io/en/latest/intro.html) and [LC-MBQC](https://graphix.readthedocs.io/en/latest/lc-mbqc.html).
 
@@ -52,7 +72,7 @@ Please suggest in [issues](https://github.com/TeamGraphix/graphix/issues) if you
 Update on the [arXiv paper](https://arxiv.org/pdf/2212.11975.pdf): [^1]
 
 [^1]: Following the release of this arXiv preprint, we were made aware of [Backens et al.](https://quantum-journal.org/papers/q-2021-03-25-421/) and related work, where graph-theoretic simplification (Pauli measurement elimination) of patterns were shown.
-Many thanks for letting us know about this work - at the time of the writing we were not aware of these important relevant works but will certainly properly mention in the new version; we are working on significant restructuring and rewriting of the paper and hope to update the paper this autumn.
+Many thanks for letting us know about this work - at the time of the writing we were not aware of these important relevant works but will certainly properly mention in the new version; we are working on significant restructuring and rewriting of the paper and hope to update the paper soon.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pattern.draw_graph()
 ```
 <img src="https://github.com/TeamGraphix/graphix/assets/33350509/de17c663-f607-44e2-945b-835f4082a940" alt="logo" width="750">
 
-(QAOA circuit, see [this example](examples/qaoa.py). Arrows indicate the [*information flow*](https://journals.aps.org/pra/abstract/10.1103/PhysRevA.74.052310) of MBQC and dashed lines are other edges of the graph.)
+<small>note: this graph is generated from QAOA circuit, see [our example code](examples/qaoa.py). Arrows indicate the [*information flow*](https://journals.aps.org/pra/abstract/10.1103/PhysRevA.74.052310) of MBQC and dashed lines are the other edges of the graph. the vertical dashed partitions and the labels 'l:n' below indicate the execution *layers* or the order in the graph (measurements should happen from left to right, and nodes in the same layer can be measured simultaneously), based on the partial order associated with the (maximally-delayed) flow. </small>
 
 ### preprocessing Pauli measurements
 ```python
@@ -51,7 +51,7 @@ pattern.draw_graph()
 ```
 <img src="https://github.com/TeamGraphix/graphix/assets/33350509/3c30a4c9-f912-4a36-925f-2ff446a07c68" alt="logo" width="140">
 
-(here, the graph has [*generalized flow*](https://iopscience.iop.org/article/10.1088/1367-2630/9/8/250).)
+<small>(here, the graph has [*generalized flow*](https://iopscience.iop.org/article/10.1088/1367-2630/9/8/250).)</small>
 
 ### simulating the pattern
 ```python

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pattern.draw_graph()
 ```
 <img src="https://github.com/TeamGraphix/graphix/assets/33350509/de17c663-f607-44e2-945b-835f4082a940" alt="logo" width="750">
 
-<small>note: this graph is generated from QAOA circuit, see [our example code](examples/qaoa.py). Arrows indicate the [*information flow*](https://journals.aps.org/pra/abstract/10.1103/PhysRevA.74.052310) of MBQC and dashed lines are the other edges of the graph. the vertical dashed partitions and the labels 'l:n' below indicate the execution *layers* or the order in the graph (measurements should happen from left to right, and nodes in the same layer can be measured simultaneously), based on the partial order associated with the (maximally-delayed) flow. </small>
+<small>note: this graph is generated from QAOA circuit, see [our example code](examples/qaoa.py). Arrows indicate the [*causal flow*](https://journals.aps.org/pra/abstract/10.1103/PhysRevA.74.052310) of MBQC and dashed lines are the other edges of the graph. the vertical dashed partitions and the labels 'l:n' below indicate the execution *layers* or the order in the graph (measurements should happen from left to right, and nodes in the same layer can be measured simultaneously), based on the partial order associated with the (maximally-delayed) flow. </small>
 
 ### preprocessing Pauli measurements
 ```python

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ pattern.draw_graph()
 
 ### simulating the pattern
 ```python
-state_out = pattern.simulate_pattern(backend='statevec')
+state_out = pattern.simulate_pattern(backend='statevector')
 ```
 
 ### and more.. 

--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ pattern.draw_graph()
 ```
 <img src="https://github.com/TeamGraphix/graphix/assets/33350509/de17c663-f607-44e2-945b-835f4082a940" alt="logo" width="750">
 
-(QAOA circuit, see [this example](examples/qaoa.py). Arrows indicate the [information flow](https://journals.aps.org/pra/abstract/10.1103/PhysRevA.74.052310) of MBQC and dashed lines are other edges of the graph.)
+(QAOA circuit, see [this example](examples/qaoa.py). Arrows indicate the [*information flow*](https://journals.aps.org/pra/abstract/10.1103/PhysRevA.74.052310) of MBQC and dashed lines are other edges of the graph.)
 
 ### preprocessing Pauli measurements
 ```python
-pattern.perform_pauli_measurements(leave_input=False)
-pattern.draw_graph(show_loop=False)
+pattern.perform_pauli_measurements()
+pattern.draw_graph()
 ```
 <img src="https://github.com/TeamGraphix/graphix/assets/33350509/3c30a4c9-f912-4a36-925f-2ff446a07c68" alt="logo" width="140">
 

--- a/examples/qaoa.py
+++ b/examples/qaoa.py
@@ -2,8 +2,7 @@
 QAOA
 ====
 
-Here we reproduce the figure in our preprint `arXiv:2212.11975 <https://arxiv.org/abs/2212.11975>`_.
-
+Here we generate and optimize pattern for QAOA circuit.
 You can run this code on your browser with `mybinder.org <https://mybinder.org/>`_ - click the badge below.
 
 .. image:: https://mybinder.org/badge_logo.svg
@@ -36,65 +35,6 @@ for v in g.nodes:
 pattern = circuit.transpile()
 pattern.standardize()
 pattern.shift_signals()
-nodes, edges = pattern.get_graph()
-g = nx.Graph()
-g.add_nodes_from(nodes)
-g.add_edges_from(edges)
-
-#%%
-# script to specify graph node positions and colors.
-#
-# We work out how to place nodes on the plot, by using the flow-finding algorithm.
-
-
-from graphix.gflow import flow
-
-f, l_k = flow(g, {0, 1, 2, 3}, set(pattern.output_nodes))
-
-flow = [[i] for i in range(4)]
-for i in range(4):
-    contd = True
-    val = i
-    while contd:
-        try:
-            val = f[val]
-            flow[i].append(val)
-        except KeyError:
-            contd = False
-longest = np.max([len(flow[i]) for i in range(4)])
-
-pos = dict()
-for i in range(4):
-    length = len(flow[i])
-    fac = longest / (length - 1)
-    for j in range(len(flow[i])):
-        pos[flow[i][j]] = (fac * j, -i)
-
-# determine wheher or not a node will be measured in Pauli basis
-def get_clr_list(pattern):
-    nodes, edges = pattern.get_graph()
-    meas_list = pattern.get_measurement_commands()
-    g = nx.Graph()
-    g.add_nodes_from(nodes)
-    g.add_edges_from(edges)
-    clr_list = []
-    for i in g.nodes:
-        for cmd in meas_list:
-            if cmd[1] == i:
-                if cmd[3] in [-1, -0.5, 0, 0.5, 1]:
-                    clr_list.append([0.5, 0.5, 0.5])
-                else:
-                    clr_list.append([1, 1, 1])
-        if i in pattern.output_nodes:
-            clr_list.append([0.8, 0.8, 0.8])
-    return clr_list
-
-
-graph_params = {"with_labels": False, "node_size": 150, "node_color": get_clr_list(pattern), "edgecolors": "k"}
-nx.draw(g, pos=pos, **graph_params)
-
-#%%
-# Similar visualization can be done by calling our recently added :class:`graphix.visualization.GraphVisualizer` class, accessible through :meth:`graphix.pattern.Pattern.draw_graph()`
 pattern.draw_graph()
 
 
@@ -102,28 +42,7 @@ pattern.draw_graph()
 # perform Pauli measurements and plot the new (minimal) graph to perform the same quantum computation
 
 pattern.perform_pauli_measurements()
-nodes, edges = pattern.get_graph()
-g = nx.Graph()
-g.add_nodes_from(nodes)
-g.add_edges_from(edges)
-graph_params = {"with_labels": False, "node_size": 150, "node_color": get_clr_list(pattern), "edgecolors": "k"}
-pos = { # hand-typed for better look
-    40: (0, 0),
-    5: (0, -1),
-    11: (0, -2),
-    17: (0, -3),
-    23: (1, -2),
-    29: (1, -3),
-    35: (2, -3),
-    42: (3, -1),
-    44: (3, -2),
-    46: (3, -3),
-    41: (4, 0),
-    43: (4, -1),
-    45: (4, -2),
-    47: (4, -3),
-}
-nx.draw(g, pos=pos, **graph_params)
+pattern.draw_graph()
 
 #%%
 # finally, simulate the QAOA circuit

--- a/examples/qft_with_tn.py
+++ b/examples/qft_with_tn.py
@@ -70,7 +70,7 @@ print(f"Number of edges: {len(edges)}")
 # %%
 # Using efficient graph state simulator `graphix.GraphSim`, we can classically preprocess Pauli measurements.
 # We are currently improving the speed of this process by using rust-based graph manipulation backend.
-pattern.perform_pauli_measurements()
+pattern.perform_pauli_measurements(use_rustworkx=True)
 
 
 # %%

--- a/examples/qnn.py
+++ b/examples/qnn.py
@@ -333,104 +333,12 @@ print(pattern.max_space())
 
 # %%
 # Plot the resource state. Node positions are determined by the flow-finding algorithm.
-nodes, edges = pattern.get_graph()
-g = nx.Graph()
-g.add_nodes_from(nodes)
-g.add_edges_from(edges)
-
-from graphix.gflow import flow  # noqa: E402
-
-f, l_k = flow(g, set(range(n_qubits)), set(pattern.output_nodes))
-
-flow = [[i] for i in range(n_qubits)]
-for i in range(n_qubits):
-    contd = True
-    val = i
-    while contd:
-        try:
-            val = f[val]
-            flow[i].append(val)
-        except KeyError:
-            contd = False
-longest = np.max([len(flow[i]) for i in range(n_qubits)])
-
-pos = dict()
-for i in range(n_qubits):
-    length = len(flow[i])
-    fac = longest / (length - 1)
-    for j in range(len(flow[i])):
-        pos[flow[i][j]] = (fac * j, -i)
-
-
-# determine wheher or not a node will be measured in Pauli basis
-def get_clr_list(pattern):
-    nodes, edges = pattern.get_graph()
-    meas_list = pattern.get_measurement_commands()
-    g = nx.Graph()
-    g.add_nodes_from(nodes)
-    g.add_edges_from(edges)
-    clr_list = []
-    for i in g.nodes:
-        for cmd in meas_list:
-            if cmd[1] == i:
-                if cmd[3] in [-1, -0.5, 0, 0.5, 1]:
-                    clr_list.append([0.5, 0.5, 0.5])
-                else:
-                    clr_list.append([1, 1, 1])
-        if i in pattern.output_nodes:
-            clr_list.append([0.8, 0.8, 0.8])
-    return clr_list
-
-
-graph_params = {
-    "with_labels": True,
-    "alpha": 0.8,
-    "node_size": 350,
-    "node_color": get_clr_list(pattern),
-    "edgecolors": "k",
-}
-
-nx.draw(g, pos=pos, **graph_params)
+pattern.draw_graph()
 
 # %%
 # The resource state after Pauli measurement preprocessing:
-pattern.perform_pauli_measurements()
-nodes, edges = pattern.get_graph()
-g = nx.Graph()
-g.add_nodes_from(nodes)
-g.add_edges_from(edges)
-graph_params = {
-    "with_labels": True,
-    "alpha": 0.8,
-    "node_size": 350,
-    "node_color": get_clr_list(pattern),
-    "edgecolors": "k",
-}
-
-pos = {  # hand-typed for better look
-    3: (0, 0),
-    4: (1, 0),
-    5: (2, 0),
-    7: (3, 0),
-    11: (0, -1),
-    12: (3, -1),
-    13: (4, -1),
-    15: (5, -1),
-    20: (4, 0),
-    21: (5, 0),
-    22: (6, 0),
-    23: (7, 0),
-    25: (8, 0),
-    27: (9, 0),
-    28: (6, -1),
-    29: (7, -1),
-    30: (8, -1),
-    31: (9, -1),
-    33: (10, -1),
-    35: (11, -1),
-}
-
-nx.draw(g, pos=pos, **graph_params)
+pattern.perform_pauli_measurements(leave_input=False)
+pattern.draw_graph()
 
 # %%
 # Qubit Resource plot

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -1235,6 +1235,7 @@ class Pattern:
         node_distance=(1, 1),
         figsize=None,
         pauli_indicator=True,
+        show_loop=False,
         local_clifford_indicator=False,
         save=False,
         filename=None,
@@ -1249,6 +1250,8 @@ class Pattern:
             Figure size of the plot.
         pauli_indicator : bool
             If True, the nodes are colored according to the measurement angles.
+        show_loop : bool
+            whether or not to show loops for graphs with gflow. defaulted to False.
         local_clifford_indicator : bool
             If True, indexes of the local Clifford operator are displayed adjacent to the nodes.
         save : bool
@@ -1278,6 +1281,7 @@ class Pattern:
             figsize=figsize,
             angles=angles,
             local_clifford=local_clifford,
+            show_loop=show_loop,
             save=save,
             filename=filename,
         )

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -1230,11 +1230,21 @@ class Pattern:
         """
         measure_pauli(self, leave_input, copy=False, use_rustworkx=use_rustworkx)
 
-    def draw_graph(self, figsize=None, pauli_indicator=True, local_clifford_indicator=False, save=False, filename=None):
+    def draw_graph(
+        self,
+        node_distance=(1, 1),
+        figsize=None,
+        pauli_indicator=True,
+        local_clifford_indicator=False,
+        save=False,
+        filename=None,
+    ):
         """Visualize the underlying graph of the pattern with flow or gflow structure.
 
         Parameters
         ----------
+        node_distance : tuple
+            Distance multiplication factor between nodes for x and y directions.
         figsize : tuple
             Figure size of the plot.
         pauli_indicator : bool
@@ -1263,7 +1273,14 @@ class Pattern:
             local_clifford = self.get_vops()
         else:
             local_clifford = None
-        vis.visualize(figsize=figsize, angles=angles, local_clifford=local_clifford, save=save, filename=filename)
+        vis.visualize(
+            node_distance=node_distance,
+            figsize=figsize,
+            angles=angles,
+            local_clifford=local_clifford,
+            save=save,
+            filename=filename,
+        )
 
     def to_qasm3(self, filename):
         """Export measurement pattern to OpenQASM 3.0 file

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -1235,7 +1235,7 @@ class Pattern:
         node_distance=(1, 1),
         figsize=None,
         pauli_indicator=True,
-        show_loop=False,
+        show_loop=True,
         local_clifford_indicator=False,
         save=False,
         filename=None,
@@ -1251,7 +1251,7 @@ class Pattern:
         pauli_indicator : bool
             If True, the nodes are colored according to the measurement angles.
         show_loop : bool
-            whether or not to show loops for graphs with gflow. defaulted to False.
+            whether or not to show loops for graphs with gflow. defaulted to True.
         local_clifford_indicator : bool
             If True, indexes of the local Clifford operator are displayed adjacent to the nodes.
         save : bool

--- a/graphix/visualization.py
+++ b/graphix/visualization.py
@@ -38,7 +38,14 @@ class GraphVisualizer:
             self.meas_plane = meas_plane
 
     def visualize(
-        self, angles=None, local_clifford=None, node_distance=(1, 1), show_loop=False, figsize=None, save=False, filename=None
+        self,
+        angles=None,
+        local_clifford=None,
+        node_distance=(1, 1),
+        show_loop=True,
+        figsize=None,
+        save=False,
+        filename=None,
     ):
         """
         Visualizes the graph with flow or gflow structure.
@@ -56,7 +63,7 @@ class GraphVisualizer:
             Indexes of local clifford operations for each nodes.
             If not None, indexes of the local Clifford operator are displayed adjacent to the nodes.
         show_loop : bool
-            whether or not to show loops for graphs with gflow. defaulted to False.
+            whether or not to show loops for graphs with gflow. defaulted to True.
         node_distance : tuple
             Distance multiplication factor between nodes for x and y directions.
         figsize : tuple
@@ -75,7 +82,9 @@ class GraphVisualizer:
             g, l_k = gflow.gflow(self.G, set(self.v_in), set(self.v_out), self.meas_plane)
             if g:
                 print("No flow found. Gflow found.")
-                self.visualize_w_gflow(g, l_k, angles, local_clifford, node_distance, show_loop, figsize, save, filename)
+                self.visualize_w_gflow(
+                    g, l_k, angles, local_clifford, node_distance, show_loop, figsize, save, filename
+                )
             else:
                 print("No flow or gflow found.")
                 self.visualize_wo_structure(angles, local_clifford, node_distance, save, filename)
@@ -188,7 +197,16 @@ class GraphVisualizer:
         plt.show()
 
     def visualize_w_gflow(
-        self, g, l_k, angles=None, local_clifford=None, node_distance=(1, 1), show_loop=False, figsize=None, save=False, filename=None
+        self,
+        g,
+        l_k,
+        angles=None,
+        local_clifford=None,
+        node_distance=(1, 1),
+        show_loop=True,
+        figsize=None,
+        save=False,
+        filename=None,
     ):
         """
         visualizes the graph with flow structure.
@@ -213,7 +231,7 @@ class GraphVisualizer:
         node_distance : tuple
             Distance multiplication factor between nodes for x and y directions.
         show_loop : bool
-            whether or not to show loops for graphs with gflow. defaulted to False.
+            whether or not to show loops for graphs with gflow. defaulted to True.
         figsize : tuple
             Figure size of the plot.
         save : bool

--- a/graphix/visualization.py
+++ b/graphix/visualization.py
@@ -23,13 +23,13 @@ class GraphVisualizer:
         """
         Parameters
         ----------
-        G : :class:`networkx.graph.Graph` object 
+        G : :class:`networkx.graph.Graph` object
             networkx graph
         v_in : list
             list of input nodes
         v_out : list
             list of output nodes
-        meas_plane : dict 
+        meas_plane : dict
             dict specifying the measurement planes for each node, except output nodes.
             if None, all measurements are assumed to be in XY-plane.
         """

--- a/graphix/visualization.py
+++ b/graphix/visualization.py
@@ -23,10 +23,14 @@ class GraphVisualizer:
         """
         Parameters
         ----------
-        G: networkx graph
-        v_in: list of input nodes
-        v_out: list of output nodes
-        meas_plane: dict specifying the measurement planes for each node, except output nodes.
+        G : :class:`networkx.graph.Graph` object 
+            networkx graph
+        v_in : list
+            list of input nodes
+        v_out : list
+            list of output nodes
+        meas_plane : dict 
+            dict specifying the measurement planes for each node, except output nodes.
             if None, all measurements are assumed to be in XY-plane.
         """
         self.G = G
@@ -580,7 +584,9 @@ class GraphVisualizer:
 
     @staticmethod
     def edge_intersects_node(start, end, node_pos, buffer=0.2):
-        """Determine if an edge intersects a node."""
+        """
+        Determine if an edge intersects a node.
+        """
         start = np.array(start)
         end = np.array(end)
         if np.all(start == end):
@@ -602,7 +608,9 @@ class GraphVisualizer:
 
     @staticmethod
     def control_point(start, end, node_pos, distance=0.6):
-        """Generate a control point to bend the edge around a node."""
+        """
+        Generate a control point to bend the edge around a node.
+        """
         edge_vector = np.array(end) - np.array(start)
         # Rotate the edge vector 90 degrees or -90 degrees according to the node position
         cross = np.cross(edge_vector, np.array(node_pos) - np.array(start))
@@ -616,6 +624,9 @@ class GraphVisualizer:
 
     @staticmethod
     def bezier_curve(bezier_path, t):
+        """
+        Generate a bezier curve from a list of points.
+        """
         n = len(bezier_path) - 1  # order of the curve
         curve = np.zeros((len(t), 2))
         for i, point in enumerate(bezier_path):

--- a/graphix/visualization.py
+++ b/graphix/visualization.py
@@ -37,7 +37,9 @@ class GraphVisualizer:
         else:
             self.meas_plane = meas_plane
 
-    def visualize(self, angles=None, local_clifford=None, figsize=None, save=False, filename=None):
+    def visualize(
+        self, angles=None, local_clifford=None, node_distance=(1, 1), figsize=None, save=False, filename=None
+    ):
         """
         Visualizes the graph with flow or gflow structure.
         If there exists a flow structure, then the graph is visualized with the flow structure.
@@ -53,6 +55,8 @@ class GraphVisualizer:
         local_clifford : dict
             Indexes of local clifford operations for each nodes.
             If not None, indexes of the local Clifford operator are displayed adjacent to the nodes.
+        node_distance : tuple
+            Distance multiplication factor between nodes for x and y directions.
         figsize : tuple
             Figure size of the plot.
         save : bool
@@ -64,17 +68,19 @@ class GraphVisualizer:
         f, l_k = gflow.flow(self.G, set(self.v_in), set(self.v_out), meas_planes=self.meas_plane)
         if f:
             print("Flow found.")
-            self.visualize_w_flow(f, l_k, angles, local_clifford, figsize, save, filename)
+            self.visualize_w_flow(f, l_k, angles, local_clifford, node_distance, figsize, save, filename)
         else:
             g, l_k = gflow.gflow(self.G, set(self.v_in), set(self.v_out), self.meas_plane)
             if g:
                 print("No flow found. Gflow found.")
-                self.visualize_w_gflow(g, l_k, angles, local_clifford, figsize, save, filename)
+                self.visualize_w_gflow(g, l_k, angles, local_clifford, node_distance, figsize, save, filename)
             else:
                 print("No flow or gflow found.")
-                self.visualize_wo_structure(angles, local_clifford, save, filename)
+                self.visualize_wo_structure(angles, local_clifford, node_distance, save, filename)
 
-    def visualize_w_flow(self, f, l_k, angles=None, local_clifford=None, figsize=None, save=False, filename=None):
+    def visualize_w_flow(
+        self, f, l_k, angles=None, local_clifford=None, node_distance=(1, 1), figsize=None, save=False, filename=None
+    ):
         """
         visualizes the graph with flow structure.
 
@@ -95,21 +101,26 @@ class GraphVisualizer:
         local_clifford : dict
             Indexes of local clifford operations for each nodes.
             If not None, indexes of the local Clifford operator are displayed adjacent to the nodes.
+        node_distance : tuple
+            Distance multiplication factor between nodes for x and y directions.
         figsize : tuple
             Figure size of the plot.
         save : bool
-            If True, the plot is saved as a png file.
+            If True, the plot is saved.
         filename : str
             Filename of the saved plot.
         """
         if figsize is None:
-            figsize = self.get_figsize(l_k)
+            figsize = self.get_figsize(l_k, node_distance=node_distance)
         plt.figure(figsize=figsize)
         pos = self.get_pos_from_flow(f, l_k)
 
         # Change the x coordinates of the nodes based on their layer, sort in descending order
         for node, layer in l_k.items():
-            pos[node] = (max(l_k.values()) - layer, pos[node][1])  # Subtracting from max for descending order
+            pos[node] = (
+                (max(l_k.values()) - layer) * node_distance[0],
+                pos[node][1] * node_distance[1],
+            )  # Subtracting from max for descending order
 
         # Draw the arrows
         for a, b in f.items():
@@ -158,19 +169,25 @@ class GraphVisualizer:
 
         # Draw the vertical lines to separate different layers
         for layer in range(min(l_k.values()), max(l_k.values())):
-            plt.axvline(x=layer + 0.5, color="gray", linestyle="--", alpha=0.5)  # Draw line between layers
+            plt.axvline(
+                x=(layer + 0.5) * node_distance[0], color="gray", linestyle="--", alpha=0.5
+            )  # Draw line between layers
         for layer in range(min(l_k.values()), max(l_k.values()) + 1):
             plt.text(
-                layer, y_min - 0.5, f"l: {max(l_k.values()) - layer}", ha="center", va="top"
+                layer * node_distance[0], y_min - 0.5, f"l: {max(l_k.values()) - layer}", ha="center", va="top"
             )  # Add layer label at bottom
 
-        plt.xlim(x_min - 0.5, x_max + 0.5)  # Add some padding to the left and right
+        plt.xlim(
+            x_min - 0.5 * node_distance[0], x_max + 0.5 * node_distance[0]
+        )  # Add some padding to the left and right
         plt.ylim(y_min - 1, y_max + 0.5)  # Add some padding to the top and bottom
         if save:
             plt.savefig(filename)
         plt.show()
 
-    def visualize_w_gflow(self, g, l_k, angles=None, local_clifford=None, figsize=None, save=False, filename=None):
+    def visualize_w_gflow(
+        self, g, l_k, angles=None, local_clifford=None, node_distance=(1, 1), figsize=None, save=False, filename=None
+    ):
         """
         visualizes the graph with flow structure.
 
@@ -191,6 +208,8 @@ class GraphVisualizer:
         local_clifford : dict
             Indexes of local clifford operations for each nodes.
             If not None, indexes of the local Clifford operator are displayed adjacent to the nodes.
+        node_distance : tuple
+            Distance multiplication factor between nodes for x and y directions.
         figsize : tuple
             Figure size of the plot.
         save : bool
@@ -199,32 +218,48 @@ class GraphVisualizer:
             Filename of the saved plot.
         """
 
-        if figsize is None:
-            figsize = self.get_figsize(l_k)
-        plt.figure(figsize=figsize)
-
         pos = self.get_pos_from_gflow(g, l_k)
+        pos = {k: (v[0] * node_distance[0], v[1] * node_distance[1]) for k, v in pos.items()}  # Scale the layout
 
         edge_path = self.get_edge_path(g, pos)
 
+        if figsize is None:
+            figsize = self.get_figsize(l_k, pos, node_distance=node_distance)
+        plt.figure(figsize=figsize)
+
         for edge in edge_path.keys():
             if edge[1] in g.get(edge[0], set()) or edge[0] in g.get(edge[1], set()):  # This edge is an arrow
-                if len(edge_path[edge]) == 2:
+                if edge[0] == edge[1]:  # self loop
+                    t = np.linspace(0, 1, 100)
+                    curve = self.bezier_curve(edge_path[edge], t)
+                    plt.plot(curve[:, 0], curve[:, 1], c="k", linewidth=1)
+                    plt.annotate(
+                        "",
+                        xy=curve[-1],
+                        xytext=curve[-2],
+                        arrowprops=dict(arrowstyle="->", color="k", lw=1),
+                    )
+                elif len(edge_path[edge]) == 2:  # straight line
                     nx.draw_networkx_edges(
                         self.G, pos, edgelist=[edge], edge_color="black", arrowstyle="->", arrows=True
                     )
                 else:
-                    t = np.linspace(0, 1, 100)
-                    curve = self.bezier_curve(edge_path[edge], t)
-                    start_point = curve[0]
-                    end_point = curve[-1]
+                    path = edge_path[edge]
+                    last = np.array(path[-1])
+                    second_last = np.array(path[-2])
+                    path[-1] = list(
+                        last - (last - second_last) / np.linalg.norm(last - second_last) * 0.2
+                    )  # Shorten the last edge not to hide arrow under the node
 
-                    plt.scatter(curve[:, 0], curve[:, 1], c="k")  # To see the points
+                    t = np.linspace(0, 1, 100)
+                    curve = self.bezier_curve(path, t)
+
+                    plt.plot(curve[:, 0], curve[:, 1], c="k", linewidth=1)
                     plt.annotate(
                         "",
-                        xy=end_point,
-                        xytext=start_point,
-                        arrowprops=dict(arrowstyle="->", color="k", lw=1, alpha=0.7),
+                        xy=curve[-1],
+                        xytext=curve[-2],
+                        arrowprops=dict(arrowstyle="->", color="k", lw=1),
                     )
             else:
                 if len(edge_path[edge]) == 2:
@@ -266,19 +301,23 @@ class GraphVisualizer:
 
         # Draw the vertical lines to separate different layers
         for layer in range(min(l_k.values()), max(l_k.values())):
-            plt.axvline(x=layer, color="gray", linestyle="--", alpha=0.5)  # Draw line between layers
+            plt.axvline(
+                x=(layer + 0.5) * node_distance[0], color="gray", linestyle="--", alpha=0.5
+            )  # Draw line between layers
         for layer in range(min(l_k.values()), max(l_k.values()) + 1):
             plt.text(
-                layer - 0.5, y_min - 0.5, f"l: {max(l_k.values()) - layer}", ha="center", va="top"
+                layer * node_distance[0], y_min - 0.5, f"l: {max(l_k.values()) - layer}", ha="center", va="top"
             )  # Add layer label at bottom
 
-        plt.xlim(x_min - 0.5, x_max + 0.5)  # Add some padding to the left and right
+        plt.xlim(
+            x_min - 0.5 * node_distance[0], x_max + 0.5 * node_distance[0]
+        )  # Add some padding to the left and right
         plt.ylim(y_min - 1, y_max + 0.5)  # Add some padding to the top and bottom
         if save:
             plt.savefig(filename)
         plt.show()
 
-    def visualize_wo_structure(self, angles=None, local_clifford=None, save=False, filename=None):
+    def visualize_wo_structure(self, angles=None, local_clifford=None, node_distance=(1, 1), save=False, filename=None):
         """
         visualizes the graph without flow or gflow.
 
@@ -299,6 +338,8 @@ class GraphVisualizer:
         local_clifford : dict
             Indexes of local clifford operations for each nodes.
             If not None, indexes of the local Clifford operator are displayed adjacent to the nodes.
+        node_distance : tuple
+            Distance multiplication factor between nodes for x and y directions.
         figsize : tuple
             Figure size of the plot.
         save : bool
@@ -311,6 +352,7 @@ class GraphVisualizer:
         plt.figure(figsize=(scale, (2 / 3) * scale))
         k_val = 2 / np.sqrt(len(self.G.nodes()))
         pos = nx.spring_layout(self.G, k=k_val)  # Layout for the nodes
+        pos = {k: (v[0] * node_distance[0], v[1] * node_distance[1]) for k, v in pos.items()}  # Scale the layout
 
         # Draw the edges
         nx.draw_networkx_edges(self.G, pos, edge_color="black")
@@ -344,7 +386,7 @@ class GraphVisualizer:
             plt.savefig(filename)
         plt.show()
 
-    def get_figsize(self, l_k):
+    def get_figsize(self, l_k, pos=None, node_distance=(1, 1)):
         """
         Returns the figure size of the graph.
 
@@ -359,8 +401,12 @@ class GraphVisualizer:
             figure size of the graph.
         """
         width = (max(l_k.values()) + 1) * 0.8
-        height = len(self.v_in)
-        figsize = (width, height)
+        if pos is not None:
+            height = len(set([pos[node][1] for node in self.G.nodes()]))
+        elif len(self.v_in) > 0:
+            height = len(self.v_in)
+        figsize = (width * node_distance[0], height * node_distance[1])
+
         return figsize
 
     def get_edge_path(self, fg, pos):
@@ -388,13 +434,28 @@ class GraphVisualizer:
         else:
             edge_set = set(self.G.edges())
         for edge in edge_set:
-            if fg.get(edge[0], set()) == edge[1] and fg.get(edge[1], set()) == edge[0]:
-                edge_path[edge] = [pos[edge[0]], pos[edge[1]]]
+            if type(next(iter(fg.values()))) is not set and (fg.get(edge[0]) == edge[1] or fg.get(edge[1]) == edge[0]):
+                # fg is flow and edge is an arrow
+                bezier_path = [pos[edge[0]], pos[edge[1]]]
+            elif edge[0] == edge[1]:  # Self loop
+
+                def _point_from_node(pos, dist, angle):
+                    angle = np.deg2rad(angle)
+                    return [pos[0] + dist * np.cos(angle), pos[1] + dist * np.sin(angle)]
+
+                bezier_path = [
+                    _point_from_node(pos[edge[0]], 0.2, 170),
+                    _point_from_node(pos[edge[0]], 0.35, 170),
+                    _point_from_node(pos[edge[0]], 0.4, 155),
+                    _point_from_node(pos[edge[0]], 0.45, 140),
+                    _point_from_node(pos[edge[0]], 0.35, 110),
+                    _point_from_node(pos[edge[0]], 0.3, 110),
+                    _point_from_node(pos[edge[0]], 0.17, 95),
+                ]
             else:
                 iteration = 0
                 nodes = self.G.nodes()
-                bezier_path = [pos[edge[0]]]
-                bezier_path.append(pos[edge[1]])
+                bezier_path = [pos[edge[0]], pos[edge[1]]]
                 while True:
                     iteration += 1
                     intersect = False
@@ -484,6 +545,14 @@ class GraphVisualizer:
 
         pos = nx.multipartite_layout(G_prime)
 
+        for node, layer in l_k.items():
+            pos[node][0] = l_max - layer
+
+        vert = list(set([pos[node][1] for node in self.G.nodes()]))
+        vert.sort()
+        for node in self.G.nodes():
+            pos[node][1] = vert.index(pos[node][1])
+
         return pos
 
     @staticmethod
@@ -491,6 +560,8 @@ class GraphVisualizer:
         """Determine if an edge intersects a node."""
         start = np.array(start)
         end = np.array(end)
+        if np.all(start == end):
+            return False
         node_pos = np.array(node_pos)
         # Vector from start to end
         line_vec = end - start

--- a/graphix/visualization.py
+++ b/graphix/visualization.py
@@ -38,7 +38,7 @@ class GraphVisualizer:
             self.meas_plane = meas_plane
 
     def visualize(
-        self, angles=None, local_clifford=None, node_distance=(1, 1), figsize=None, save=False, filename=None
+        self, angles=None, local_clifford=None, node_distance=(1, 1), show_loop=False, figsize=None, save=False, filename=None
     ):
         """
         Visualizes the graph with flow or gflow structure.
@@ -55,6 +55,8 @@ class GraphVisualizer:
         local_clifford : dict
             Indexes of local clifford operations for each nodes.
             If not None, indexes of the local Clifford operator are displayed adjacent to the nodes.
+        show_loop : bool
+            whether or not to show loops for graphs with gflow. defaulted to False.
         node_distance : tuple
             Distance multiplication factor between nodes for x and y directions.
         figsize : tuple
@@ -73,7 +75,7 @@ class GraphVisualizer:
             g, l_k = gflow.gflow(self.G, set(self.v_in), set(self.v_out), self.meas_plane)
             if g:
                 print("No flow found. Gflow found.")
-                self.visualize_w_gflow(g, l_k, angles, local_clifford, node_distance, figsize, save, filename)
+                self.visualize_w_gflow(g, l_k, angles, local_clifford, node_distance, show_loop, figsize, save, filename)
             else:
                 print("No flow or gflow found.")
                 self.visualize_wo_structure(angles, local_clifford, node_distance, save, filename)
@@ -186,7 +188,7 @@ class GraphVisualizer:
         plt.show()
 
     def visualize_w_gflow(
-        self, g, l_k, angles=None, local_clifford=None, node_distance=(1, 1), figsize=None, save=False, filename=None
+        self, g, l_k, angles=None, local_clifford=None, node_distance=(1, 1), show_loop=False, figsize=None, save=False, filename=None
     ):
         """
         visualizes the graph with flow structure.
@@ -210,6 +212,8 @@ class GraphVisualizer:
             If not None, indexes of the local Clifford operator are displayed adjacent to the nodes.
         node_distance : tuple
             Distance multiplication factor between nodes for x and y directions.
+        show_loop : bool
+            whether or not to show loops for graphs with gflow. defaulted to False.
         figsize : tuple
             Figure size of the plot.
         save : bool
@@ -230,15 +234,16 @@ class GraphVisualizer:
         for edge in edge_path.keys():
             if edge[1] in g.get(edge[0], set()) or edge[0] in g.get(edge[1], set()):  # This edge is an arrow
                 if edge[0] == edge[1]:  # self loop
-                    t = np.linspace(0, 1, 100)
-                    curve = self.bezier_curve(edge_path[edge], t)
-                    plt.plot(curve[:, 0], curve[:, 1], c="k", linewidth=1)
-                    plt.annotate(
-                        "",
-                        xy=curve[-1],
-                        xytext=curve[-2],
-                        arrowprops=dict(arrowstyle="->", color="k", lw=1),
-                    )
+                    if show_loop:
+                        t = np.linspace(0, 1, 100)
+                        curve = self.bezier_curve(edge_path[edge], t)
+                        plt.plot(curve[:, 0], curve[:, 1], c="k", linewidth=1)
+                        plt.annotate(
+                            "",
+                            xy=curve[-1],
+                            xytext=curve[-2],
+                            arrowprops=dict(arrowstyle="->", color="k", lw=1),
+                        )
                 elif len(edge_path[edge]) == 2:  # straight line
                     nx.draw_networkx_edges(
                         self.G, pos, edgelist=[edge], edge_color="black", arrowstyle="->", arrows=True


### PR DESCRIPTION
Before submitting, please check the following:
- Make sure you have tests for the new code and that test passes (run `tox`)
- format added code by `black -l 120 <filename>`
- If applicable, add a line to the [unreleased] part of CHANGELOG.md, following [keep-a-changelog](https://keepachangelog.com/en/1.0.0/).

Then, please fill in below:

**Context (if applicable):**
Singular matrix error occured with visualisation tool when drawing graph with gflow. (#97 )

**Description of the change:**
The direct cause of the error was in the `get_figsize()` method, which returned 0 height for pattern without input_nodes. Fixed that part and modified some detailed drawing methods for better gflow visualization.

**Related issue:**
#97 

also see that checks (github actions) pass.
If lint check keeps failing, try installing black==22.8.0 as behavior seems to vary across versions.



