### PR TITLE
Safer pattern nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ docs/source/gallery/**
 docs/source/benchmarks/**
 .tox/
 .python-version
+.pre-commit-config.yaml
+graphix/sim/graphix.code-workspace
+graphix/graphix.code-workspace
+*~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Renamed methods; `gflow.flow` and `gflow.gflow` are now `gflow.find_flow` and `gflow.find_gflow`, respectively.
+- `Pattern.seq` is renamed into a private field `Pattern.__seq` and
+  `Pattern.Nnode` is now a read-only property.  `Pattern` constructor
+  now only takes an optional list of `input_nodes`, and can only be
+  updated via `add` and `extend`. `Pattern` are now iterable and `len`
+  is now defined for patterns: we should write `for command in pattern:`
+  instead of `for command in pattern.seq:` and `len(pattern)` instead
+  of `len(pattern.seq)`.  `N` commands are no longer added by `Pattern`
+  constructor and should be added explicitly after the instantiation.
 
 ## [0.2.10] - 2024-01-03
 

--- a/graphix/generator.py
+++ b/graphix/generator.py
@@ -62,46 +62,44 @@ def generate_from_graph(graph, angles, inputs, outputs, meas_planes=None):
     if f:
         # flow found
         depth, layers = get_layers(l_k)
-        pattern = Pattern(input_nodes=inputs, output_nodes=outputs, width=len(inputs))
-        pattern.seq = [["N", i] for i in inputs]
+        pattern = Pattern(input_nodes=inputs)
+        pattern.extend([["N", i] for i in inputs])
         for i in set(graph.nodes) - set(inputs):
-            pattern.seq.append(["N", i])
+            pattern.add(["N", i])
         for e in graph.edges:
-            pattern.seq.append(["E", e])
+            pattern.add(["E", e])
         measured = []
         for i in range(depth, 0, -1):  # i from depth, depth-1, ... 1
             for j in layers[i]:
                 measured.append(j)
-                pattern.seq.append(["M", j, "XY", angles[j], [], []])
+                pattern.add(["M", j, "XY", angles[j], [], []])
                 neighbors = set()
                 for k in f[j]:
                     neighbors = neighbors | set(graph.neighbors(k))
                 for k in neighbors - set([j]):
                     # if k not in measured:
-                    pattern.seq.append(["Z", k, [j]])
-                pattern.seq.append(["X", f[j].pop(), [j]])
-        pattern.Nnode = len(graph.nodes)
+                    pattern.add(["Z", k, [j]])
+                pattern.add(["X", f[j].pop(), [j]])
     else:
         # no flow found - we try gflow
         g, l_k = find_gflow(graph, set(inputs), set(outputs), meas_planes=meas_planes)
         if g:
             # gflow found
             depth, layers = get_layers(l_k)
-            pattern = Pattern(input_nodes=inputs, output_nodes=outputs, width=len(inputs))
-            pattern.seq = [["N", i] for i in inputs]
+            pattern = Pattern(input_nodes=inputs)
+            pattern.extend([["N", i] for i in inputs])
             for i in set(graph.nodes) - set(inputs):
-                pattern.seq.append(["N", i])
+                pattern.add(["N", i])
             for e in graph.edges:
-                pattern.seq.append(["E", e])
+                pattern.add(["E", e])
             for i in range(depth, 0, -1):  # i from depth, depth-1, ... 1
                 for j in layers[i]:
-                    pattern.seq.append(["M", j, meas_planes[j], angles[j], [], []])
+                    pattern.add(["M", j, meas_planes[j], angles[j], [], []])
                     odd_neighbors = find_odd_neighbor(graph, g[j])
                     for k in odd_neighbors - set([j]):
-                        pattern.seq.append(["Z", k, [j]])
+                        pattern.add(["Z", k, [j]])
                     for k in g[j] - set([j]):
-                        pattern.seq.append(["X", k, [j]])
-            pattern.Nnode = len(graph.nodes)
+                        pattern.add(["X", k, [j]])
         else:
             raise ValueError("no flow or gflow found")
 

--- a/graphix/generator.py
+++ b/graphix/generator.py
@@ -63,7 +63,7 @@ def generate_from_graph(graph, angles, inputs, outputs, meas_planes=None):
         # flow found
         depth, layers = get_layers(l_k)
         pattern = Pattern(input_nodes=inputs)
-        pattern.extend([["N", i] for i in inputs])
+        # pattern.extend([["N", i] for i in inputs])
         for i in set(graph.nodes) - set(inputs):
             pattern.add(["N", i])
         for e in graph.edges:
@@ -87,7 +87,7 @@ def generate_from_graph(graph, angles, inputs, outputs, meas_planes=None):
             # gflow found
             depth, layers = get_layers(l_k)
             pattern = Pattern(input_nodes=inputs)
-            pattern.extend([["N", i] for i in inputs])
+            # pattern.extend([["N", i] for i in inputs])
             for i in set(graph.nodes) - set(inputs):
                 pattern.add(["N", i])
             for e in graph.edges:

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -1084,7 +1084,7 @@ class Pattern:
         Returns
         -------
         node_list : list
-            list of nodes that are entangled with speicifed node
+            list of nodes that are entangled with specified node
         """
         if not self.is_standard():
             self.standardize()
@@ -1636,8 +1636,8 @@ class LocalPattern:
         list of node indices in a measurement order.
 
     signal_destination : dict
-       stores the set of nodes where dependent feedforward operations are performed, from the result of measurement at each node.
-       stored separately for each nodes, and for each kind of signal(Ms, Mt, X, Z).
+    stores the set of nodes where dependent feedforward operations are performed, from the result of measurement at each node.
+    stored separately for each nodes, and for each kind of signal(Ms, Mt, X, Z).
     """
 
     def __init__(self, nodes=dict(), input_nodes=[], output_nodes=[], morder=[]):

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -27,10 +27,7 @@ class Pattern:
 
     Attributes
     ----------
-    width : int
-        number of output qubits
-
-    seq : list
+    list(self) :
         list of commands.
 
         .. line-block::
@@ -47,18 +44,18 @@ class Pattern:
         total number of nodes in the resource state
     """
 
-    def __init__(self, width=0, input_nodes=None, output_nodes=[]):
+    def __init__(self, input_nodes=[]):
         """
-        :param width:  number of input/output qubits
+        :param input_nodes:  optional, list of input qubits
         """
-        # number of input qubits
-        self.width = width
-        self.seq = [["N", i] for i in range(width)]  # where command sequence is stored
         self.results = {}  # measurement results from the graph state simulator
-        self.input_nodes = input_nodes  # input nodes
-        self.output_nodes = output_nodes  # output nodes
-        self.Nnode = width  # total number of nodes in the graph state
+        self.__input_nodes = list(input_nodes)  # input nodes (list() makes our own copy of the list)
+        self.__Nnode = len(input_nodes)  # total number of nodes in the graph state
         self._pauli_preprocessed = False  # flag for `measure_pauli` preprocessing completion
+
+        self.__seq = []
+        # output nodes are initially input nodes, since none are measured yet
+        self.__output_nodes = list(input_nodes)
 
     def add(self, cmd):
         """add command to the end of the pattern.
@@ -93,13 +90,66 @@ class Pattern:
         assert type(cmd) == list
         assert cmd[0] in ["N", "E", "M", "X", "Z", "S", "C"]
         if cmd[0] == "N":
-            self.Nnode += 1
-            self.output_nodes.append(cmd[1])
+            if cmd[1] not in self.__output_nodes:
+                self.__Nnode += 1
+                self.__output_nodes.append(cmd[1])
         elif cmd[0] == "M":
-            self.output_nodes.remove(cmd[1])
-        self.seq.append(cmd)
+            self.__output_nodes.remove(cmd[1])
+        self.__seq.append(cmd)
 
-    def set_output_nodes(self, output_nodes):
+    def extend(self, cmds):
+        """Add a list of commands.
+
+        :param cmds: list of commands
+        """
+        for cmd in cmds:
+            self.add(cmd)
+
+    def clear(self):
+        """Clear the sequence of pattern commands."""
+        self.__Nnode = len(self.__input_nodes)
+        self.__seq = []
+        self.__output_nodes = list(self.__input_nodes)
+
+    def replace(self, cmds, input_nodes=None):
+        """Replace pattern with a given sequence of pattern commands.
+
+        :param cmds: list of commands
+
+        :param input_nodes:  optional, list of input qubits
+        (by default, keep the same input nodes as before)
+        """
+        if input_nodes is not None:
+            self.__input_nodes = list(input_nodes)
+        self.clear()
+        self.extend(cmds)
+
+    @property
+    def input_nodes(self):
+        """list of input nodes"""
+        return list(self.__input_nodes)  # copy for preventing modification
+
+    @property
+    def output_nodes(self):
+        """list of all nodes that are either `input_nodes` or prepared with
+        `N` commands and that have not been measured with an `M` command
+        """
+        return list(self.__output_nodes)  # copy for preventing modification
+
+    def __len__(self):
+        """length of command sequence"""
+        return len(self.__seq)
+
+    def __iter__(self):
+        """iterate over commands"""
+        return iter(self.__seq)
+
+    @property
+    def Nnode(self):
+        """count of nodes that are either `input_nodes` or prepared with `N` commands"""
+        return self.__Nnode
+
+    def reorder_output_nodes(self, output_nodes):
         """arrange the order of output_nodes.
 
         Parameters
@@ -107,9 +157,10 @@ class Pattern:
         output_nodes: list of int
             output nodes order determined by user. each index corresponds to that of logical qubits.
         """
-        self.output_nodes = output_nodes
+        assert_permutation(self.__output_nodes, output_nodes)
+        self.__output_nodes = list(output_nodes)
 
-    def set_input_nodes(self, input_nodes):
+    def reorder_input_nodes(self, input_nodes):
         """arrange the order of input_nodes.
 
         Parameters
@@ -117,10 +168,20 @@ class Pattern:
         input_nodes: list of int
             input nodes order determined by user. each index corresponds to that of logical qubits.
         """
-        self.input_nodes = input_nodes
+        assert_permutation(self.__input_nodes, input_nodes)
+        self.__input_nodes = list(input_nodes)
 
     def __repr__(self):
-        return f"graphix.pattern.Pattern object with {len(self.seq)} commands and {self.width} output qubits"
+        return (
+            f"graphix.pattern.Pattern object with {len(self.__seq)} commands and {len(self.output_nodes)} output qubits"
+        )
+
+    def equal(self, other):
+        return (
+            self.__seq == other.__seq
+            and self.input_nodes == other.input_nodes
+            and self.output_nodes == other.output_nodes
+        )
 
     def print_pattern(self, lim=40, filter=None):
         """print the pattern sequence (Pattern.seq).
@@ -132,8 +193,8 @@ class Pattern:
         filter : list of str, optional
             show only specified commands, e.g. ['M', 'X', 'Z']
         """
-        if len(self.seq) < lim:
-            nmax = len(self.seq)
+        if len(self.__seq) < lim:
+            nmax = len(self.__seq)
         else:
             nmax = lim
         if filter is None:
@@ -142,52 +203,52 @@ class Pattern:
         i = -1
         while count < nmax:
             i = i + 1
-            if i == len(self.seq):
+            if i == len(self.__seq):
                 break
-            if self.seq[i][0] == "N" and ("N" in filter):
+            if self.__seq[i][0] == "N" and ("N" in filter):
                 count += 1
-                print(f"N, node = {self.seq[i][1]}")
-            elif self.seq[i][0] == "E" and ("E" in filter):
+                print(f"N, node = {self.__seq[i][1]}")
+            elif self.__seq[i][0] == "E" and ("E" in filter):
                 count += 1
-                print(f"E, nodes = {self.seq[i][1]}")
-            elif self.seq[i][0] == "M" and ("M" in filter):
+                print(f"E, nodes = {self.__seq[i][1]}")
+            elif self.__seq[i][0] == "M" and ("M" in filter):
                 count += 1
-                if len(self.seq[i]) == 6:
+                if len(self.__seq[i]) == 6:
                     print(
-                        f"M, node = {self.seq[i][1]}, plane = {self.seq[i][2]}, angle(pi) = {self.seq[i][3]}, "
-                        + f"s-domain = {self.seq[i][4]}, t_domain = {self.seq[i][5]}"
+                        f"M, node = {self.__seq[i][1]}, plane = {self.__seq[i][2]}, angle(pi) = {self.__seq[i][3]}, "
+                        + f"s-domain = {self.__seq[i][4]}, t_domain = {self.__seq[i][5]}"
                     )
-                elif len(self.seq[i]) == 7:
+                elif len(self.__seq[i]) == 7:
                     print(
-                        f"M, node = {self.seq[i][1]}, plane = {self.seq[i][2]}, angle(pi) = {self.seq[i][3]}, "
-                        + f"s-domain = {self.seq[i][4]}, t_domain = {self.seq[i][5]}, Clifford index = {self.seq[i][6]}"
+                        f"M, node = {self.__seq[i][1]}, plane = {self.__seq[i][2]}, angle(pi) = {self.__seq[i][3]}, "
+                        + f"s-domain = {self.__seq[i][4]}, t_domain = {self.__seq[i][5]}, Clifford index = {self.__seq[i][6]}"
                     )
-            elif self.seq[i][0] == "X" and ("X" in filter):
+            elif self.__seq[i][0] == "X" and ("X" in filter):
                 count += 1
                 # remove duplicates
-                _domain = np.array(self.seq[i][2])
+                _domain = np.array(self.__seq[i][2])
                 uind = np.unique(_domain)
                 unique_domain = []
                 for ind in uind:
                     if np.mod(np.count_nonzero(_domain == ind), 2) == 1:
                         unique_domain.append(ind)
-                print(f"X byproduct, node = {self.seq[i][1]}, domain = {unique_domain}")
-            elif self.seq[i][0] == "Z" and ("Z" in filter):
+                print(f"X byproduct, node = {self.__seq[i][1]}, domain = {unique_domain}")
+            elif self.__seq[i][0] == "Z" and ("Z" in filter):
                 count += 1
                 # remove duplicates
-                _domain = np.array(self.seq[i][2])
+                _domain = np.array(self.__seq[i][2])
                 uind = np.unique(_domain)
                 unique_domain = []
                 for ind in uind:
                     if np.mod(np.count_nonzero(_domain == ind), 2) == 1:
                         unique_domain.append(ind)
-                print(f"Z byproduct, node = {self.seq[i][1]}, domain = {unique_domain}")
-            elif self.seq[i][0] == "C" and ("C" in filter):
+                print(f"Z byproduct, node = {self.__seq[i][1]}, domain = {unique_domain}")
+            elif self.__seq[i][0] == "C" and ("C" in filter):
                 count += 1
-                print(f"Clifford, node = {self.seq[i][1]}, Clifford index = {self.seq[i][2]}")
+                print(f"Clifford, node = {self.__seq[i][1]}, Clifford index = {self.__seq[i][2]}")
 
-        if len(self.seq) > i + 1:
-            print(f"{len(self.seq)-lim} more commands truncated. Change lim argument of print_pattern() to show more")
+        if len(self.__seq) > i + 1:
+            print(f"{len(self.__seq)-lim} more commands truncated. Change lim argument of print_pattern() to show more")
 
     def get_local_pattern(self):
         """Get a local pattern transpiled from the pattern.
@@ -200,7 +261,7 @@ class Pattern:
         standardized = self.is_standard()
         node_prop = dict()
         morder = []
-        for cmd in self.seq:
+        for cmd in self.__seq:
             if cmd[0] == "N":
                 node_prop[cmd[1]] = {
                     "seq": [],
@@ -260,7 +321,7 @@ class Pattern:
         if method == "local":
             localpattern = self.get_local_pattern()
             localpattern.standardize()
-            self.seq = localpattern.get_pattern().seq
+            self.__seq = localpattern.get_pattern().__seq
         elif method == "global":
             self._move_N_to_left()
             self._move_byproduct_to_right()
@@ -286,7 +347,7 @@ class Pattern:
         }
         result = True
         op_ref = "N"
-        for cmd in self.seq:
+        for cmd in self.__seq:
             op = cmd[0]
             result = result & (op in order_dict[op_ref])
             op_ref = op
@@ -313,22 +374,22 @@ class Pattern:
         if method == "local":
             localpattern = self.get_local_pattern()
             localpattern.shift_signals()
-            self.seq = localpattern.get_pattern().seq
+            self.__seq = localpattern.get_pattern().__seq
         elif method == "global":
             self.extract_signals()
             target = self._find_op_to_be_moved("S", rev=True)
             while target != "end":
-                if target == len(self.seq) - 1:
-                    self.seq.pop(target)
+                if target == len(self.__seq) - 1:
+                    self.__seq.pop(target)
                     target = self._find_op_to_be_moved("S", rev=True)
                     continue
-                if self.seq[target + 1][0] == "X":
+                if self.__seq[target + 1][0] == "X":
                     self._commute_XS(target)
-                elif self.seq[target + 1][0] == "Z":
+                elif self.__seq[target + 1][0] == "Z":
                     self._commute_ZS(target)
-                elif self.seq[target + 1][0] == "M":
+                elif self.__seq[target + 1][0] == "M":
                     self._commute_MS(target)
-                elif self.seq[target + 1][0] == "S":
+                elif self.__seq[target + 1][0] == "S":
                     self._commute_SS(target)
                 else:
                     self._commute_with_following(target)
@@ -352,12 +413,12 @@ class Pattern:
             target = 0
             step = 1
         else:  # search from the back
-            target = len(self.seq) - 1
+            target = len(self.__seq) - 1
             step = -1
         ite = 0
         num_ops = 0
-        while ite < len(self.seq):
-            if self.seq[target][0] == op:
+        while ite < len(self.__seq):
+            if self.__seq[target][0] == op:
                 num_ops += 1
             if num_ops == skipnum + 1:
                 return target
@@ -374,21 +435,21 @@ class Pattern:
             target command index. this must point to
             a X command followed by E command
         """
-        assert self.seq[target][0] == "X"
-        assert self.seq[target + 1][0] == "E"
-        X = self.seq[target]
-        E = self.seq[target + 1]
+        assert self.__seq[target][0] == "X"
+        assert self.__seq[target + 1][0] == "E"
+        X = self.__seq[target]
+        E = self.__seq[target + 1]
         if E[1][0] == X[1]:
             Z = ["Z", E[1][1], X[2]]
-            self.seq.pop(target + 1)  # del E
-            self.seq.insert(target, Z)  # add Z in front of X
-            self.seq.insert(target, E)  # add E in front of Z
+            self.__seq.pop(target + 1)  # del E
+            self.__seq.insert(target, Z)  # add Z in front of X
+            self.__seq.insert(target, E)  # add E in front of Z
             return True
         elif E[1][1] == X[1]:
             Z = ["Z", E[1][0], X[2]]
-            self.seq.pop(target + 1)  # del E
-            self.seq.insert(target, Z)  # add Z in front of X
-            self.seq.insert(target, E)  # add E in front of Z
+            self.__seq.pop(target + 1)  # del E
+            self.__seq.insert(target, Z)  # add Z in front of X
+            self.__seq.insert(target, E)  # add E in front of Z
             return True
         else:
             self._commute_with_following(target)
@@ -403,10 +464,10 @@ class Pattern:
             target command index. this must point to
             a X command followed by M command
         """
-        assert self.seq[target][0] == "X"
-        assert self.seq[target + 1][0] == "M"
-        X = self.seq[target]
-        M = self.seq[target + 1]
+        assert self.__seq[target][0] == "X"
+        assert self.__seq[target + 1][0] == "M"
+        X = self.__seq[target]
+        M = self.__seq[target + 1]
         if X[1] == M[1]:  # s to s+r
             if len(M) == 7:
                 vop = M[6]
@@ -416,7 +477,7 @@ class Pattern:
                 M[5].extend(X[2])
             elif M[2] == "XY":
                 M[4].extend(X[2])
-            self.seq.pop(target)  # del X
+            self.__seq.pop(target)  # del X
             return True
         else:
             self._commute_with_following(target)
@@ -431,10 +492,10 @@ class Pattern:
             target command index. this must point to
             a Z command followed by M command
         """
-        assert self.seq[target][0] == "Z"
-        assert self.seq[target + 1][0] == "M"
-        Z = self.seq[target]
-        M = self.seq[target + 1]
+        assert self.__seq[target][0] == "Z"
+        assert self.__seq[target + 1][0] == "M"
+        Z = self.__seq[target]
+        M = self.__seq[target + 1]
         if Z[1] == M[1]:
             if len(M) == 7:
                 vop = M[6]
@@ -444,7 +505,7 @@ class Pattern:
                 M[4].extend(Z[2])
             elif M[2] == "XY":
                 M[5].extend(Z[2])
-            self.seq.pop(target)  # del Z
+            self.__seq.pop(target)  # del Z
             return True
         else:
             self._commute_with_following(target)
@@ -459,10 +520,10 @@ class Pattern:
             target command index. this must point to
             a S command followed by X command
         """
-        assert self.seq[target][0] == "S"
-        assert self.seq[target + 1][0] == "X"
-        S = self.seq[target]
-        X = self.seq[target + 1]
+        assert self.__seq[target][0] == "S"
+        assert self.__seq[target + 1][0] == "X"
+        S = self.__seq[target]
+        X = self.__seq[target + 1]
         if np.mod(X[2].count(S[1]), 2):
             X[2].extend(S[2])
         self._commute_with_following(target)
@@ -476,10 +537,10 @@ class Pattern:
             target command index. this must point to
             a S command followed by Z command
         """
-        assert self.seq[target][0] == "S"
-        assert self.seq[target + 1][0] == "Z"
-        S = self.seq[target]
-        Z = self.seq[target + 1]
+        assert self.__seq[target][0] == "S"
+        assert self.__seq[target + 1][0] == "Z"
+        S = self.__seq[target]
+        Z = self.__seq[target + 1]
         if np.mod(Z[2].count(S[1]), 2):
             Z[2].extend(S[2])
         self._commute_with_following(target)
@@ -493,10 +554,10 @@ class Pattern:
             target command index. this must point to
             a S command followed by M command
         """
-        assert self.seq[target][0] == "S"
-        assert self.seq[target + 1][0] == "M"
-        S = self.seq[target]
-        M = self.seq[target + 1]
+        assert self.__seq[target][0] == "S"
+        assert self.__seq[target + 1][0] == "M"
+        S = self.__seq[target]
+        M = self.__seq[target + 1]
         if np.mod(M[4].count(S[1]), 2):
             M[4].extend(S[2])
         if np.mod(M[5].count(S[1]), 2):
@@ -511,10 +572,10 @@ class Pattern:
             target command index. this must point to
             a S command followed by S command
         """
-        assert self.seq[target][0] == "S"
-        assert self.seq[target + 1][0] == "S"
-        S1 = self.seq[target]
-        S2 = self.seq[target + 1]
+        assert self.__seq[target][0] == "S"
+        assert self.__seq[target + 1][0] == "S"
+        S1 = self.__seq[target]
+        S2 = self.__seq[target + 1]
         if np.mod(S2[2].count(S1[1]), 2):
             S2[2].extend(S1[2])
         self._commute_with_following(target)
@@ -529,9 +590,9 @@ class Pattern:
         target : int
             target command index
         """
-        A = self.seq[target + 1]
-        self.seq.pop(target + 1)
-        self.seq.insert(target, A)
+        A = self.__seq[target + 1]
+        self.__seq.pop(target + 1)
+        self.__seq.insert(target, A)
 
     def _commute_with_preceding(self, target):
         """Internal method to perform the commutation of
@@ -543,9 +604,9 @@ class Pattern:
         target : int
             target command index
         """
-        A = self.seq[target - 1]
-        self.seq.pop(target - 1)
-        self.seq.insert(target, A)
+        A = self.__seq[target - 1]
+        self.__seq.pop(target - 1)
+        self.__seq.insert(target, A)
 
     def _move_N_to_left(self):
         """Internal method to move all 'N' commands to the start of the sequence.
@@ -553,13 +614,13 @@ class Pattern:
         commutation relations.
         """
         Nlist = []
-        for cmd in self.seq:
+        for cmd in self.__seq:
             if cmd[0] == "N":
                 Nlist.append(cmd)
         Nlist.sort()
         for N in Nlist:
-            self.seq.remove(N)
-        self.seq = Nlist + self.seq
+            self.__seq.remove(N)
+        self.__seq = Nlist + self.__seq
 
     def _move_byproduct_to_right(self):
         """Internal method to move the byproduct commands to the end of sequence,
@@ -569,15 +630,15 @@ class Pattern:
         moved_X = 0  # number of moved X
         target = self._find_op_to_be_moved("X", rev=True, skipnum=moved_X)
         while target != "end":
-            if (target == len(self.seq) - 1) or (self.seq[target + 1] == "X"):
+            if (target == len(self.__seq) - 1) or (self.__seq[target + 1] == "X"):
                 moved_X += 1
                 target = self._find_op_to_be_moved("X", rev=True, skipnum=moved_X)
                 continue
-            if self.seq[target + 1][0] == "E":
+            if self.__seq[target + 1][0] == "E":
                 move = self._commute_EX(target)
                 if move:
                     target += 1  # addition of extra Z means target must be increased
-            elif self.seq[target + 1][0] == "M":
+            elif self.__seq[target + 1][0] == "M":
                 search = self._commute_MX(target)
                 if search:
                     target = self._find_op_to_be_moved("X", rev=True, skipnum=moved_X)
@@ -590,11 +651,11 @@ class Pattern:
         moved_Z = 0  # number of moved Z
         target = self._find_op_to_be_moved("Z", rev=True, skipnum=moved_Z)
         while target != "end":
-            if (target == len(self.seq) - 1) or (self.seq[target + 1][0] == ("X" or "Z")):
+            if (target == len(self.__seq) - 1) or (self.__seq[target + 1][0] == ("X" or "Z")):
                 moved_Z += 1
                 target = self._find_op_to_be_moved("Z", rev=True, skipnum=moved_Z)
                 continue
-            if self.seq[target + 1][0] == "M":
+            if self.__seq[target + 1][0] == "M":
                 search = self._commute_MZ(target)
                 if search:
                     target = self._find_op_to_be_moved("Z", rev=True, skipnum=moved_Z)
@@ -610,7 +671,7 @@ class Pattern:
         moved_E = 0
         target = self._find_op_to_be_moved("E", skipnum=moved_E)
         while target != "end":
-            if (target == 0) or (self.seq[target - 1][0] == ("N" or "E")):
+            if (target == 0) or (self.__seq[target - 1][0] == ("N" or "E")):
                 moved_E += 1
                 target = self._find_op_to_be_moved("E", skipnum=moved_E)
                 continue
@@ -623,13 +684,13 @@ class Pattern:
         This is used for shift_signals() method.
         """
         pos = 0
-        while pos < len(self.seq):
-            cmd = self.seq[pos]
+        while pos < len(self.__seq):
+            cmd = self.__seq[pos]
             if cmd[0] == "M":
                 if cmd[2] == "XY":
                     node = cmd[1]
                     if cmd[5]:
-                        self.seq.insert(pos + 1, ["S", node, cmd[5]])
+                        self.__seq.insert(pos + 1, ["S", node, cmd[5]])
                         cmd[5] = []
                         pos += 1
             pos += 1
@@ -646,7 +707,7 @@ class Pattern:
         """
         nodes, _ = self.get_graph()
         dependency = {i: set() for i in nodes}
-        for cmd in self.seq:
+        for cmd in self.__seq:
             if cmd[0] == "M":
                 dependency[cmd[1]] = dependency[cmd[1]] | set(cmd[4]) | set(cmd[5])
             elif cmd[0] == "X":
@@ -690,7 +751,7 @@ class Pattern:
         measured = self.results.keys()
         dependency = self.update_dependency(measured, dependency)
         not_measured = set()
-        for cmd in self.seq:
+        for cmd in self.__seq:
             if cmd[0] == "N":
                 if not cmd[1] in self.output_nodes:
                     not_measured = not_measured | {cmd[1]}
@@ -727,7 +788,7 @@ class Pattern:
 
         Returns
         -------
-        connected: set of taple
+        connected: set of tuple
                 set of connected edges
         """
         connected = set()
@@ -746,6 +807,7 @@ class Pattern:
         meas_order: list of int
             sub-optimal measurement order for classical simulation
         """
+        # NOTE calling get_graph
         nodes, edges = self.get_graph()
         nodes = set(nodes)
         edges = set(edges)
@@ -781,6 +843,7 @@ class Pattern:
         meas_order: list of int
             measurement order
         """
+        # NOTE calling get_graph
         nodes, edges = self.get_graph()
         G = nx.Graph()
         G.add_nodes_from(nodes)
@@ -796,7 +859,7 @@ class Pattern:
         for i in range(depth):
             k = depth - i
             nodes = layer[k]
-            meas_order += nodes
+            meas_order += nodes  # NOTE this is list concatenation
         return meas_order
 
     def get_measurement_order_from_gflow(self):
@@ -808,6 +871,7 @@ class Pattern:
         meas_order : list of int
             measurement order
         """
+        # NOTE calling get_graph
         nodes, edges = self.get_graph()
         G = nx.Graph()
         G.add_nodes_from(nodes)
@@ -846,8 +910,8 @@ class Pattern:
         for i in meas_order:
             target = 0
             while True:
-                if (self.seq[target][0] == "M") & (self.seq[target][1] == i):
-                    meas_cmds.append(self.seq[target])
+                if (self.__seq[target][0] == "M") & (self.__seq[target][1] == i):
+                    meas_cmds.append(self.__seq[target])
                     break
                 target += 1
         return meas_cmds
@@ -867,8 +931,8 @@ class Pattern:
         ind = self._find_op_to_be_moved("M")
         if ind == "end":
             return []
-        while self.seq[ind][0] == "M":
-            meas_cmds.append(self.seq[ind])
+        while self.__seq[ind][0] == "M":
+            meas_cmds.append(self.__seq[ind])
             ind += 1
         return meas_cmds
 
@@ -882,7 +946,7 @@ class Pattern:
         """
         meas_plane = dict()
         order = ["X", "Y", "Z"]
-        for cmd in self.seq:
+        for cmd in self.__seq:
             if cmd[0] == "M":
                 mplane = cmd[2]
                 if len(cmd) == 7:
@@ -904,7 +968,7 @@ class Pattern:
             measurement angles of the each node.
         """
         angles = {}
-        for cmd in self.seq:
+        for cmd in self.__seq:
             if cmd[0] == "M":
                 angles[cmd[1]] = cmd[3]
         return angles
@@ -937,7 +1001,7 @@ class Pattern:
             list of tuples (i,j) specifying edges
         """
         node_list, edge_list = [], []
-        for cmd in self.seq:
+        for cmd in self.__seq:
             if cmd[0] == "N":
                 node_list.append(cmd[1])
             elif cmd[0] == "E":
@@ -974,7 +1038,7 @@ class Pattern:
             vops : dict
         """
         vops = dict()
-        for cmd in self.seq:
+        for cmd in self.__seq:
             if cmd[0] == "M":
                 if len(cmd) == 7:
                     if cmd[6] == 0:
@@ -1027,13 +1091,13 @@ class Pattern:
         node_list = []
         ind = self._find_op_to_be_moved("E")
         if not ind == "end":  # end -> 'node' is isolated
-            while self.seq[ind][0] == "E":
-                if self.seq[ind][1][0] == node:
-                    if not self.seq[ind][1][1] in prepared:
-                        node_list.append(self.seq[ind][1][1])
-                elif self.seq[ind][1][1] == node:
-                    if not self.seq[ind][1][0] in prepared:
-                        node_list.append(self.seq[ind][1][0])
+            while self.__seq[ind][0] == "E":
+                if self.__seq[ind][1][0] == node:
+                    if not self.__seq[ind][1][1] in prepared:
+                        node_list.append(self.__seq[ind][1][1])
+                elif self.__seq[ind][1][1] == node:
+                    if not self.__seq[ind][1][0] in prepared:
+                        node_list.append(self.__seq[ind][1][0])
                 ind += 1
         return node_list
 
@@ -1051,7 +1115,7 @@ class Pattern:
             localpattern = self.get_local_pattern()
             localpattern.standardize()
             localpattern.shift_signals()
-            self.seq = localpattern.get_pattern().seq
+            self.__seq = localpattern.get_pattern().__seq
         elif method == "global":
             self.standardize()
             self.shift_signals()
@@ -1062,9 +1126,9 @@ class Pattern:
         """Returns the list of byproduct correction commands"""
         assert self.is_standard()
         Clist = []
-        for i in range(len(self.seq)):
-            if self.seq[i][0] in ["X", "Z"]:
-                Clist.append(self.seq[i])
+        for i in range(len(self.__seq)):
+            if self.__seq[i][0] in ["X", "Z"]:
+                Clist.append(self.__seq[i])
         return Clist
 
     def parallelize_pattern(self):
@@ -1119,18 +1183,18 @@ class Pattern:
             measured.append(node)
 
         # add isolated nodes
-        for cmd in self.seq:
+        for cmd in self.__seq:
             if cmd[0] == "N":
                 if not cmd[1] in prepared:
                     new.append(["N", cmd[1]])
-        for cmd in self.seq:
+        for cmd in self.__seq:
             if cmd[0] == "E":
                 if cmd[1][0] in self.output_nodes:
                     if cmd[1][1] in self.output_nodes:
                         new.append(cmd)
 
         # add Clifford nodes
-        for cmd in self.seq:
+        for cmd in self.__seq:
             if cmd[0] == "C":
                 new.append(cmd)
 
@@ -1138,7 +1202,7 @@ class Pattern:
         c_list = self.correction_commands()
         new.extend(c_list)
 
-        self.seq = new
+        self.__seq = new
 
     def max_space(self):
         """The maximum number of nodes that must be present in the graph (graph space) during the execution of the pattern.
@@ -1152,7 +1216,7 @@ class Pattern:
         """
         max_nodes = 0
         nodes = 0
-        for cmd in self.seq:
+        for cmd in self.__seq:
             if cmd[0] == "N":
                 nodes += 1
             elif cmd[0] == "M":
@@ -1172,7 +1236,7 @@ class Pattern:
         """
         nodes = 0
         N_list = []
-        for cmd in self.seq:
+        for cmd in self.__seq:
             if cmd[0] == "N":
                 nodes += 1
                 N_list.append(nodes)
@@ -1320,7 +1384,7 @@ class Pattern:
                     file.write("// measurement result of qubit q" + str(id) + "\n")
                     file.write("bit c" + str(id) + " = " + str(res) + ";\n")
                     file.write("\n")
-            for command in self.seq:
+            for command in self.__seq:
                 for line in cmd_to_qasm3(command):
                     file.write(line)
 
@@ -1685,11 +1749,7 @@ class LocalPattern:
             standardized global pattern
         """
         assert self.is_standard()
-        pattern = Pattern(
-            input_nodes=self.input_nodes,
-            output_nodes=self.output_nodes,
-            width=len(self.output_nodes),
-        )
+        pattern = Pattern(input_nodes=self.input_nodes)
         Nseq = [["N", i] for i in self.nodes.keys()]
         Eseq = []
         Mseq = []
@@ -1714,8 +1774,7 @@ class LocalPattern:
                     raise ValueError(f"command {cmd} is invalid!")
             if node.result is not None:
                 pattern.results[node.index] = node.result
-        pattern.seq = Nseq + Eseq + Mseq + Xseq + Zseq + Cseq
-        self.Nnodes = len(Nseq)
+        pattern.replace(Nseq + Eseq + Mseq + Xseq + Zseq + Cseq)
         return pattern
 
 
@@ -1778,7 +1837,7 @@ def measure_pauli(pattern, leave_input, copy=False, use_rustworkx=False):
     results = {}
     to_measure, non_pauli_meas = pauli_nodes(pattern, leave_input)
     if not leave_input and len(list(set(pattern.input_nodes) & set([i[0][1] for i in to_measure]))) > 0:
-        new_inputs = None
+        new_inputs = []
     else:
         new_inputs = pattern.input_nodes
     for cmd in to_measure:
@@ -1831,7 +1890,7 @@ def measure_pauli(pattern, leave_input, copy=False, use_rustworkx=False):
         new_seq.append(["N", index])
     for edge in iter(graph_state.edges):
         new_seq.append(["E", edge])
-    for cmd in pattern.seq:
+    for cmd in pattern:
         if cmd[0] == "M":
             if cmd[1] in list(graph_state.nodes):
                 cmd_new = deepcopy(cmd)
@@ -1845,24 +1904,20 @@ def measure_pauli(pattern, leave_input, copy=False, use_rustworkx=False):
         new_clifford_ = vops[index]
         if new_clifford_ != 0:
             new_seq.append(["C", index, new_clifford_])
-    for cmd in pattern.seq:
+    for cmd in pattern:
         if cmd[0] == "X" or cmd[0] == "Z":
             new_seq.append(cmd)
 
     if copy:
-        pat = deepcopy(pattern)
-        pat.seq = new_seq
-        pat.input_nodes = new_inputs
-        pat.Nnode = len(graph_state.nodes)
-        pat.results = results
-        pat._pauli_preprocessed = True
-        return pat
+        pat = Pattern()
     else:
-        pattern.seq = new_seq
-        pattern.input_nodes = new_inputs
-        pattern.Nnode = len(graph_state.nodes)
-        pattern.results = results
-        pattern._pauli_preprocessed = True
+        pat = pattern
+
+    pat.replace(new_seq, input_nodes=new_inputs)
+    assert pat.Nnode == len(graph_state.nodes)
+    pat.results = results
+    pat._pauli_preprocessed = True
+    return pat
 
 
 def pauli_nodes(pattern, leave_input):
@@ -2068,3 +2123,13 @@ def cmd_to_qasm3(cmd):
 
     else:
         raise ValueError("invalid command {}".format(name))
+
+
+def assert_permutation(original, user):
+    node_set = set(user)
+    assert node_set == set(original), f"{node_set} != {set(original)}"
+    for node in user:
+        if node in node_set:
+            node_set.remove(node)
+        else:
+            assert False, f"{node} appears twice"

--- a/graphix/simulator.py
+++ b/graphix/simulator.py
@@ -49,7 +49,7 @@ class PatternSimulator:
             the output quantum state,
             in the representation depending on the backend used.
         """
-        for cmd in self.pattern.seq:
+        for cmd in self.pattern:
             if cmd[0] == "N":
                 self.backend.add_nodes([cmd[1]])
             elif cmd[0] == "E":
@@ -64,7 +64,6 @@ class PatternSimulator:
                 self.backend.apply_clifford(cmd)
             else:
                 raise ValueError("invalid commands")
-            if self.pattern.seq[-1] == cmd:
-                self.backend.finalize()
+        self.backend.finalize()
 
         return self.backend.state

--- a/graphix/simulator.py
+++ b/graphix/simulator.py
@@ -49,6 +49,7 @@ class PatternSimulator:
             the output quantum state,
             in the representation depending on the backend used.
         """
+        self.backend.add_nodes(self.pattern.input_nodes)
         for cmd in self.pattern:
             if cmd[0] == "N":
                 self.backend.add_nodes([cmd[1]])

--- a/graphix/transpiler.py
+++ b/graphix/transpiler.py
@@ -229,7 +229,7 @@ class Circuit:
         input = [j for j in range(self.width)]
         out = [j for j in range(self.width)]
         pattern = Pattern(input_nodes=input)
-        pattern.extend([["N", i] for i in range(self.width)])
+        # pattern.extend([["N", i] for i in range(self.width)])
         for instr in self.instruction:
             if instr[0] == "CNOT":
                 ancilla = [Nnode, Nnode + 1]
@@ -342,8 +342,8 @@ class Circuit:
         pattern : :class:`graphix.pattern.Pattern` object
         """
         self._N = []
-        for i in range(self.width):
-            self._N.append(["N", i])
+        # for i in range(self.width):
+        #    self._N.append(["N", i])
         self._M = []
         self._E = []
         self._instr = []

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -13,6 +13,15 @@ rc.set_seed(SEED)
 
 
 class TestPattern(unittest.TestCase):
+
+
+    # this fails without behaviour modification
+    def test_manual_generation(self):
+        pattern = Pattern(2)
+        pattern.add(["M", 0, 'XY', 0, [], []])
+
+
+
     def test_standardize(self):
         nqubits = 2
         depth = 1

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -13,14 +13,12 @@ rc.set_seed(SEED)
 
 
 class TestPattern(unittest.TestCase):
-
-
     # this fails without behaviour modification
     def test_manual_generation(self):
-        pattern = Pattern(2)
-        pattern.add(["M", 0, 'XY', 0, [], []])
-
-
+        pattern = Pattern()
+        pattern.add(["N", 0])
+        pattern.add(["N", 1])
+        pattern.add(["M", 0, "XY", 0, [], []])
 
     def test_standardize(self):
         nqubits = 2
@@ -244,8 +242,7 @@ class TestPattern(unittest.TestCase):
     def test_get_meas_plane(self):
         preset_meas_plane = ["XY", "XY", "XY", "YZ", "YZ", "YZ", "XZ", "XZ", "XZ"]
         vop_list = [0, 5, 6]  # [identity, S gate, H gate]
-        pattern = Pattern(len(preset_meas_plane))
-        pattern.set_output_nodes([i for i in range(len(preset_meas_plane))])
+        pattern = Pattern(input_nodes=[i for i in range(len(preset_meas_plane))])
         for i in range(len(preset_meas_plane)):
             pattern.add(["M", i, preset_meas_plane[i], 0, [], [], vop_list[i % 3]])
         ref_meas_plane = {


### PR DESCRIPTION
This pull request ensures that `Pattern` class preserves this internal invariant: `Pattern.output_nodes` is now ensured to be equal to `Pattern.input_nodes` plus nodes introduced by `N` commands minus nodes removed by `M` commands.

`Pattern.seq` is renamed into a private field `Pattern.__seq` and `Pattern.Nnode` is now a read-only property.  `Pattern` constructor now only takes an optional list of `input_nodes`, and can only be updated via `add` and `extend`. `Pattern` are now iterable and `len` is now defined for patterns: we should write `for command in pattern:` instead of `for command in pattern.seq:` and `len(pattern)` instead of `len(pattern.seq)`.  `N` commands are no longer added by `Pattern` constructor and should be added explicitly after the instantiation.



