### PR TITLE
Use Parameterized Test

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,12 @@
+# Style
+black==22.8.0
+
+# Tests
+pytest
+parameterized
+tox
+
+# Optional dependencies
+qiskit
+qiskit-aer
+rustworkx

--- a/tests/random_circuit.py
+++ b/tests/random_circuit.py
@@ -1,5 +1,7 @@
-import numpy as np
 from copy import deepcopy
+
+import numpy as np
+
 from graphix.transpiler import Circuit
 
 GLOBAL_SEED = None
@@ -16,7 +18,7 @@ def get_rng(seed=None):
     elif seed is None and GLOBAL_SEED is not None:
         return np.random.default_rng(GLOBAL_SEED)
     else:
-        np.random.default_rng()
+        return np.random.default_rng()
 
 
 def first_rotation(circuit, nqubits, rng):

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -1,12 +1,20 @@
+import sys
 import unittest
+
+from parameterized import parameterized_class
 
 import graphix
 from graphix import extraction
 
 
+@parameterized_class([{"use_rustworkx": False}, {"use_rustworkx": True}])
 class TestExtraction(unittest.TestCase):
+    def setUp(self):
+        if sys.modules.get("rustworkx") is None and self.use_rustworkx is True:
+            self.skipTest("rustworkx not installed")
+
     def test_cluster_extraction_one_ghz_cluster(self):
-        gs = graphix.GraphState()
+        gs = graphix.GraphState(use_rustworkx=self.use_rustworkx)
         nodes = [0, 1, 2, 3, 4]
         edges = [(0, 1), (0, 2), (0, 3), (0, 4)]
         gs.add_nodes_from(nodes)
@@ -18,7 +26,7 @@ class TestExtraction(unittest.TestCase):
 
     # we consider everything smaller than 4, a GHZ
     def test_cluster_extraction_small_ghz_cluster_1(self):
-        gs = graphix.GraphState()
+        gs = graphix.GraphState(use_rustworkx=self.use_rustworkx)
         nodes = [0, 1, 2]
         edges = [(0, 1), (1, 2)]
         gs.add_nodes_from(nodes)
@@ -30,7 +38,7 @@ class TestExtraction(unittest.TestCase):
 
     # we consider everything smaller than 4, a GHZ
     def test_cluster_extraction_small_ghz_cluster_2(self):
-        gs = graphix.GraphState()
+        gs = graphix.GraphState(use_rustworkx=self.use_rustworkx)
         nodes = [0, 1]
         edges = [(0, 1)]
         gs.add_nodes_from(nodes)
@@ -41,7 +49,7 @@ class TestExtraction(unittest.TestCase):
         self.assertEqual(clusters[0] == extraction.ResourceGraph(type=extraction.ResourceType.GHZ, graph=gs), True)
 
     def test_cluster_extraction_one_linear_cluster(self):
-        gs = graphix.GraphState()
+        gs = graphix.GraphState(use_rustworkx=self.use_rustworkx)
         nodes = [0, 1, 2, 3, 4, 5, 6]
         edges = [(0, 1), (1, 2), (2, 3), (5, 4), (4, 6), (6, 0)]
         gs.add_nodes_from(nodes)
@@ -52,7 +60,7 @@ class TestExtraction(unittest.TestCase):
         self.assertEqual(clusters[0] == extraction.ResourceGraph(type=extraction.ResourceType.LINEAR, graph=gs), True)
 
     def test_cluster_extraction_one_ghz_one_linear(self):
-        gs = graphix.GraphState()
+        gs = graphix.GraphState(use_rustworkx=self.use_rustworkx)
         nodes = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         edges = [(0, 1), (0, 2), (0, 3), (0, 4), (4, 5), (5, 6), (6, 7), (7, 8), (8, 9)]
         gs.add_nodes_from(nodes)
@@ -61,11 +69,11 @@ class TestExtraction(unittest.TestCase):
         self.assertEqual(len(clusters), 2)
 
         clusters_expected = []
-        lin_cluster = graphix.GraphState()
+        lin_cluster = graphix.GraphState(use_rustworkx=self.use_rustworkx)
         lin_cluster.add_nodes_from([4, 5, 6, 7, 8, 9])
         lin_cluster.add_edges_from([(4, 5), (5, 6), (6, 7), (7, 8), (8, 9)])
         clusters_expected.append(extraction.ResourceGraph(extraction.ResourceType.LINEAR, lin_cluster))
-        ghz_cluster = graphix.GraphState()
+        ghz_cluster = graphix.GraphState(use_rustworkx=self.use_rustworkx)
         ghz_cluster.add_nodes_from([0, 1, 2, 3, 4])
         ghz_cluster.add_edges_from([(0, 1), (0, 2), (0, 3), (0, 4)])
         clusters_expected.append(extraction.ResourceGraph(extraction.ResourceType.GHZ, ghz_cluster))
@@ -77,7 +85,7 @@ class TestExtraction(unittest.TestCase):
         )
 
     def test_cluster_extraction_pentagonal_cluster(self):
-        gs = graphix.GraphState()
+        gs = graphix.GraphState(use_rustworkx=self.use_rustworkx)
         nodes = [0, 1, 2, 3, 4]
         edges = [(0, 1), (1, 2), (2, 3), (3, 4), (4, 0)]
         gs.add_nodes_from(nodes)
@@ -96,117 +104,7 @@ class TestExtraction(unittest.TestCase):
         )
 
     def test_cluster_extraction_one_plus_two(self):
-        gs = graphix.GraphState()
-        nodes = [0, 1, 2]
-        edges = [(0, 1)]
-        gs.add_nodes_from(nodes)
-        gs.add_edges_from(edges)
-        clusters = extraction.get_fusion_network_from_graph(gs)
-        self.assertEqual(len(clusters), 2)
-        self.assertEqual(
-            (clusters[0].type == extraction.ResourceType.GHZ and clusters[1].type == extraction.ResourceType.GHZ),
-            True,
-        )
-        self.assertEqual(
-            (len(clusters[0].graph.nodes) == 2 and len(clusters[1].graph.nodes) == 1)
-            or (len(clusters[0].graph.nodes) == 1 and len(clusters[1].graph.nodes) == 2),
-            True,
-        )
-
-
-class TestExtractionWithRustworkX(unittest.TestCase):
-    def test_cluster_extraction_one_ghz_cluster(self):
-        gs = graphix.GraphState(use_rustworkx=True)
-        nodes = [0, 1, 2, 3, 4]
-        edges = [(0, 1), (0, 2), (0, 3), (0, 4)]
-        gs.add_nodes_from(nodes)
-        gs.add_edges_from(edges)
-        clusters = extraction.get_fusion_network_from_graph(gs)
-
-        self.assertEqual(len(clusters), 1)
-        self.assertEqual(clusters[0] == extraction.ResourceGraph(type=extraction.ResourceType.GHZ, graph=gs), True)
-
-    # we consider everything smaller than 4, a GHZ
-    def test_cluster_extraction_small_ghz_cluster_1(self):
-        gs = graphix.GraphState(use_rustworkx=True)
-        nodes = [0, 1, 2]
-        edges = [(0, 1), (1, 2)]
-        gs.add_nodes_from(nodes)
-        gs.add_edges_from(edges)
-        clusters = extraction.get_fusion_network_from_graph(gs)
-
-        self.assertEqual(len(clusters), 1)
-        self.assertEqual(clusters[0] == extraction.ResourceGraph(type=extraction.ResourceType.GHZ, graph=gs), True)
-
-    # we consider everything smaller than 4, a GHZ
-    def test_cluster_extraction_small_ghz_cluster_2(self):
-        gs = graphix.GraphState(use_rustworkx=True)
-        nodes = [0, 1]
-        edges = [(0, 1)]
-        gs.add_nodes_from(nodes)
-        gs.add_edges_from(edges)
-        clusters = extraction.get_fusion_network_from_graph(gs)
-
-        self.assertEqual(len(clusters), 1)
-        self.assertEqual(clusters[0] == extraction.ResourceGraph(type=extraction.ResourceType.GHZ, graph=gs), True)
-
-    def test_cluster_extraction_one_linear_cluster(self):
-        gs = graphix.GraphState(use_rustworkx=True)
-        nodes = [0, 1, 2, 3, 4, 5, 6]
-        edges = [(0, 1), (1, 2), (2, 3), (5, 4), (4, 6), (6, 0)]
-        gs.add_nodes_from(nodes)
-        gs.add_edges_from(edges)
-        clusters = extraction.get_fusion_network_from_graph(gs)
-
-        self.assertEqual(len(clusters), 1)
-        self.assertEqual(clusters[0] == extraction.ResourceGraph(type=extraction.ResourceType.LINEAR, graph=gs), True)
-
-    def test_cluster_extraction_one_ghz_one_linear(self):
-        gs = graphix.GraphState(use_rustworkx=True)
-        nodes = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-        edges = [(0, 1), (0, 2), (0, 3), (0, 4), (4, 5), (5, 6), (6, 7), (7, 8), (8, 9)]
-        gs.add_nodes_from(nodes)
-        gs.add_edges_from(edges)
-        clusters = extraction.get_fusion_network_from_graph(gs)
-        self.assertEqual(len(clusters), 2)
-
-        clusters_expected = []
-        lin_cluster = graphix.GraphState(use_rustworkx=True)
-        lin_cluster.add_nodes_from([4, 5, 6, 7, 8, 9])
-        lin_cluster.add_edges_from([(4, 5), (5, 6), (6, 7), (7, 8), (8, 9)])
-        clusters_expected.append(extraction.ResourceGraph(extraction.ResourceType.LINEAR, lin_cluster))
-        ghz_cluster = graphix.GraphState(use_rustworkx=True)
-        ghz_cluster.add_nodes_from([0, 1, 2, 3, 4])
-        ghz_cluster.add_edges_from([(0, 1), (0, 2), (0, 3), (0, 4)])
-        clusters_expected.append(extraction.ResourceGraph(extraction.ResourceType.GHZ, ghz_cluster))
-
-        self.assertEqual(
-            (clusters[0] == clusters_expected[0] and clusters[1] == clusters_expected[1])
-            or (clusters[0] == clusters_expected[1] and clusters[1] == clusters_expected[0]),
-            True,
-        )
-
-    def test_cluster_extraction_pentagonal_cluster(self):
-        gs = graphix.GraphState(use_rustworkx=True)
-        nodes = [0, 1, 2, 3, 4]
-        edges = [(0, 1), (1, 2), (2, 3), (3, 4), (4, 0)]
-        gs.add_nodes_from(nodes)
-        gs.add_edges_from(edges)
-        clusters = extraction.get_fusion_network_from_graph(gs)
-        self.assertEqual(len(clusters), 2)
-        self.assertEqual(
-            (clusters[0].type == extraction.ResourceType.GHZ and clusters[1].type == extraction.ResourceType.LINEAR)
-            or (clusters[0].type == extraction.ResourceType.LINEAR and clusters[1].type == extraction.ResourceType.GHZ),
-            True,
-        )
-        self.assertEqual(
-            (len(clusters[0].graph.nodes) == 3 and len(clusters[1].graph.nodes) == 4)
-            or (len(clusters[0].graph.nodes) == 4 and len(clusters[1].graph.nodes) == 3),
-            True,
-        )
-
-    def test_cluster_extraction_one_plus_two(self):
-        gs = graphix.GraphState(use_rustworkx=True)
+        gs = graphix.GraphState(use_rustworkx=self.use_rustworkx)
         nodes = [0, 1, 2]
         edges = [(0, 1)]
         gs.add_nodes_from(nodes)

--- a/tests/test_graphsim.py
+++ b/tests/test_graphsim.py
@@ -1,9 +1,15 @@
+import sys
 import unittest
 
 import numpy as np
 from networkx import Graph
 from networkx.utils import graphs_equal
-from rustworkx import PyGraph
+from parameterized import parameterized_class
+
+try:
+    from rustworkx import PyGraph
+except ModuleNotFoundError:
+    pass
 
 from graphix.graphsim.graphstate import GraphState
 from graphix.graphsim.utils import convert_rustworkx_to_networkx, is_graphs_equal
@@ -31,14 +37,19 @@ def get_state(g):
     return gstate
 
 
+@parameterized_class([{"use_rustworkx": False}, {"use_rustworkx": True}])
 class TestGraphSim(unittest.TestCase):
+    def setUp(self):
+        if sys.modules.get("rustworkx") is None and self.use_rustworkx is True:
+            self.skipTest("rustworkx not installed")
+
     def test_fig2(self):
         """Example of three single-qubit measurements
         presented in Fig.2 of M. Elliot et al (2010)
         """
         nqubit = 6
         edges = [(0, 1), (1, 2), (3, 4), (4, 5), (0, 3), (1, 4), (2, 5)]
-        g = GraphState(nodes=np.arange(nqubit), edges=edges)
+        g = GraphState(nodes=np.arange(nqubit), edges=edges, use_rustworkx=self.use_rustworkx)
         gstate = get_state(g)
         g.measure_x(0)
         gstate.evolve_single(meas_op(0), [0])  # x meas
@@ -64,7 +75,7 @@ class TestGraphSim(unittest.TestCase):
     def test_E2(self):
         nqubit = 6
         edges = [(0, 1), (1, 2), (3, 4), (4, 5), (0, 3), (1, 4), (2, 5)]
-        g = GraphState(nodes=np.arange(nqubit), edges=edges)
+        g = GraphState(nodes=np.arange(nqubit), edges=edges, use_rustworkx=self.use_rustworkx)
         g.h(3)
         gstate = get_state(g)
 
@@ -91,7 +102,7 @@ class TestGraphSim(unittest.TestCase):
     def test_E1(self):
         nqubit = 6
         edges = [(0, 1), (1, 2), (3, 4), (4, 5), (0, 3), (1, 4), (2, 5)]
-        g = GraphState(nodes=np.arange(nqubit), edges=edges)
+        g = GraphState(nodes=np.arange(nqubit), edges=edges, use_rustworkx=self.use_rustworkx)
         g.nodes[3]["loop"] = True
         gstate = get_state(g)
         g.equivalent_graph_E1(3)
@@ -111,98 +122,13 @@ class TestGraphSim(unittest.TestCase):
         nqubit = 6
         edges = [(0, 1), (1, 2), (2, 3), (3, 4), (4, 0)]
         exp_edges = [(0, 1), (1, 2), (0, 2), (2, 3), (3, 4), (4, 0)]
-        g = GraphState(nodes=np.arange(nqubit), edges=edges)
+        g = GraphState(nodes=np.arange(nqubit), edges=edges, use_rustworkx=self.use_rustworkx)
         g.local_complement(1)
         exp_g = GraphState(nodes=np.arange(nqubit), edges=exp_edges)
         self.assertTrue(is_graphs_equal(g, exp_g))
 
 
-class TestGraphSimWithRustworkX(unittest.TestCase):
-    def test_fig2(self):
-        """Example of three single-qubit measurements
-        presented in Fig.2 of M. Elliot et al (2010)
-        """
-        nqubit = 6
-        edges = [(0, 1), (1, 2), (3, 4), (4, 5), (0, 3), (1, 4), (2, 5)]
-        g = GraphState(nodes=np.arange(nqubit), edges=edges, use_rustworkx=True)
-        gstate = get_state(g)
-        g.measure_x(0)
-        gstate.evolve_single(meas_op(0), [0])  # x meas
-        gstate.normalize()
-        gstate.remove_qubit(0)
-        gstate2 = get_state(g)
-        np.testing.assert_almost_equal(np.abs(np.dot(gstate.flatten().conjugate(), gstate2.flatten())), 1)
-
-        g.measure_y(1, choice=0)
-        gstate.evolve_single(meas_op(0.5 * np.pi), [0])  # y meas
-        gstate.normalize()
-        gstate.remove_qubit(0)
-        gstate2 = get_state(g)
-        np.testing.assert_almost_equal(np.abs(np.dot(gstate.flatten().conjugate(), gstate2.flatten())), 1)
-
-        g.measure_z(3)
-        gstate.evolve_single(meas_op(0.5 * np.pi, plane="YZ"), 1)  # z meas
-        gstate.normalize()
-        gstate.remove_qubit(1)
-        gstate2 = get_state(g)
-        np.testing.assert_almost_equal(np.abs(np.dot(gstate.flatten().conjugate(), gstate2.flatten())), 1)
-
-    def test_E2(self):
-        nqubit = 6
-        edges = [(0, 1), (1, 2), (3, 4), (4, 5), (0, 3), (1, 4), (2, 5)]
-        g = GraphState(nodes=np.arange(nqubit), edges=edges, use_rustworkx=True)
-        g.h(3)
-        gstate = get_state(g)
-
-        g.equivalent_graph_E2(3, 4)
-        gstate2 = get_state(g)
-        np.testing.assert_almost_equal(np.abs(np.dot(gstate.flatten().conjugate(), gstate2.flatten())), 1)
-
-        g.equivalent_graph_E2(4, 0)
-        gstate3 = get_state(g)
-        np.testing.assert_almost_equal(np.abs(np.dot(gstate.flatten().conjugate(), gstate3.flatten())), 1)
-
-        g.equivalent_graph_E2(4, 5)
-        gstate4 = get_state(g)
-        np.testing.assert_almost_equal(np.abs(np.dot(gstate.flatten().conjugate(), gstate4.flatten())), 1)
-
-        g.equivalent_graph_E2(0, 3)
-        gstate5 = get_state(g)
-        np.testing.assert_almost_equal(np.abs(np.dot(gstate.flatten().conjugate(), gstate5.flatten())), 1)
-
-        g.equivalent_graph_E2(0, 3)
-        gstate6 = get_state(g)
-        np.testing.assert_almost_equal(np.abs(np.dot(gstate.flatten().conjugate(), gstate6.flatten())), 1)
-
-    def test_E1(self):
-        nqubit = 6
-        edges = [(0, 1), (1, 2), (3, 4), (4, 5), (0, 3), (1, 4), (2, 5)]
-        g = GraphState(nodes=np.arange(nqubit), edges=edges, use_rustworkx=True)
-        g.nodes[3]["loop"] = True
-        gstate = get_state(g)
-        g.equivalent_graph_E1(3)
-
-        gstate2 = get_state(g)
-        np.testing.assert_almost_equal(np.abs(np.dot(gstate.flatten().conjugate(), gstate2.flatten())), 1)
-        g.z(4)
-        gstate = get_state(g)
-        g.equivalent_graph_E1(4)
-        gstate2 = get_state(g)
-        np.testing.assert_almost_equal(np.abs(np.dot(gstate.flatten().conjugate(), gstate2.flatten())), 1)
-        g.equivalent_graph_E1(4)
-        gstate3 = get_state(g)
-        np.testing.assert_almost_equal(np.abs(np.dot(gstate.flatten().conjugate(), gstate3.flatten())), 1)
-
-    def test_local_complement(self):
-        nqubit = 6
-        edges = [(0, 1), (1, 2), (2, 3), (3, 4), (4, 0)]
-        exp_edges = [(0, 1), (1, 2), (0, 2), (2, 3), (3, 4), (4, 0)]
-        g = GraphState(nodes=np.arange(nqubit), edges=edges, use_rustworkx=True)
-        g.local_complement(1)
-        exp_g = GraphState(nodes=np.arange(nqubit), edges=exp_edges)
-        self.assertTrue(is_graphs_equal(g, exp_g))
-
-
+@unittest.skipIf(sys.modules.get("rustworkx") is None, "rustworkx not installed")
 class TestGraphSimUtils(unittest.TestCase):
     def test_is_graphs_equal_nx_nx(self):
         nnode = 6

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -1,6 +1,8 @@
+import sys
 import unittest
 
 import numpy as np
+from parameterized import parameterized
 
 import tests.random_circuit as rc
 from graphix.pattern import CommandNode, Pattern
@@ -33,7 +35,10 @@ class TestPattern(unittest.TestCase):
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_minimize_space_with_gflow(self):
+    @parameterized.expand([(False), (True)])
+    def test_minimize_space_with_gflow(self, use_rustworkx):
+        if sys.modules.get("rustworkx") is None and use_rustworkx is True:
+            self.skipTest("rustworkx not installed")
         nqubits = 3
         depth = 3
         pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
@@ -41,7 +46,7 @@ class TestPattern(unittest.TestCase):
         pattern = circuit.transpile()
         pattern.standardize(method="global")
         pattern.shift_signals(method="global")
-        pattern.perform_pauli_measurements()
+        pattern.perform_pauli_measurements(use_rustworkx=use_rustworkx)
         pattern.minimize_space()
         state = circuit.simulate_statevector()
         state_mbqc = pattern.simulate_pattern()
@@ -82,7 +87,10 @@ class TestPattern(unittest.TestCase):
             state_mbqc = pattern.simulate_pattern()
             np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_pauli_measurment(self):
+    @parameterized.expand([(False), (True)])
+    def test_pauli_measurment(self, use_rustworkx):
+        if sys.modules.get("rustworkx") is None and use_rustworkx is True:
+            self.skipTest("rustworkx not installed")
         nqubits = 3
         depth = 3
         for i in range(10):
@@ -90,13 +98,16 @@ class TestPattern(unittest.TestCase):
             pattern = circuit.transpile()
             pattern.standardize(method="global")
             pattern.shift_signals(method="global")
-            pattern.perform_pauli_measurements()
+            pattern.perform_pauli_measurements(use_rustworkx=use_rustworkx)
             pattern.minimize_space()
             state = circuit.simulate_statevector()
             state_mbqc = pattern.simulate_pattern()
             np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_pauli_measurment_leave_input(self):
+    @parameterized.expand([(False), (True)])
+    def test_pauli_measurment_leave_input(self, use_rustworkx):
+        if sys.modules.get("rustworkx") is None and use_rustworkx is True:
+            self.skipTest("rustworkx not installed")
         nqubits = 3
         depth = 3
         for i in range(10):
@@ -104,13 +115,16 @@ class TestPattern(unittest.TestCase):
             pattern = circuit.transpile()
             pattern.standardize(method="global")
             pattern.shift_signals(method="global")
-            pattern.perform_pauli_measurements(leave_input=True)
+            pattern.perform_pauli_measurements(use_rustworkx=use_rustworkx, leave_input=True)
             pattern.minimize_space()
             state = circuit.simulate_statevector()
             state_mbqc = pattern.simulate_pattern()
             np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_pauli_measurment_opt_gate(self):
+    @parameterized.expand([(False), (True)])
+    def test_pauli_measurment_opt_gate(self, use_rustworkx):
+        if sys.modules.get("rustworkx") is None and use_rustworkx is True:
+            self.skipTest("rustworkx not installed")
         nqubits = 3
         depth = 3
         for i in range(10):
@@ -118,13 +132,16 @@ class TestPattern(unittest.TestCase):
             pattern = circuit.transpile(opt=True)
             pattern.standardize(method="global")
             pattern.shift_signals(method="global")
-            pattern.perform_pauli_measurements()
+            pattern.perform_pauli_measurements(use_rustworkx=use_rustworkx)
             pattern.minimize_space()
             state = circuit.simulate_statevector()
             state_mbqc = pattern.simulate_pattern()
             np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_pauli_measurment_opt_gate_transpiler(self):
+    @parameterized.expand([(False), (True)])
+    def test_pauli_measurment_opt_gate_transpiler(self, use_rustworkx):
+        if sys.modules.get("rustworkx") is None and use_rustworkx is True:
+            self.skipTest("rustworkx not installed")
         nqubits = 3
         depth = 3
         for i in range(10):
@@ -132,25 +149,31 @@ class TestPattern(unittest.TestCase):
             pattern = circuit.standardize_and_transpile(opt=True)
             pattern.standardize(method="global")
             pattern.shift_signals(method="global")
-            pattern.perform_pauli_measurements()
+            pattern.perform_pauli_measurements(use_rustworkx=use_rustworkx)
             pattern.minimize_space()
             state = circuit.simulate_statevector()
             state_mbqc = pattern.simulate_pattern()
             np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_pauli_measurment_opt_gate_transpiler_without_signalshift(self):
+    @parameterized.expand([(False), (True)])
+    def test_pauli_measurment_opt_gate_transpiler_without_signalshift(self, use_rustworkx):
+        if sys.modules.get("rustworkx") is None and use_rustworkx is True:
+            self.skipTest("rustworkx not installed")
         nqubits = 3
         depth = 3
         for i in range(10):
             circuit = rc.get_rand_circuit(nqubits, depth, use_rzz=True)
             pattern = circuit.standardize_and_transpile(opt=True)
-            pattern.perform_pauli_measurements()
+            pattern.perform_pauli_measurements(use_rustworkx=use_rustworkx)
             pattern.minimize_space()
             state = circuit.simulate_statevector()
             state_mbqc = pattern.simulate_pattern()
             np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_pauli_measurement(self):
+    @parameterized.expand([(False), (True)])
+    def test_pauli_measurement(self, use_rustworkx):
+        if sys.modules.get("rustworkx") is None and use_rustworkx is True:
+            self.skipTest("rustworkx not installed")
         # test pattern is obtained from 3-qubit QFT with pauli measurement
         circuit = Circuit(3)
         for i in range(3):
@@ -170,7 +193,7 @@ class TestPattern(unittest.TestCase):
         pattern = circuit.transpile()
         pattern.standardize(method="global")
         pattern.shift_signals(method="global")
-        pattern.perform_pauli_measurements()
+        pattern.perform_pauli_measurements(use_rustworkx=use_rustworkx)
 
         isolated_nodes = pattern.get_isolated_nodes()
         # 48-node is the isolated and output node.
@@ -178,7 +201,10 @@ class TestPattern(unittest.TestCase):
 
         np.testing.assert_equal(isolated_nodes, isolated_nodes_ref)
 
-    def test_pauli_measurement_leave_input(self):
+    @parameterized.expand([(False), (True)])
+    def test_pauli_measurement_leave_input(self, use_rustworkx):
+        if sys.modules.get("rustworkx") is None and use_rustworkx is True:
+            self.skipTest("rustworkx not installed")
         # test pattern is obtained from 3-qubit QFT with pauli measurement
         circuit = Circuit(3)
         for i in range(3):
@@ -198,7 +224,7 @@ class TestPattern(unittest.TestCase):
         pattern = circuit.transpile()
         pattern.standardize(method="global")
         pattern.shift_signals(method="global")
-        pattern.perform_pauli_measurements(leave_input=True)
+        pattern.perform_pauli_measurements(use_rustworkx=use_rustworkx, leave_input=True)
 
         isolated_nodes = pattern.get_isolated_nodes()
         # There is no isolated node.
@@ -226,146 +252,6 @@ class TestPattern(unittest.TestCase):
         }
         meas_plane = pattern.get_meas_plane()
         np.testing.assert_equal(meas_plane, ref_meas_plane)
-
-
-class TestPatternWithRustworkX(unittest.TestCase):
-    def test_minimize_space_with_gflow(self):
-        nqubits = 3
-        depth = 3
-        pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
-        circuit = rc.generate_gate(nqubits, depth, pairs)
-        pattern = circuit.transpile()
-        pattern.standardize(method="global")
-        pattern.shift_signals(method="global")
-        pattern.perform_pauli_measurements(use_rustworkx=True)
-        pattern.minimize_space()
-        state = circuit.simulate_statevector()
-        state_mbqc = pattern.simulate_pattern()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
-
-    def test_pauli_measurment(self):
-        nqubits = 3
-        depth = 3
-        for i in range(10):
-            circuit = rc.get_rand_circuit(nqubits, depth)
-            pattern = circuit.transpile()
-            pattern.standardize(method="global")
-            pattern.shift_signals(method="global")
-            pattern.perform_pauli_measurements(use_rustworkx=True)
-            pattern.minimize_space()
-            state = circuit.simulate_statevector()
-            state_mbqc = pattern.simulate_pattern()
-            np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
-
-    def test_pauli_measurment_leave_input(self):
-        nqubits = 3
-        depth = 3
-        for i in range(10):
-            circuit = rc.get_rand_circuit(nqubits, depth)
-            pattern = circuit.transpile()
-            pattern.standardize(method="global")
-            pattern.shift_signals(method="global")
-            pattern.perform_pauli_measurements(use_rustworkx=True, leave_input=True)
-            pattern.minimize_space()
-            state = circuit.simulate_statevector()
-            state_mbqc = pattern.simulate_pattern()
-            np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
-
-    def test_pauli_measurment_opt_gate(self):
-        nqubits = 3
-        depth = 3
-        for i in range(10):
-            circuit = rc.get_rand_circuit(nqubits, depth, use_rzz=True)
-            pattern = circuit.transpile(opt=True)
-            pattern.standardize(method="global")
-            pattern.shift_signals(method="global")
-            pattern.perform_pauli_measurements(use_rustworkx=True)
-            pattern.minimize_space()
-            state = circuit.simulate_statevector()
-            state_mbqc = pattern.simulate_pattern()
-            np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
-
-    def test_pauli_measurment_opt_gate_transpiler(self):
-        nqubits = 3
-        depth = 3
-        for i in range(10):
-            circuit = rc.get_rand_circuit(nqubits, depth, use_rzz=True)
-            pattern = circuit.standardize_and_transpile(opt=True)
-            pattern.standardize(method="global")
-            pattern.shift_signals(method="global")
-            pattern.perform_pauli_measurements(use_rustworkx=True)
-            pattern.minimize_space()
-            state = circuit.simulate_statevector()
-            state_mbqc = pattern.simulate_pattern()
-            np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
-
-    def test_pauli_measurment_opt_gate_transpiler_without_signalshift(self):
-        nqubits = 3
-        depth = 3
-        for i in range(10):
-            circuit = rc.get_rand_circuit(nqubits, depth, use_rzz=True)
-            pattern = circuit.standardize_and_transpile(opt=True)
-            pattern.perform_pauli_measurements(use_rustworkx=True)
-            pattern.minimize_space()
-            state = circuit.simulate_statevector()
-            state_mbqc = pattern.simulate_pattern()
-            np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
-
-    def test_pauli_measurement(self):
-        # test pattern is obtained from 3-qubit QFT with pauli measurement
-        circuit = Circuit(3)
-        for i in range(3):
-            circuit.h(i)
-        circuit.x(1)
-        circuit.x(2)
-
-        # QFT
-        circuit.h(2)
-        cp(circuit, np.pi / 4, 0, 2)
-        cp(circuit, np.pi / 2, 1, 2)
-        circuit.h(1)
-        cp(circuit, np.pi / 2, 0, 1)
-        circuit.h(0)
-        swap(circuit, 0, 2)
-
-        pattern = circuit.transpile()
-        pattern.standardize(method="global")
-        pattern.shift_signals(method="global")
-        pattern.perform_pauli_measurements(use_rustworkx=True)
-
-        isolated_nodes = pattern.get_isolated_nodes()
-        # 48-node is the isolated and output node.
-        isolated_nodes_ref = {48}
-
-        np.testing.assert_equal(isolated_nodes, isolated_nodes_ref)
-
-    def test_pauli_measurement_leave_input(self):
-        # test pattern is obtained from 3-qubit QFT with pauli measurement
-        circuit = Circuit(3)
-        for i in range(3):
-            circuit.h(i)
-        circuit.x(1)
-        circuit.x(2)
-
-        # QFT
-        circuit.h(2)
-        cp(circuit, np.pi / 4, 0, 2)
-        cp(circuit, np.pi / 2, 1, 2)
-        circuit.h(1)
-        cp(circuit, np.pi / 2, 0, 1)
-        circuit.h(0)
-        swap(circuit, 0, 2)
-
-        pattern = circuit.transpile()
-        pattern.standardize(method="global")
-        pattern.shift_signals(method="global")
-        pattern.perform_pauli_measurements(use_rustworkx=True, leave_input=True)
-
-        isolated_nodes = pattern.get_isolated_nodes()
-        # There is no isolated node.
-        isolated_nodes_ref = set()
-
-        np.testing.assert_equal(isolated_nodes, isolated_nodes_ref)
 
 
 def cp(circuit, theta, control, target):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3,8 +3,12 @@ import unittest
 from unittest.mock import MagicMock
 
 import numpy as np
-import qiskit
-from qiskit_aer import Aer
+
+try:
+    import qiskit
+    from qiskit_aer import Aer
+except ModuleNotFoundError:
+    pass
 
 import graphix
 from graphix.device_interface import PatternRunner
@@ -28,6 +32,7 @@ def modify_statevector(statevector, output_qubit):
 
 
 class TestPatternRunner(unittest.TestCase):
+    @unittest.skipIf(sys.modules.get("qiskit") is None, "qiskit not installed")
     def test_ibmq_backend(self):
         # circuit in qiskit
         qc = qiskit.QuantumCircuit(3)

--- a/tox.ini
+++ b/tox.ini
@@ -1,36 +1,29 @@
 [tox]
-envlist = py{38,39,310,311}, lint, with_rustworkx-py{38,39,310,311}
+envlist = py{38,39,310,311}, minimum-deps-py{38,39,310,311}, lint
 
 [gh-actions]
 python =
-    3.8: lint, py38, with_rustworkx-py38
-    3.9: py39, with_rustworkx-py39
-    3.10: py310, with_rustworkx-py310
-    3.11: py311, with_rustworkx-py311
+    3.8: lint, py38, minimum-deps-py38
+    3.9: py39, minimum-deps-py39
+    3.10: py310, minimum-deps-py310
+    3.11: py311, minimum-deps-py311
 
 [testenv]
 description = Run the unit tests
 deps =
     -r {toxinidir}/requirements.txt
-    qiskit
-    qiskit-aer
-    pytest
+    -r {toxinidir}/requirements-dev.txt
 commands =
     pytest {toxinidir}
 
-[testenv:with_rustworkx-py{38,39,310,311}]
-description = Run the unit tests without rustworkx
+[testenv:minimum-deps-py{38,39,310,311}]
+description = Run the unit tests with minimum dependencies
 deps =
     -r {toxinidir}/requirements.txt
-    qiskit
-    qiskit-aer
-    rustworkx
     pytest
-
+    parameterized
 commands =
-    pytest {toxinidir}/tests/test_graphsim.py::TestGraphSimWithRustworkX \
-    {toxinidir}/tests/test_pattern.py::TestPatternWithRustworkX \
-    {toxinidir}/tests/test_extraction.py::TestExtractionWithRustworkX
+    pytest {toxinidir}
 
 [testenv:lint]
 description = Run lint checker


### PR DESCRIPTION
**Description of the change:**
- Use `parameterized` to parameterize the test.
  - I used to copy tests to test the graph simulator in both `networkx` and `rustworkx`, but copying is no longer necessary with parameterized tests.
- Added `requirements-dev.txt`
  - `requirements.txt` will install the necessary libraries, and `requirements-dev.txt` will install optional libraries and libraries for testing.