### PR TITLE
Fix `test_runner` to work with the release of Qiskit 1.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,6 @@ parameterized
 tox
 
 # Optional dependencies
-qiskit
+qiskit>=1.0
 qiskit-aer
 rustworkx

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -43,7 +43,8 @@ class TestPatternRunner(unittest.TestCase):
         qc.cx(1, 2)
         qc.save_statevector()
         sim = Aer.get_backend("aer_simulator")
-        job = qiskit.execute(qc, sim)
+        new_qc = qiskit.transpile(qc, sim)
+        job = sim.run(new_qc)
         result = job.result()
 
         # Mock


### PR DESCRIPTION
This pull request make test compatible with Qiskit release.

https://docs.quantum.ibm.com/api/migration-guides/qiskit-1.0-features#execute
