### PR TITLE
Refactor measure operator in a new pauli module

### DIFF
--- a/graphix/clifford.py
+++ b/graphix/clifford.py
@@ -4,8 +4,9 @@ multiplications, conjugations and Pauli conjugations.
 
 """
 
-
+import typing
 import numpy as np
+import graphix.pauli
 
 # 24 Unique 1-qubit Clifford gates
 _C0 = np.array([[1, 0], [0, 1]])  # identity
@@ -219,3 +220,80 @@ CLIFFORD_TO_QASM3 = [
     ["h", "x", "sdg"],
     ["h", "x", "s"],
 ]
+
+
+class Clifford:
+    def __init__(self, index: int):
+        self.__index = index
+
+    @property
+    def index(self) -> int:
+        """
+        Return the index of the Clifford gate (inverse of clifford.get).
+        """
+        return self.__index
+
+    @property
+    def matrix(self) -> np.ndarray:
+        """
+        Return the matrix of the Clifford gate.
+        """
+        return CLIFFORD[self.__index]
+
+    def __repr__(self) -> str:
+        return CLIFFORD_LABEL[self.__index]
+
+    @property
+    def conj(self) -> "Clifford":
+        """
+        Return the conjugate of the Clifford gate.
+        """
+        return get(CLIFFORD_CONJ[self.__index])
+
+    @property
+    def hsz(self) -> list["Clifford"]:
+        """
+        Return a decomposition of the Clifford gate with the gates H, S, Z.
+        """
+        return list(map(get, CLIFFORD_HSZ_DECOMPOSITION[self.__index]))
+
+    @property
+    def qasm3(self) -> typing.Tuple[str, ...]:
+        """
+        Return a decomposition of the Clifford gate as qasm3 gates.
+        """
+        return CLIFFORD_TO_QASM3[self.__index]
+
+    def __matmul__(self, other) -> "Clifford":
+        """
+        Multiplication within the Clifford group (modulo unit factor).
+        """
+        if isinstance(other, Clifford):
+            return get(CLIFFORD_MUL[self.__index, other.__index])
+        return NotImplemented
+
+    def measure(self, pauli: graphix.pauli.Pauli) -> graphix.pauli.Pauli:
+        """
+        Compute C† P C.
+        """
+        if pauli.symbol == graphix.pauli.IXYZ.I:
+            return pauli
+        table = CLIFFORD_MEASURE[self.__index]
+        symbol, sign = table[pauli.symbol.value]
+        return pauli.unit * graphix.pauli.TABLE[symbol + 1][sign][False]
+
+
+TABLE = tuple(map(Clifford, range(len(CLIFFORD))))
+
+
+def get(index: int) -> Clifford:
+    """Return the Clifford gate with given index"""
+    return TABLE[index]
+
+
+I = get(0)
+X = get(1)
+Y = get(2)
+Z = get(3)
+S = get(4)
+H = get(6)

--- a/graphix/clifford.py
+++ b/graphix/clifford.py
@@ -126,6 +126,9 @@ CLIFFORD_MUL = np.array(
 # Conjugation of Clifford gates result in a Clifford gate.
 # CLIFFORD_CONJ provides the Clifford index of conjugated matrix.
 # Example (S and S dagger):  CLIFFORD_CONJ[4] = 5
+# WARNING: CLIFFORD[i].conj().T is not necessarily equal to
+# CLIFFORD[CLIFFORD_CONJ[i]] in general: the phase may differ.
+# For instance, CLIFFORD[7].conj().T = - CLIFFORD[CLIFFORD_CONJ[7]]
 CLIFFORD_CONJ = np.array(
     [0, 1, 2, 3, 5, 4, 6, 15, 12, 9, 10, 11, 8, 13, 14, 7, 20, 22, 23, 21, 16, 19, 17, 18], dtype=np.int32
 )

--- a/graphix/clifford.py
+++ b/graphix/clifford.py
@@ -254,7 +254,7 @@ class Clifford:
         return get(CLIFFORD_CONJ[self.__index])
 
     @property
-    def hsz(self) -> list["Clifford"]:
+    def hsz(self) -> typing.List["Clifford"]:
         """
         Return a decomposition of the Clifford gate with the gates H, S, Z.
         """

--- a/graphix/pauli.py
+++ b/graphix/pauli.py
@@ -254,3 +254,32 @@ def parse(name: str) -> Pauli:
     Return the Pauli gate with the given name (limited to "I", "X", "Y" and "Z").
     """
     return get(IXYZ[name], UNIT)
+
+
+class MeasureUpdate(pydantic.BaseModel):
+    new_plane: Plane
+    coeff: int
+    add_term: float
+
+    @staticmethod
+    def compute(plane: Plane, s: bool, t: bool, clifford: "graphix.clifford.Clifford") -> "MeasureUpdate":
+        gates = list(map(Pauli.from_axis, plane.axes))
+        if s:
+            clifford = graphix.clifford.X @ clifford
+        if t:
+            clifford = graphix.clifford.Z @ clifford
+        gates = list(map(clifford.measure, gates))
+        new_plane = Plane.from_axes(*(gate.axis for gate in gates))
+        cos_pauli = clifford.measure(Pauli.from_axis(plane.cos))
+        sin_pauli = clifford.measure(Pauli.from_axis(plane.sin))
+        exchange = cos_pauli.axis != new_plane.cos
+        if exchange == (cos_pauli.unit.sign == sin_pauli.unit.sign):
+            coeff = -1
+        else:
+            coeff = 1
+        add_term = 0
+        if cos_pauli.unit.sign:
+            add_term += np.pi
+        if exchange:
+            add_term = np.pi / 2 - add_term
+        return MeasureUpdate(new_plane=new_plane, coeff=coeff, add_term=add_term)

--- a/graphix/pauli.py
+++ b/graphix/pauli.py
@@ -3,6 +3,7 @@ Pauli gates ± {1,j} × {I, X, Y, Z}
 """
 
 import enum
+import typing
 import numpy as np
 import pydantic
 import graphix.clifford
@@ -111,7 +112,7 @@ class Plane(enum.Enum):
     XZ = 2
 
     @property
-    def axes(self) -> list[Axis]:
+    def axes(self) -> typing.List[Axis]:
         # match self:
         #     case Plane.XY:
         #         return [Axis.X, Axis.Y]
@@ -158,7 +159,7 @@ class Plane(enum.Enum):
         elif self == Plane.XZ:
             return Axis.X  # former convention was Z
 
-    def polar(self, angle: float) -> tuple[float, float, float]:
+    def polar(self, angle: float) -> typing.Tuple[float, float, float]:
         result = [0, 0, 0]
         result[self.cos.value] = np.cos(angle)
         result[self.sin.value] = np.sin(angle)

--- a/graphix/pauli.py
+++ b/graphix/pauli.py
@@ -126,9 +126,9 @@ class Plane(enum.Enum):
             case Plane.XY:
                 return Axis.X
             case Plane.YZ:
-                return Axis.Y
+                return Axis.Z  # former convention was Y
             case Plane.XZ:
-                return Axis.X
+                return Axis.Z  # former convention was X
 
     @property
     def sin(self) -> Axis:
@@ -136,9 +136,9 @@ class Plane(enum.Enum):
             case Plane.XY:
                 return Axis.Y
             case Plane.YZ:
-                return Axis.Z
+                return Axis.Y  # former convention was Z
             case Plane.XZ:
-                return Axis.Z
+                return Axis.X  # former convention was Z
 
     def polar(self, angle: float) -> tuple[float, float, float]:
         result = [0, 0, 0]

--- a/graphix/pauli.py
+++ b/graphix/pauli.py
@@ -1,0 +1,256 @@
+"""
+Pauli gates ± {1,j} × {I, X, Y, Z}
+"""
+
+import enum
+import numpy as np
+import pydantic
+import graphix.clifford
+
+
+class IXYZ(enum.Enum):
+    I = -1
+    X = 0
+    Y = 1
+    Z = 2
+
+
+class ComplexUnit:
+    """
+    Complex unit: 1, -1, j, -j.
+
+    Complex units can be multiplied with other complex units,
+    with Python constants 1, -1, 1j, -1j, and can be negated.
+    """
+
+    def __init__(self, sign: bool, im: bool):
+        self.__sign = sign
+        self.__im = im
+
+    @property
+    def sign(self):
+        return self.__sign
+
+    @property
+    def im(self):
+        return self.__im
+
+    @property
+    def complex(self) -> complex:
+        """
+        Return the unit as complex number
+        """
+        result: complex = 1
+        if self.__sign:
+            result *= -1
+        if self.__im:
+            result *= 1j
+        return result
+
+    def __repr__(self):
+        if self.__im:
+            result = "1j"
+        else:
+            result = "1"
+        if self.__sign:
+            result = "-" + result
+        return result
+
+    def prefix(self, s: str) -> str:
+        """
+        Prefix the given string by the complex unit as coefficient,
+        1 leaving the string unchanged.
+        """
+        if self.__im:
+            result = "1j*" + s
+        else:
+            result = s
+        if self.__sign:
+            result = "-" + result
+        return result
+
+    def __mul__(self, other):
+        if isinstance(other, ComplexUnit):
+            im = self.__im != other.__im
+            sign = (self.__sign != other.__sign) != (self.__im and other.__im)
+            return COMPLEX_UNITS[sign][im]
+        return NotImplemented
+
+    def __rmul__(self, other):
+        if other == 1:
+            return self
+        elif other == -1:
+            return COMPLEX_UNITS[not self.__sign][self.__im]
+        elif other == 1j:
+            return COMPLEX_UNITS[self.__sign != self.__im][not self.__im]
+        elif other == -1j:
+            return COMPLEX_UNITS[self.__sign == self.__im][not self.__im]
+
+    def __neg__(self):
+        return COMPLEX_UNITS[not self.__sign][self.__im]
+
+
+COMPLEX_UNITS = [[ComplexUnit(sign, im) for im in (False, True)] for sign in (False, True)]
+
+
+UNIT = COMPLEX_UNITS[False][False]
+
+
+UNITS = [UNIT, -UNIT, 1j * UNIT, -1j * UNIT]
+
+
+class Axis(enum.Enum):
+    X = 0
+    Y = 1
+    Z = 2
+
+
+class Plane(enum.Enum):
+    XY = 0
+    YZ = 1
+    XZ = 2
+
+    @property
+    def axes(self) -> list[Axis]:
+        match self:
+            case Plane.XY:
+                return [Axis.X, Axis.Y]
+            case Plane.YZ:
+                return [Axis.Y, Axis.Z]
+            case Plane.XZ:
+                return [Axis.X, Axis.Z]
+
+    @property
+    def cos(self) -> Axis:
+        match self:
+            case Plane.XY:
+                return Axis.X
+            case Plane.YZ:
+                return Axis.Y
+            case Plane.XZ:
+                return Axis.X
+
+    @property
+    def sin(self) -> Axis:
+        match self:
+            case Plane.XY:
+                return Axis.Y
+            case Plane.YZ:
+                return Axis.Z
+            case Plane.XZ:
+                return Axis.Z
+
+    def polar(self, angle: float) -> tuple[float, float, float]:
+        result = [0, 0, 0]
+        result[self.cos.value] = np.cos(angle)
+        result[self.sin.value] = np.sin(angle)
+        return tuple(result)
+
+    @staticmethod
+    def from_axes(a: Axis, b: Axis) -> "Plane":
+        if b.value < a.value:
+            a, b = b, a
+        match a, b:
+            case Axis.X, Axis.Y:
+                return Plane.XY
+            case Axis.Y, Axis.Z:
+                return Plane.YZ
+            case Axis.X, Axis.Z:
+                return Plane.XZ
+        assert a == b
+        raise ValueError(f"Cannot make a plane giving the same axis {a} twice.")
+
+
+class Pauli:
+    """
+    Pauli gate: u * {I, X, Y, Z} where u is a complex unit
+
+    Pauli gates can be multiplied with other Pauli gates (with @),
+    with complex units and unit constants (with *),
+    and can be negated.
+    """
+
+    def __init__(self, symbol: IXYZ, unit: ComplexUnit):
+        self.__symbol = symbol
+        self.__unit = unit
+
+    @staticmethod
+    def from_axis(axis: Axis) -> "Pauli":
+        return Pauli(IXYZ[axis.name], UNIT)
+
+    @property
+    def axis(self) -> Axis:
+        if self.__symbol == IXYZ.I:
+            raise ValueError("I is not an axis.")
+        return Axis[self.__symbol.name]
+
+    @property
+    def symbol(self):
+        return self.__symbol
+
+    @property
+    def unit(self):
+        return self.__unit
+
+    @property
+    def matrix(self) -> np.ndarray:
+        """
+        Return the matrix of the Pauli gate.
+        """
+        return self.__unit.complex * graphix.clifford.CLIFFORD[self.__symbol.value + 1]
+
+    def __repr__(self):
+        return self.__unit.prefix(self.__symbol.name)
+
+    def __matmul__(self, other):
+        if isinstance(other, Pauli):
+            if self.__symbol == IXYZ.I:
+                symbol = other.__symbol
+                unit = 1
+            elif other.__symbol == IXYZ.I:
+                symbol = self.__symbol
+                unit = 1
+            elif self.__symbol == other.__symbol:
+                symbol = IXYZ.I
+                unit = 1
+            elif (self.__symbol.value + 1) % 3 == other.__symbol.value:
+                symbol = IXYZ((self.__symbol.value + 2) % 3)
+                unit = 1j
+            else:
+                symbol = IXYZ((self.__symbol.value + 1) % 3)
+                unit = -1j
+            return get(symbol, unit * self.__unit * other.__unit)
+        return NotImplemented
+
+    def __rmul__(self, other):
+        return get(self.__symbol, other * self.__unit)
+
+    def __neg__(self):
+        return get(self.__symbol, -self.__unit)
+
+
+TABLE = [
+    [[Pauli(symbol, COMPLEX_UNITS[sign][im]) for im in (False, True)] for sign in (False, True)]
+    for symbol in (IXYZ.I, IXYZ.X, IXYZ.Y, IXYZ.Z)
+]
+
+
+LIST = [pauli for sign_im_list in TABLE for im_list in sign_im_list for pauli in im_list]
+
+
+def get(symbol: IXYZ, unit: ComplexUnit) -> Pauli:
+    """Return the Pauli gate with given symbol and unit."""
+    return TABLE[symbol.value + 1][unit.sign][unit.im]
+
+
+I = get(IXYZ.I, UNIT)
+X = get(IXYZ.X, UNIT)
+Y = get(IXYZ.Y, UNIT)
+Z = get(IXYZ.Z, UNIT)
+
+
+def parse(name: str) -> Pauli:
+    """
+    Return the Pauli gate with the given name (limited to "I", "X", "Y" and "Z").
+    """
+    return get(IXYZ[name], UNIT)

--- a/graphix/pauli.py
+++ b/graphix/pauli.py
@@ -112,33 +112,51 @@ class Plane(enum.Enum):
 
     @property
     def axes(self) -> list[Axis]:
-        match self:
-            case Plane.XY:
-                return [Axis.X, Axis.Y]
-            case Plane.YZ:
-                return [Axis.Y, Axis.Z]
-            case Plane.XZ:
-                return [Axis.X, Axis.Z]
+        # match self:
+        #     case Plane.XY:
+        #         return [Axis.X, Axis.Y]
+        #     case Plane.YZ:
+        #         return [Axis.Y, Axis.Z]
+        #     case Plane.XZ:
+        #         return [Axis.X, Axis.Z]
+        if self == Plane.XY:
+            return [Axis.X, Axis.Y]
+        elif self == Plane.YZ:
+            return [Axis.Y, Axis.Z]
+        elif self == Plane.XZ:
+            return [Axis.X, Axis.Z]
 
     @property
     def cos(self) -> Axis:
-        match self:
-            case Plane.XY:
-                return Axis.X
-            case Plane.YZ:
-                return Axis.Z  # former convention was Y
-            case Plane.XZ:
-                return Axis.Z  # former convention was X
+        # match self:
+        #     case Plane.XY:
+        #         return Axis.X
+        #     case Plane.YZ:
+        #         return Axis.Z  # former convention was Y
+        #     case Plane.XZ:
+        #         return Axis.Z  # former convention was X
+        if self == Plane.XY:
+            return Axis.X
+        elif self == Plane.YZ:
+            return Axis.Z  # former convention was Y
+        elif self == Plane.XZ:
+            return Axis.Z  # former convention was X
 
     @property
     def sin(self) -> Axis:
-        match self:
-            case Plane.XY:
-                return Axis.Y
-            case Plane.YZ:
-                return Axis.Y  # former convention was Z
-            case Plane.XZ:
-                return Axis.X  # former convention was Z
+        # match self:
+        #     case Plane.XY:
+        #         return Axis.Y
+        #     case Plane.YZ:
+        #         return Axis.Y  # former convention was Z
+        #     case Plane.XZ:
+        #         return Axis.X  # former convention was Z
+        if self == Plane.XY:
+            return Axis.Y
+        elif self == Plane.YZ:
+            return Axis.Y  # former convention was Z
+        elif self == Plane.XZ:
+            return Axis.X  # former convention was Z
 
     def polar(self, angle: float) -> tuple[float, float, float]:
         result = [0, 0, 0]
@@ -150,13 +168,19 @@ class Plane(enum.Enum):
     def from_axes(a: Axis, b: Axis) -> "Plane":
         if b.value < a.value:
             a, b = b, a
-        match a, b:
-            case Axis.X, Axis.Y:
-                return Plane.XY
-            case Axis.Y, Axis.Z:
-                return Plane.YZ
-            case Axis.X, Axis.Z:
-                return Plane.XZ
+        # match a, b:
+        #     case Axis.X, Axis.Y:
+        #         return Plane.XY
+        #     case Axis.Y, Axis.Z:
+        #         return Plane.YZ
+        #     case Axis.X, Axis.Z:
+        #         return Plane.XZ
+        if a == Axis.X and b == Axis.Y:
+            return Plane.XY
+        elif a == Axis.Y and b == Axis.Z:
+            return Plane.YZ
+        elif a == Axis.X and b == Axis.Z:
+            return Plane.XZ
         assert a == b
         raise ValueError(f"Cannot make a plane giving the same axis {a} twice.")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ opt_einsum>=3.2
 galois>=0.3.0
 sympy>=1.9
 matplotlib
+pydantic

--- a/tests/test_pauli.py
+++ b/tests/test_pauli.py
@@ -14,3 +14,29 @@ class TestPauli(unittest.TestCase):
         for a in graphix.pauli.LIST:
             for b in graphix.pauli.LIST:
                 assert np.allclose((a @ b).matrix, a.matrix @ b.matrix)
+
+    def test_measure_update(self):
+        for plane in graphix.pauli.Plane:
+            for s in (False, True):
+                for t in (False, True):
+                    for clifford in graphix.clifford.TABLE:
+                        for angle in (0, np.pi):
+                            for choice in (False, True):
+                                vop = clifford.index
+                                if s:
+                                    vop = graphix.clifford.CLIFFORD_MUL[1, vop]
+                                if t:
+                                    vop = graphix.clifford.CLIFFORD_MUL[3, vop]
+                                vec = plane.polar(angle)
+                                op_mat_ref = np.eye(2, dtype=np.complex128) / 2
+                                for i in range(3):
+                                    op_mat_ref += (-1) ** (choice) * vec[i] * graphix.clifford.CLIFFORD[i + 1] / 2
+                                clifford_mat = graphix.clifford.CLIFFORD[vop]
+                                op_mat_ref = clifford_mat.conj().T @ op_mat_ref @ clifford_mat
+                                measure_update = graphix.pauli.MeasureUpdate.compute(plane, s, t, clifford)
+                                new_angle = angle * measure_update.coeff + measure_update.add_term
+                                vec = measure_update.new_plane.polar(new_angle)
+                                op_mat = np.eye(2, dtype=np.complex128) / 2
+                                for i in range(3):
+                                    op_mat += (-1) ** (choice) * vec[i] * graphix.clifford.CLIFFORD[i + 1] / 2
+                                assert np.allclose(op_mat, op_mat_ref) or np.allclose(op_mat, -op_mat_ref)

--- a/tests/test_pauli.py
+++ b/tests/test_pauli.py
@@ -1,0 +1,16 @@
+import unittest
+import numpy as np
+import graphix.clifford
+import graphix.pauli
+
+
+class TestPauli(unittest.TestCase):
+    def test_unit_mul(self):
+        for u in graphix.pauli.UNITS:
+            for p in graphix.pauli.LIST:
+                assert np.allclose((u * p).matrix, u.complex * p.matrix)
+
+    def test_matmul(self):
+        for a in graphix.pauli.LIST:
+            for b in graphix.pauli.LIST:
+                assert np.allclose((a @ b).matrix, a.matrix @ b.matrix)


### PR DESCRIPTION
This pull-request introduces a `pauli` module for symbolic Pauli calculations, which are used in `statevec` instead of direct matrix computation. The `test_pauli` module checks that the computations are the same as before, modulo a bug fix: ` CLIFFORD[CLIFFORD_CONJ[vop]]` was used instead of `CLIFFORD[vop].conj().T`, despite the two are only equal modulo phase in the general case (see the comment in `pauli.py`). The new implementation allows the angle and the plane to be computed separately from the state vector back-end, which will be useful for future client/server computations and to share the code with other back-ends.