### PR TITLE
Gflow from pattern

### DIFF
--- a/graphix/gflow.py
+++ b/graphix/gflow.py
@@ -19,7 +19,7 @@ import sympy as sp
 from graphix.linalg import MatGF2
 
 
-def gflow(graph, input, output, meas_planes, mode="single", pattern=None):
+def gflow(graph, input, output, meas_planes, mode="single"):
     """Maximally delayed gflow finding algorithm
 
     For open graph g with input, output, and measurement planes, this returns maximally delayed gflow.
@@ -47,7 +47,6 @@ def gflow(graph, input, output, meas_planes, mode="single", pattern=None):
     mode: str(optional)
         The gflow finding algorithm can yield multiple equivalent solutions. So there are three options
             - "single": Returrns a single solution
-            - "pattern": Returns a single solution consistent with a given pattern
             - "all": Returns all possible solutions
             - "abstract": Returns an abstract solution. Uncertainty is represented with sympy.Symbol objects,
               requiring user substitution to get a concrete answer.
@@ -63,10 +62,6 @@ def gflow(graph, input, output, meas_planes, mode="single", pattern=None):
     l_k: dict
         layers obtained by gflow algorithm. l_k[d] is a node set of depth d.
     """
-    if mode == "pattern":
-        if pattern is None:
-            raise ValueError("pattern must be specified when mode is pattern")
-        g, l_k = gflow_from_pattern(pattern)
     l_k = dict()
     g = dict()
     for node in graph.nodes:

--- a/graphix/gflow.py
+++ b/graphix/gflow.py
@@ -212,16 +212,16 @@ def gflowaux(
             g,
             mode=mode,
         )
-        
-        
+
+
 def gflow_from_pattern(pattern):
     """Get gflow from pattern
-    
+
     Parameters
     ----------
     pattern: graphix.Pattern object
         pattern to be based on
-    
+
     Returns
     -------
     g: dict
@@ -241,9 +241,9 @@ def gflow_from_pattern(pattern):
         l_k[node] = lmax - l_k[node] + 1
     for output_node in pattern.output_nodes:
         l_k[output_node] = 0
-    g = dict() 
+    g = dict()
     for cmd in pattern.seq:
-        if cmd[0] == 'M':
+        if cmd[0] == "M":
             g_in = cmd[1]
             g_outs = set(cmd[2]) & nodes
             for g_out in g_outs:
@@ -251,7 +251,7 @@ def gflow_from_pattern(pattern):
                     g[g_out] = g[g_out].union({g_in})
                 else:
                     g[g_out] = {g_in}
-        if cmd[0] == 'X':
+        if cmd[0] == "X":
             g_in = cmd[1]
             g_outs = set(cmd[2]) & nodes
             for g_out in g_outs:
@@ -259,7 +259,7 @@ def gflow_from_pattern(pattern):
                     g[g_out] = g[g_out].union({g_in})
                 else:
                     g[g_out] = {g_in}
-                    
+
     return g, l_k
 
 

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -1234,9 +1234,11 @@ class Pattern:
         self,
         node_distance=(1, 1),
         figsize=None,
+        gflow_from_pattern=False,
         pauli_indicator=True,
         show_loop=True,
         local_clifford_indicator=False,
+        meas_plane_indicator=False,
         save=False,
         filename=None,
     ):
@@ -1248,12 +1250,16 @@ class Pattern:
             Distance multiplication factor between nodes for x and y directions.
         figsize : tuple
             Figure size of the plot.
+        gflow_from_pattern : bool
+            If True, the gflow is calculated based on the pattern.
         pauli_indicator : bool
             If True, the nodes are colored according to the measurement angles.
         show_loop : bool
             whether or not to show loops for graphs with gflow. defaulted to True.
         local_clifford_indicator : bool
             If True, indexes of the local Clifford operator are displayed adjacent to the nodes.
+        meas_plane_indicator : bool
+            If True, measurement planes are displayed adjacent to the nodes.
         save : bool
             If True, the plot is saved as a png file.
         filename : str
@@ -1272,6 +1278,10 @@ class Pattern:
             angles = self.get_angles()
         else:
             angles = None
+        if gflow_from_pattern:
+            pattern = deepcopy(self)
+        else:
+            pattern = None
         if local_clifford_indicator:
             local_clifford = self.get_vops()
         else:
@@ -1280,7 +1290,9 @@ class Pattern:
             node_distance=node_distance,
             figsize=figsize,
             angles=angles,
+            pattern_for_gflow=pattern,
             local_clifford=local_clifford,
+            meas_plane_indicator=meas_plane_indicator,
             show_loop=show_loop,
             save=save,
             filename=filename,

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -1234,7 +1234,7 @@ class Pattern:
         self,
         node_distance=(1, 1),
         figsize=None,
-        gflow_from_pattern=False,
+        gflow_from_pattern=True,
         pauli_indicator=True,
         show_loop=True,
         local_clifford_indicator=False,

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -1238,7 +1238,7 @@ class Pattern:
         pauli_indicator=True,
         show_loop=True,
         local_clifford_indicator=False,
-        meas_plane_indicator=False,
+        show_measurement_planes=False,
         save=False,
         filename=None,
     ):
@@ -1258,7 +1258,7 @@ class Pattern:
             whether or not to show loops for graphs with gflow. defaulted to True.
         local_clifford_indicator : bool
             If True, indexes of the local Clifford operator are displayed adjacent to the nodes.
-        meas_plane_indicator : bool
+        show_measurement_planes : bool
             If True, measurement planes are displayed adjacent to the nodes.
         save : bool
             If True, the plot is saved as a png file.
@@ -1292,7 +1292,7 @@ class Pattern:
             angles=angles,
             pattern_for_gflow=pattern,
             local_clifford=local_clifford,
-            meas_plane_indicator=meas_plane_indicator,
+            show_measurement_planes=show_measurement_planes,
             show_loop=show_loop,
             save=save,
             filename=filename,

--- a/graphix/visualization.py
+++ b/graphix/visualization.py
@@ -1,4 +1,8 @@
 from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from graphix.pattern import Pattern
 
 import numpy as np
 from matplotlib import pyplot as plt
@@ -46,7 +50,7 @@ class GraphVisualizer:
     def visualize(
         self,
         angles: dict[int, float] | None = None,
-        pattern_for_gflow: graphix.Pattern | None = None,
+        pattern_for_gflow: Pattern | None = None,
         local_clifford: dict[int, int] | None = None,
         meas_plane_indicator: bool = False,
         node_distance: tuple[int, int] = (1, 1),

--- a/graphix/visualization.py
+++ b/graphix/visualization.py
@@ -44,7 +44,9 @@ class GraphVisualizer:
     def visualize(
         self,
         angles=None,
+        pattern_for_gflow=None,
         local_clifford=None,
+        meas_plane_indicator=False,
         node_distance=(1, 1),
         show_loop=True,
         figsize=None,
@@ -63,9 +65,13 @@ class GraphVisualizer:
         angles : dict
             Measurement angles for each nodes on the graph (unit of pi), except output nodes.
             If not None, the nodes with Pauli measurement angles are colored light blue.
+        pattern_for_gflow : graphix.Pattern object
+            If not None, gflow is found from the pattern.
         local_clifford : dict
             Indexes of local clifford operations for each nodes.
             If not None, indexes of the local Clifford operator are displayed adjacent to the nodes.
+        meas_plane_indicator : bool
+            If True, the measurement planes are displayed adjacent to the nodes.
         show_loop : bool
             whether or not to show loops for graphs with gflow. defaulted to True.
         node_distance : tuple
@@ -81,20 +87,27 @@ class GraphVisualizer:
         f, l_k = gflow.flow(self.G, set(self.v_in), set(self.v_out), meas_planes=self.meas_plane)
         if f:
             print("Flow found.")
-            self.visualize_w_flow(f, l_k, angles, local_clifford, node_distance, figsize, save, filename)
+            self.visualize_w_flow(f, l_k, angles, local_clifford, meas_plane_indicator, node_distance, figsize, save, filename)
         else:
-            g, l_k = gflow.gflow(self.G, set(self.v_in), set(self.v_out), self.meas_plane)
-            if g:
+            if pattern_for_gflow is not None:
+                g, l_k = gflow.gflow_from_pattern(pattern_for_gflow)
                 print("No flow found. Gflow found.")
                 self.visualize_w_gflow(
-                    g, l_k, angles, local_clifford, node_distance, show_loop, figsize, save, filename
+                    g, l_k, angles, local_clifford, meas_plane_indicator, node_distance, show_loop, figsize, save, filename
                 )
             else:
-                print("No flow or gflow found.")
-                self.visualize_wo_structure(angles, local_clifford, node_distance, save, filename)
+                g, l_k = gflow.gflow(self.G, set(self.v_in), set(self.v_out), self.meas_plane)
+                if g:
+                    print("No flow found. Gflow found.")
+                    self.visualize_w_gflow(
+                        g, l_k, angles, local_clifford, meas_plane_indicator, node_distance, show_loop, figsize, save, filename
+                    )
+                else:
+                    print("No flow or gflow found.")
+                    self.visualize_wo_structure(angles, local_clifford, meas_plane_indicator, node_distance, save, filename)
 
     def visualize_w_flow(
-        self, f, l_k, angles=None, local_clifford=None, node_distance=(1, 1), figsize=None, save=False, filename=None
+        self, f, l_k, angles=None, local_clifford=None, meas_plane_indicator=False, node_distance=(1, 1), figsize=None, save=False, filename=None
     ):
         """
         visualizes the graph with flow structure.
@@ -116,6 +129,8 @@ class GraphVisualizer:
         local_clifford : dict
             Indexes of local clifford operations for each nodes.
             If not None, indexes of the local Clifford operator are displayed adjacent to the nodes.
+        meas_plane_indicator : bool
+            If True, the measurement planes are displayed adjacent to the nodes.
         node_distance : tuple
             Distance multiplication factor between nodes for x and y directions.
         figsize : tuple
@@ -170,6 +185,11 @@ class GraphVisualizer:
             for node in self.G.nodes():
                 if node in local_clifford.keys():
                     plt.text(*pos[node] + np.array([0.2, 0.2]), f"{local_clifford[node]}", fontsize=10, zorder=3)
+                    
+        if meas_plane_indicator:
+            for node in self.G.nodes():
+                if node in self.meas_plane.keys():
+                    plt.text(*pos[node] + np.array([0.22, -0.2]), f"{self.meas_plane[node]}", fontsize=9, zorder=3)
 
         # Draw the labels
         fontsize = 12
@@ -206,6 +226,7 @@ class GraphVisualizer:
         l_k,
         angles=None,
         local_clifford=None,
+        meas_plane_indicator=False,
         node_distance=(1, 1),
         show_loop=True,
         figsize=None,
@@ -232,6 +253,8 @@ class GraphVisualizer:
         local_clifford : dict
             Indexes of local clifford operations for each nodes.
             If not None, indexes of the local Clifford operator are displayed adjacent to the nodes.
+        meas_plane_indicator : bool
+            If True, the measurement planes are displayed adjacent to the nodes.
         node_distance : tuple
             Distance multiplication factor between nodes for x and y directions.
         show_loop : bool
@@ -314,6 +337,11 @@ class GraphVisualizer:
             for node in self.G.nodes():
                 if node in local_clifford.keys():
                     plt.text(*pos[node] + np.array([0.2, 0.2]), f"{local_clifford[node]}", fontsize=10, zorder=3)
+                    
+        if meas_plane_indicator:
+            for node in self.G.nodes():
+                if node in self.meas_plane.keys():
+                    plt.text(*pos[node] + np.array([0.22, -0.2]), f"{self.meas_plane[node]}", fontsize=9, zorder=3)
 
         # Draw the labels
         fontsize = 12
@@ -344,7 +372,7 @@ class GraphVisualizer:
             plt.savefig(filename)
         plt.show()
 
-    def visualize_wo_structure(self, angles=None, local_clifford=None, node_distance=(1, 1), save=False, filename=None):
+    def visualize_wo_structure(self, angles=None, local_clifford=None, meas_plane_indicator=False, node_distance=(1, 1), save=False, filename=None):
         """
         visualizes the graph without flow or gflow.
 
@@ -365,6 +393,8 @@ class GraphVisualizer:
         local_clifford : dict
             Indexes of local clifford operations for each nodes.
             If not None, indexes of the local Clifford operator are displayed adjacent to the nodes.
+        meas_plane_indicator : bool
+            If True, the measurement planes are displayed adjacent to the nodes.
         node_distance : tuple
             Distance multiplication factor between nodes for x and y directions.
         figsize : tuple
@@ -402,6 +432,11 @@ class GraphVisualizer:
             for node in self.G.nodes():
                 if node in local_clifford.keys():
                     plt.text(*pos[node] + np.array([0.04, 0.04]), f"{local_clifford[node]}", fontsize=10, zorder=3)
+                    
+        if meas_plane_indicator:
+            for node in self.G.nodes():
+                if node in self.meas_plane.keys():
+                    plt.text(*pos[node] + np.array([0.05, -0.04]), f"{self.meas_plane[node]}", fontsize=9, zorder=3)
 
         # Draw the labels
         fontsize = 12

--- a/graphix/visualization.py
+++ b/graphix/visualization.py
@@ -544,8 +544,11 @@ class GraphVisualizer:
         max_iter = 5
         edge_path = {}
         if type(next(iter(fg.values()))) is set:  # fg is gflow
-            edge_set1 = set(self.G.edges())
-            edge_set2 = {(k, v) for k, values in fg.items() for v in values}
+            edge_set1 = {(k, v) for k, values in fg.items() for v in values}
+            edge_set2 = set()
+            for edge in self.G.edges():
+                if edge not in edge_set1 and (edge[1], edge[0]) not in edge_set1:
+                    edge_set2.add(edge)
             edge_set = edge_set1.union(edge_set2)
         else:
             edge_set = set(self.G.edges())

--- a/graphix/visualization.py
+++ b/graphix/visualization.py
@@ -52,7 +52,7 @@ class GraphVisualizer:
         angles: dict[int, float] | None = None,
         pattern_for_gflow: Pattern | None = None,
         local_clifford: dict[int, int] | None = None,
-        meas_plane_indicator: bool = False,
+        show_measurement_planes: bool = False,
         node_distance: tuple[int, int] = (1, 1),
         show_loop: bool = True,
         figsize: tuple[int, int] | None = None,
@@ -76,7 +76,7 @@ class GraphVisualizer:
         local_clifford : dict
             Indexes of local clifford operations for each nodes.
             If not None, indexes of the local Clifford operator are displayed adjacent to the nodes.
-        meas_plane_indicator : bool
+        show_measurement_planes : bool
             If True, the measurement planes are displayed adjacent to the nodes.
         show_loop : bool
             whether or not to show loops for graphs with gflow. defaulted to True.
@@ -94,7 +94,7 @@ class GraphVisualizer:
         if f:
             print("Flow found.")
             self.visualize_w_flow(
-                f, l_k, angles, local_clifford, meas_plane_indicator, node_distance, figsize, save, filename
+                f, l_k, angles, local_clifford, show_measurement_planes, node_distance, figsize, save, filename
             )
         else:
             if pattern_for_gflow is not None:
@@ -105,7 +105,7 @@ class GraphVisualizer:
                     l_k,
                     angles,
                     local_clifford,
-                    meas_plane_indicator,
+                    show_measurement_planes,
                     node_distance,
                     show_loop,
                     figsize,
@@ -121,7 +121,7 @@ class GraphVisualizer:
                         l_k,
                         angles,
                         local_clifford,
-                        meas_plane_indicator,
+                        show_measurement_planes,
                         node_distance,
                         show_loop,
                         figsize,
@@ -131,7 +131,7 @@ class GraphVisualizer:
                 else:
                     print("No flow or gflow found.")
                     self.visualize_wo_structure(
-                        angles, local_clifford, meas_plane_indicator, node_distance, save, filename
+                        angles, local_clifford, show_measurement_planes, node_distance, save, filename
                     )
 
     def visualize_w_flow(
@@ -140,7 +140,7 @@ class GraphVisualizer:
         l_k: dict[int, int],
         angles: dict[int, float] | None = None,
         local_clifford: dict[int, int] | None = None,
-        meas_plane_indicator: bool = False,
+        show_measurement_planes: bool = False,
         node_distance: tuple[int, int] = (1, 1),
         figsize: tuple[int, int] | None = None,
         save: bool = False,
@@ -166,7 +166,7 @@ class GraphVisualizer:
         local_clifford : dict
             Indexes of local clifford operations for each nodes.
             If not None, indexes of the local Clifford operator are displayed adjacent to the nodes.
-        meas_plane_indicator : bool
+        show_measurement_planes : bool
             If True, the measurement planes are displayed adjacent to the nodes.
         node_distance : tuple
             Distance multiplication factor between nodes for x and y directions.
@@ -223,7 +223,7 @@ class GraphVisualizer:
                 if node in local_clifford.keys():
                     plt.text(*pos[node] + np.array([0.2, 0.2]), f"{local_clifford[node]}", fontsize=10, zorder=3)
 
-        if meas_plane_indicator:
+        if show_measurement_planes:
             for node in self.G.nodes():
                 if node in self.meas_plane.keys():
                     plt.text(*pos[node] + np.array([0.22, -0.2]), f"{self.meas_plane[node]}", fontsize=9, zorder=3)
@@ -263,7 +263,7 @@ class GraphVisualizer:
         l_k: dict[int, int],
         angles: dict[int, float] | None = None,
         local_clifford: dict[int, int] | None = None,
-        meas_plane_indicator: bool = False,
+        show_measurement_planes: bool = False,
         node_distance: tuple[int, int] = (1, 1),
         show_loop: bool = True,
         figsize: tuple[int, int] | None = None,
@@ -290,7 +290,7 @@ class GraphVisualizer:
         local_clifford : dict
             Indexes of local clifford operations for each nodes.
             If not None, indexes of the local Clifford operator are displayed adjacent to the nodes.
-        meas_plane_indicator : bool
+        show_measurement_planes : bool
             If True, the measurement planes are displayed adjacent to the nodes.
         node_distance : tuple
             Distance multiplication factor between nodes for x and y directions.
@@ -375,7 +375,7 @@ class GraphVisualizer:
                 if node in local_clifford.keys():
                     plt.text(*pos[node] + np.array([0.2, 0.2]), f"{local_clifford[node]}", fontsize=10, zorder=3)
 
-        if meas_plane_indicator:
+        if show_measurement_planes:
             for node in self.G.nodes():
                 if node in self.meas_plane.keys():
                     plt.text(*pos[node] + np.array([0.22, -0.2]), f"{self.meas_plane[node]}", fontsize=9, zorder=3)
@@ -413,7 +413,7 @@ class GraphVisualizer:
         self,
         angles: dict[int, float] | None = None,
         local_clifford: dict[int, int] | None = None,
-        meas_plane_indicator: bool = False,
+        show_measurement_planes: bool = False,
         node_distance: tuple[int, int] = (1, 1),
         save: bool = False,
         filename: str | None = None,
@@ -438,7 +438,7 @@ class GraphVisualizer:
         local_clifford : dict
             Indexes of local clifford operations for each nodes.
             If not None, indexes of the local Clifford operator are displayed adjacent to the nodes.
-        meas_plane_indicator : bool
+        show_measurement_planes : bool
             If True, the measurement planes are displayed adjacent to the nodes.
         node_distance : tuple
             Distance multiplication factor between nodes for x and y directions.
@@ -478,7 +478,7 @@ class GraphVisualizer:
                 if node in local_clifford.keys():
                     plt.text(*pos[node] + np.array([0.04, 0.04]), f"{local_clifford[node]}", fontsize=10, zorder=3)
 
-        if meas_plane_indicator:
+        if show_measurement_planes:
             for node in self.G.nodes():
                 if node in self.meas_plane.keys():
                     plt.text(*pos[node] + np.array([0.05, -0.04]), f"{self.meas_plane[node]}", fontsize=9, zorder=3)

--- a/graphix/visualization.py
+++ b/graphix/visualization.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 from matplotlib import pyplot as plt
 import math
@@ -19,7 +21,7 @@ class GraphVisualizer:
         list of output nodes
     """
 
-    def __init__(self, G, v_in, v_out, meas_plane=None):
+    def __init__(self, G: nx.Graph, v_in: list[int], v_out: list[int], meas_plane: dict[str] | None = None):
         """
         Parameters
         ----------
@@ -43,15 +45,15 @@ class GraphVisualizer:
 
     def visualize(
         self,
-        angles=None,
-        pattern_for_gflow=None,
-        local_clifford=None,
-        meas_plane_indicator=False,
-        node_distance=(1, 1),
-        show_loop=True,
-        figsize=None,
-        save=False,
-        filename=None,
+        angles: dict[int, float] | None = None,
+        pattern_for_gflow: graphix.Pattern | None = None,
+        local_clifford: dict[int, int] | None = None,
+        meas_plane_indicator: bool = False,
+        node_distance: tuple[int, int] = (1, 1),
+        show_loop: bool = True,
+        figsize: tuple[int, int] | None = None,
+        save: bool = False,
+        filename: str | None = None,
     ):
         """
         Visualizes the graph with flow or gflow structure.
@@ -130,15 +132,15 @@ class GraphVisualizer:
 
     def visualize_w_flow(
         self,
-        f,
-        l_k,
-        angles=None,
-        local_clifford=None,
-        meas_plane_indicator=False,
-        node_distance=(1, 1),
-        figsize=None,
-        save=False,
-        filename=None,
+        f: dict[int, int],
+        l_k: dict[int, int],
+        angles: dict[int, float] | None = None,
+        local_clifford: dict[int, int] | None = None,
+        meas_plane_indicator: bool = False,
+        node_distance: tuple[int, int] = (1, 1),
+        figsize: tuple[int, int] | None = None,
+        save: bool = False,
+        filename: str | None = None,
     ):
         """
         visualizes the graph with flow structure.
@@ -195,7 +197,7 @@ class GraphVisualizer:
                     nx.draw_networkx_edges(self.G, pos, edgelist=[edge], style="dashed", alpha=0.7)
                 else:
                     t = np.linspace(0, 1, 100)
-                    curve = self.bezier_curve(edge_path[edge], t)
+                    curve = self._bezier_curve(edge_path[edge], t)
                     plt.plot(curve[:, 0], curve[:, 1], "k--", linewidth=1, alpha=0.7)
 
         # Draw the nodes with different colors based on their role (input, output, or other)
@@ -253,16 +255,16 @@ class GraphVisualizer:
 
     def visualize_w_gflow(
         self,
-        g,
-        l_k,
-        angles=None,
-        local_clifford=None,
-        meas_plane_indicator=False,
-        node_distance=(1, 1),
-        show_loop=True,
-        figsize=None,
-        save=False,
-        filename=None,
+        g: dict[int, set[int]],
+        l_k: dict[int, int],
+        angles: dict[int, float] | None = None,
+        local_clifford: dict[int, int] | None = None,
+        meas_plane_indicator: bool = False,
+        node_distance: tuple[int, int] = (1, 1),
+        show_loop: bool = True,
+        figsize: tuple[int, int] | None = None,
+        save: bool = False,
+        filename: str | None = None,
     ):
         """
         visualizes the graph with flow structure.
@@ -312,7 +314,7 @@ class GraphVisualizer:
                 if edge[0] == edge[1]:  # self loop
                     if show_loop:
                         t = np.linspace(0, 1, 100)
-                        curve = self.bezier_curve(edge_path[edge], t)
+                        curve = self._bezier_curve(edge_path[edge], t)
                         plt.plot(curve[:, 0], curve[:, 1], c="k", linewidth=1)
                         plt.annotate(
                             "",
@@ -333,7 +335,7 @@ class GraphVisualizer:
                     )  # Shorten the last edge not to hide arrow under the node
 
                     t = np.linspace(0, 1, 100)
-                    curve = self.bezier_curve(path, t)
+                    curve = self._bezier_curve(path, t)
 
                     plt.plot(curve[:, 0], curve[:, 1], c="k", linewidth=1)
                     plt.annotate(
@@ -347,7 +349,7 @@ class GraphVisualizer:
                     nx.draw_networkx_edges(self.G, pos, edgelist=[edge], style="dashed", alpha=0.7)
                 else:
                     t = np.linspace(0, 1, 100)
-                    curve = self.bezier_curve(edge_path[edge], t)
+                    curve = self._bezier_curve(edge_path[edge], t)
                     plt.plot(curve[:, 0], curve[:, 1], "k--", linewidth=1, alpha=0.7)
 
         # Draw the nodes with different colors based on their role (input, output, or other)
@@ -405,12 +407,12 @@ class GraphVisualizer:
 
     def visualize_wo_structure(
         self,
-        angles=None,
-        local_clifford=None,
-        meas_plane_indicator=False,
-        node_distance=(1, 1),
-        save=False,
-        filename=None,
+        angles: dict[int, float] | None = None,
+        local_clifford: dict[int, int] | None = None,
+        meas_plane_indicator: bool = False,
+        node_distance: tuple[int, int] = (1, 1),
+        save: bool = False,
+        filename: str | None = None,
     ):
         """
         visualizes the graph without flow or gflow.
@@ -487,7 +489,12 @@ class GraphVisualizer:
             plt.savefig(filename)
         plt.show()
 
-    def get_figsize(self, l_k, pos=None, node_distance=(1, 1)):
+    def get_figsize(
+        self,
+        l_k: dict[int, int],
+        pos: dict[int, tuple[float, float]] | None = None,
+        node_distance: tuple[int, int] = (1, 1),
+    ) -> tuple[int, int]:
         """
         Returns the figure size of the graph.
 
@@ -495,6 +502,10 @@ class GraphVisualizer:
         ----------
         l_k : dict
             Layer mapping.
+        pos : dict
+            dictionary of node positions.
+        node_distance : tuple
+            Distance multiplication factor between nodes for x and y directions.
 
         Returns
         -------
@@ -510,7 +521,7 @@ class GraphVisualizer:
 
         return figsize
 
-    def get_edge_path(self, fg, pos):
+    def get_edge_path(self, fg: dict[int, int | set[int]], pos: dict[int, tuple[float, float]]) -> dict[int, list]:
         """
         Returns the path of edges.
 
@@ -567,12 +578,16 @@ class GraphVisualizer:
                         start = bezier_path[i]
                         end = bezier_path[i + 1]
                         for node in nodes:
-                            if node != edge[0] and node != edge[1] and self.edge_intersects_node(start, end, pos[node]):
+                            if (
+                                node != edge[0]
+                                and node != edge[1]
+                                and self._edge_intersects_node(start, end, pos[node])
+                            ):
                                 intersect = True
                                 ctrl_points.append(
                                     [
                                         i,
-                                        self.control_point(
+                                        self._control_point(
                                             bezier_path[0], bezier_path[-1], pos[node], distance=0.6 / iteration
                                         ),
                                     ]
@@ -583,12 +598,12 @@ class GraphVisualizer:
                     else:
                         for i, ctrl_point in enumerate(ctrl_points):
                             bezier_path.insert(ctrl_point[0] + i + 1, ctrl_point[1])
-            bezier_path = self.check_path(bezier_path)
+            bezier_path = self._check_path(bezier_path)
             edge_path[edge] = bezier_path
 
         return edge_path
 
-    def get_pos_from_flow(self, f, l_k):
+    def get_pos_from_flow(self, f: dict[int, int], l_k: dict[int, int]) -> dict[int, tuple[float, float]]:
         """
         Returns the position of nodes based on the flow.
 
@@ -619,9 +634,16 @@ class GraphVisualizer:
             pos[node][0] = lmax - layer
         return pos
 
-    def get_pos_from_gflow(self, g, l_k):
+    def get_pos_from_gflow(self, g: dict[int, set[int]], l_k: dict[int, int]) -> dict[int, tuple[float, float]]:
         """
         Returns the position of nodes based on the gflow.
+
+        Parameters
+        ----------
+        g : dict
+            gflow mapping.
+        l_k : dict
+            Layer mapping.
 
         Returns
         -------
@@ -657,7 +679,7 @@ class GraphVisualizer:
         return pos
 
     @staticmethod
-    def edge_intersects_node(start, end, node_pos, buffer=0.2):
+    def _edge_intersects_node(start, end, node_pos, buffer=0.2):
         """
         Determine if an edge intersects a node.
         """
@@ -681,7 +703,7 @@ class GraphVisualizer:
         return distance < buffer
 
     @staticmethod
-    def control_point(start, end, node_pos, distance=0.6):
+    def _control_point(start, end, node_pos, distance=0.6):
         """
         Generate a control point to bend the edge around a node.
         """
@@ -697,7 +719,7 @@ class GraphVisualizer:
         return control.tolist()
 
     @staticmethod
-    def bezier_curve(bezier_path, t):
+    def _bezier_curve(bezier_path, t):
         """
         Generate a bezier curve from a list of points.
         """
@@ -707,7 +729,7 @@ class GraphVisualizer:
             curve += np.outer(comb(n, i) * ((1 - t) ** (n - i)) * (t**i), np.array(point))
         return curve
 
-    def check_path(self, path):
+    def _check_path(self, path):
         """
         if there is an acute angle in the path, merge points
         """
@@ -738,4 +760,7 @@ class GraphVisualizer:
 
 
 def comb(n, r):
+    """
+    returns the binomial coefficient of n and r.
+    """
     return math.factorial(n) // (math.factorial(n - r) * math.factorial(r))

--- a/graphix/visualization.py
+++ b/graphix/visualization.py
@@ -87,27 +87,58 @@ class GraphVisualizer:
         f, l_k = gflow.flow(self.G, set(self.v_in), set(self.v_out), meas_planes=self.meas_plane)
         if f:
             print("Flow found.")
-            self.visualize_w_flow(f, l_k, angles, local_clifford, meas_plane_indicator, node_distance, figsize, save, filename)
+            self.visualize_w_flow(
+                f, l_k, angles, local_clifford, meas_plane_indicator, node_distance, figsize, save, filename
+            )
         else:
             if pattern_for_gflow is not None:
                 g, l_k = gflow.gflow_from_pattern(pattern_for_gflow)
                 print("No flow found. Gflow found.")
                 self.visualize_w_gflow(
-                    g, l_k, angles, local_clifford, meas_plane_indicator, node_distance, show_loop, figsize, save, filename
+                    g,
+                    l_k,
+                    angles,
+                    local_clifford,
+                    meas_plane_indicator,
+                    node_distance,
+                    show_loop,
+                    figsize,
+                    save,
+                    filename,
                 )
             else:
                 g, l_k = gflow.gflow(self.G, set(self.v_in), set(self.v_out), self.meas_plane)
                 if g:
                     print("No flow found. Gflow found.")
                     self.visualize_w_gflow(
-                        g, l_k, angles, local_clifford, meas_plane_indicator, node_distance, show_loop, figsize, save, filename
+                        g,
+                        l_k,
+                        angles,
+                        local_clifford,
+                        meas_plane_indicator,
+                        node_distance,
+                        show_loop,
+                        figsize,
+                        save,
+                        filename,
                     )
                 else:
                     print("No flow or gflow found.")
-                    self.visualize_wo_structure(angles, local_clifford, meas_plane_indicator, node_distance, save, filename)
+                    self.visualize_wo_structure(
+                        angles, local_clifford, meas_plane_indicator, node_distance, save, filename
+                    )
 
     def visualize_w_flow(
-        self, f, l_k, angles=None, local_clifford=None, meas_plane_indicator=False, node_distance=(1, 1), figsize=None, save=False, filename=None
+        self,
+        f,
+        l_k,
+        angles=None,
+        local_clifford=None,
+        meas_plane_indicator=False,
+        node_distance=(1, 1),
+        figsize=None,
+        save=False,
+        filename=None,
     ):
         """
         visualizes the graph with flow structure.
@@ -185,7 +216,7 @@ class GraphVisualizer:
             for node in self.G.nodes():
                 if node in local_clifford.keys():
                     plt.text(*pos[node] + np.array([0.2, 0.2]), f"{local_clifford[node]}", fontsize=10, zorder=3)
-                    
+
         if meas_plane_indicator:
             for node in self.G.nodes():
                 if node in self.meas_plane.keys():
@@ -337,7 +368,7 @@ class GraphVisualizer:
             for node in self.G.nodes():
                 if node in local_clifford.keys():
                     plt.text(*pos[node] + np.array([0.2, 0.2]), f"{local_clifford[node]}", fontsize=10, zorder=3)
-                    
+
         if meas_plane_indicator:
             for node in self.G.nodes():
                 if node in self.meas_plane.keys():
@@ -372,7 +403,15 @@ class GraphVisualizer:
             plt.savefig(filename)
         plt.show()
 
-    def visualize_wo_structure(self, angles=None, local_clifford=None, meas_plane_indicator=False, node_distance=(1, 1), save=False, filename=None):
+    def visualize_wo_structure(
+        self,
+        angles=None,
+        local_clifford=None,
+        meas_plane_indicator=False,
+        node_distance=(1, 1),
+        save=False,
+        filename=None,
+    ):
         """
         visualizes the graph without flow or gflow.
 
@@ -432,7 +471,7 @@ class GraphVisualizer:
             for node in self.G.nodes():
                 if node in local_clifford.keys():
                     plt.text(*pos[node] + np.array([0.04, 0.04]), f"{local_clifford[node]}", fontsize=10, zorder=3)
-                    
+
         if meas_plane_indicator:
             for node in self.G.nodes():
                 if node in self.meas_plane.keys():

--- a/graphix/visualization.py
+++ b/graphix/visualization.py
@@ -25,7 +25,7 @@ class GraphVisualizer:
         list of output nodes
     """
 
-    def __init__(self, G: nx.Graph, v_in: list[int], v_out: list[int], meas_plane: dict[str] | None = None):
+    def __init__(self, G: nx.Graph, v_in: list[int], v_out: list[int], meas_plane: dict[int, str] | None = None):
         """
         Parameters
         ----------


### PR DESCRIPTION
Before submitting, please check the following:
- Make sure you have tests for the new code and that test passes (run `tox`)
- format added code by `black -l 120 <filename>`
- If applicable, add a line to the [unreleased] part of CHANGELOG.md, following [keep-a-changelog](https://keepachangelog.com/en/1.0.0/).

Then, please fill in below:

**Context (if applicable):**
Current gflow visualization method is based on gflow obtained from `graphix.gflow.gflow`, which is not always consistent with the pattern. #109

**Description of the change:**
Add a method to obtain gflow which is consistent with the feedforward structure of the patterns. Integrate this to the visualization method which shows gflow structure based on the pattern with the option `pattern.draw_graph(gflow_from_pattern=True)`
Also, add an option `meas_plane_indicator` to the visualization. If True, measurement plane for each node is showed adjacent to the node.

**Related issue:**
#109

also see that checks (github actions) pass.
If lint check keeps failing, try installing black==22.8.0 as behavior seems to vary across versions.



