### PR TITLE
Allow empty output nodes and measures at circuit level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Transpiled circuits can now have "measure" gates, introduced with
+  the `circ.m(qubit, plane, angle)` method.  The measured qubit cannot
+  be used in any subsequent gate.
+
 ### Fixed
 
 ### Changed
+
+- The transpiler now returns a `TranspileResult` dataclass: the
+  pattern is available in the `pattern` field, and the field
+  `classical_outputs` contains the index where the classical measures
+  can be found in the `results` array of the simulator.
+
+- The circuit simulator now returns a `SimulateResult` dataclass: the
+  state vector is available in the `statevec` field, and the field
+  `classical_measures` contains the results of the measure gates.
+
+- Patterns are now allowed to measure all their nodes, and have an
+  empty output set.
 
 ## [0.2.11] - 2024-03-16
 

--- a/docs/source/generator.rst
+++ b/docs/source/generator.rst
@@ -34,6 +34,12 @@ Pattern Generation
 
     .. automethod:: rz
 
+    .. automethod:: m
+
+.. autoclass:: TranspileResult
+
+.. autoclass:: SimulateResult
+
 :mod:`graphix.generator` module
 +++++++++++++++++++++++++++++++
 

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -1275,7 +1275,7 @@ class Pattern:
         """Simulate the execution of the pattern by using
         :class:`graphix.simulator.PatternSimulator`.
 
-        Available backend: ['statevector', 'tensornetwork']
+        Available backend: ['statevector', 'densitymatrix', 'tensornetwork']
 
         Parameters
         ----------

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -174,8 +174,9 @@ class Pattern:
         output_nodes: list of int
             output nodes order determined by user. each index corresponds to that of logical qubits.
         """
+        output_nodes = list(output_nodes)  # make our own copy (allow iterators to be passed)
         assert_permutation(self.__output_nodes, output_nodes)
-        self.__output_nodes = list(output_nodes)
+        self.__output_nodes = output_nodes
 
     def reorder_input_nodes(self, input_nodes):
         """arrange the order of input_nodes.

--- a/graphix/sim/base_backend.py
+++ b/graphix/sim/base_backend.py
@@ -1,6 +1,33 @@
+import typing
 import numpy as np
 import graphix.clifford
 import graphix.pauli
+
+
+def op_mat_from_result(vec: typing.Tuple[float, float, float], result: bool) -> np.ndarray:
+    op_mat = np.eye(2, dtype=np.complex128) / 2
+    sign = (-1) ** result
+    for i in range(3):
+        op_mat += sign * vec[i] * graphix.clifford.CLIFFORD[i + 1] / 2
+    return op_mat
+
+
+def perform_measure(
+    qubit: int, plane: graphix.pauli.Plane, angle: float, state, rng, pr_calc: bool = True
+) -> np.ndarray:
+    vec = plane.polar(angle)
+    if pr_calc:
+        op_mat = op_mat_from_result(vec, False)
+        prob_0 = state.expectation_single(op_mat, qubit)
+        result = rng.rand() > prob_0
+        if result:
+            op_mat = op_mat_from_result(vec, True)
+    else:
+        # choose the measurement result randomly
+        result = np.random.choice([0, 1])
+        op_mat = op_mat_from_result(vec, result)
+    state.evolve_single(op_mat, qubit)
+    return result
 
 
 class Backend:
@@ -27,27 +54,8 @@ class Backend:
             graphix.pauli.Plane[cmd[2]], s_signal % 2 == 1, t_signal % 2 == 1, graphix.clifford.TABLE[vop]
         )
         angle = angle * measure_update.coeff + measure_update.add_term
-        vec = measure_update.new_plane.polar(angle)
         loc = self.node_index.index(cmd[1])
-
-        def op_mat_from_result(result: bool) -> np.ndarray:
-            op_mat = np.eye(2, dtype=np.complex128) / 2
-            sign = (-1) ** result
-            for i in range(3):
-                op_mat += sign * vec[i] * graphix.clifford.CLIFFORD[i + 1] / 2
-            return op_mat
-
-        if self.pr_calc:
-            op_mat = op_mat_from_result(False)
-            prob_0 = self.state.expectation_single(op_mat, loc)
-            result = np.random.rand() > prob_0
-            if result:
-                op_mat = op_mat_from_result(True)
-        else:
-            # choose the measurement result randomly
-            result = np.random.choice([0, 1])
-            op_mat = op_mat_from_result(result)
+        result = perform_measure(loc, measure_update.new_plane, angle, self.state, np.random, self.pr_calc)
         self.results[cmd[1]] = result
-        self.state.evolve_single(op_mat, loc)
         self.node_index.remove(cmd[1])
         return loc

--- a/graphix/sim/density_matrix.py
+++ b/graphix/sim/density_matrix.py
@@ -297,7 +297,7 @@ class DensityMatrixBackend(graphix.sim.base_backend.Backend):
                 if False, measurements yield results 0/1 with 50% probabilities each.
         """
         # check that pattern has output nodes configured
-        assert len(pattern.output_nodes) > 0
+        # assert len(pattern.output_nodes) > 0
         self.pattern = pattern
         self.results = deepcopy(pattern.results)
         self.state = None

--- a/graphix/sim/statevec.py
+++ b/graphix/sim/statevec.py
@@ -26,7 +26,7 @@ class StatevectorBackend(graphix.sim.base_backend.Backend):
             if False, measurements yield results 0/1 with 50% probabilities each.
         """
         # check that pattern has output nodes configured
-        assert len(pattern.output_nodes) > 0
+        # assert len(pattern.output_nodes) > 0
         self.pattern = pattern
         self.results = deepcopy(pattern.results)
         self.state = None

--- a/graphix/simulator.py
+++ b/graphix/simulator.py
@@ -35,7 +35,7 @@ class PatternSimulator:
             :class:`graphix.sim.density_matrix.DensityMatrixBackend`\
         """
         # check that pattern has output nodes configured
-        assert len(pattern.output_nodes) > 0
+        # assert len(pattern.output_nodes) > 0
 
         if backend == "statevector" and noise_model is None:
             self.noise_model = None
@@ -61,12 +61,18 @@ class PatternSimulator:
         else:
             raise ValueError("Unknown backend.")
         self.pattern = pattern
-        self.results = self.backend.results
-        self.state = self.backend.state
         self.node_index = []
 
     def set_noise_model(self, model):
         self.noise_model = model
+
+    @property
+    def results(self):
+        return self.backend.results
+
+    @property
+    def state(self):
+        return self.backend.state
 
     def run(self):
         """Perform the simulation.

--- a/graphix/transpiler.py
+++ b/graphix/transpiler.py
@@ -5,6 +5,7 @@ accepts desired gate operations and transpile into MBQC measurement patterns.
 """
 
 from __future__ import annotations
+import dataclasses
 
 from copy import deepcopy
 from typing import Optional, Sequence
@@ -14,6 +15,34 @@ import numpy as np
 from graphix.ops import Ops
 from graphix.pattern import Pattern
 from graphix.sim.statevec import Statevec
+import graphix.pauli
+import graphix.sim.base_backend
+
+
+@dataclasses.dataclass
+class TranspileResult:
+    """
+    The result of a transpilation.
+
+    pattern : :class:`graphix.pattern.Pattern` object
+    classical_outputs : tuple[int,...], index of nodes measured with `M` gates
+    """
+
+    pattern: Pattern
+    classical_outputs: tuple[int, ...]
+
+
+@dataclasses.dataclass
+class SimulateResult:
+    """
+    The result of a simulation.
+
+    statevec : :class:`graphix.sim.statevec.Statevec` object
+    classical_measures : tuple[int,...], classical measures
+    """
+
+    statevec: Statevec
+    classical_measures: tuple[int, ...]
 
 
 class Circuit:
@@ -38,6 +67,7 @@ class Circuit:
         """
         self.width = width
         self.instruction = []
+        self.active_qubits = set(range(width))
 
     def cnot(self, control: int, target: int):
         """CNOT gate
@@ -49,8 +79,8 @@ class Circuit:
         target : int
             target qubit
         """
-        assert control in np.arange(self.width)
-        assert target in np.arange(self.width)
+        assert control in self.active_qubits
+        assert target in self.active_qubits
         assert control != target
         self.instruction.append(["CNOT", [control, target]])
 
@@ -64,8 +94,8 @@ class Circuit:
         qubit2 : int
             second qubit to be swapped
         """
-        assert qubit1 in np.arange(self.width)
-        assert qubit2 in np.arange(self.width)
+        assert qubit1 in self.active_qubits
+        assert qubit2 in self.active_qubits
         assert qubit1 != qubit2
         self.instruction.append(["SWAP", [qubit1, qubit2]])
 
@@ -77,7 +107,7 @@ class Circuit:
         qubit : int
             target qubit
         """
-        assert qubit in np.arange(self.width)
+        assert qubit in self.active_qubits
         self.instruction.append(["H", qubit])
 
     def s(self, qubit: int):
@@ -88,7 +118,7 @@ class Circuit:
         qubit : int
             target qubit
         """
-        assert qubit in np.arange(self.width)
+        assert qubit in self.active_qubits
         self.instruction.append(["S", qubit])
 
     def x(self, qubit):
@@ -99,7 +129,7 @@ class Circuit:
         qubit : int
             target qubit
         """
-        assert qubit in np.arange(self.width)
+        assert qubit in self.active_qubits
         self.instruction.append(["X", qubit])
 
     def y(self, qubit: int):
@@ -110,7 +140,7 @@ class Circuit:
         qubit : int
             target qubit
         """
-        assert qubit in np.arange(self.width)
+        assert qubit in self.active_qubits
         self.instruction.append(["Y", qubit])
 
     def z(self, qubit: int):
@@ -121,7 +151,7 @@ class Circuit:
         qubit : int
             target qubit
         """
-        assert qubit in np.arange(self.width)
+        assert qubit in self.active_qubits
         self.instruction.append(["Z", qubit])
 
     def rx(self, qubit: int, angle: float):
@@ -134,7 +164,7 @@ class Circuit:
         angle : float
             rotation angle in radian
         """
-        assert qubit in np.arange(self.width)
+        assert qubit in self.active_qubits
         self.instruction.append(["Rx", qubit, angle])
 
     def ry(self, qubit: int, angle: float):
@@ -147,7 +177,7 @@ class Circuit:
         angle : float
             angle in radian
         """
-        assert qubit in np.arange(self.width)
+        assert qubit in self.active_qubits
         self.instruction.append(["Ry", qubit, angle])
 
     def rz(self, qubit: int, angle: float):
@@ -160,7 +190,7 @@ class Circuit:
         angle : float
             rotation angle in radian
         """
-        assert qubit in np.arange(self.width)
+        assert qubit in self.active_qubits
         self.instruction.append(["Rz", qubit, angle])
 
     def rzz(self, control: int, target: int, angle: float):
@@ -182,8 +212,8 @@ class Circuit:
         angle : float
             rotation angle in radian
         """
-        assert control in np.arange(self.width)
-        assert target in np.arange(self.width)
+        assert control in self.active_qubits
+        assert target in self.active_qubits
         self.instruction.append(["Rzz", [control, target], angle])
 
     def ccx(self, control1: int, control2: int, target: int):
@@ -198,9 +228,9 @@ class Circuit:
         target : int
             target qubit
         """
-        assert control1 in np.arange(self.width)
-        assert control2 in np.arange(self.width)
-        assert target in np.arange(self.width)
+        assert control1 in self.active_qubits
+        assert control2 in self.active_qubits
+        assert target in self.active_qubits
         self.instruction.append(["CCX", [control1, control2, target]])
 
     def i(self, qubit: int):
@@ -211,10 +241,24 @@ class Circuit:
         qubit : int
             target qubit
         """
-        assert qubit in np.arange(self.width)
+        assert qubit in self.active_qubits
         self.instruction.append(["I", qubit])
 
-    def transpile(self, opt: bool = False):
+    def m(self, qubit: int, plane: graphix.pauli.Plane, angle: float):
+        """measure a quantum qubit
+
+        Parameters
+        ---------
+        qubit : int
+            target qubit
+        plane : graphix.pauli.Plane
+        angle : float
+        """
+        assert qubit in self.active_qubits
+        self.instruction.append(["M", qubit, plane, angle])
+        self.active_qubits.remove(qubit)
+
+    def transpile(self, opt: bool = False) -> TranspileResult:
         """gate-to-MBQC transpile function.
 
         Parameters
@@ -231,54 +275,67 @@ class Circuit:
         out = [j for j in range(self.width)]
         pattern = Pattern(input_nodes=input)
         # pattern.extend([["N", i] for i in range(self.width)])
+        classical_outputs = []
         for instr in self.instruction:
             if instr[0] == "CNOT":
                 ancilla = [Nnode, Nnode + 1]
+                assert out[instr[1][0]] is not None
+                assert out[instr[1][1]] is not None
                 out[instr[1][0]], out[instr[1][1]], seq = self._cnot_command(
                     out[instr[1][0]], out[instr[1][1]], ancilla
                 )
                 pattern.extend(seq)
                 Nnode += 2
             elif instr[0] == "SWAP":
+                assert out[instr[1][0]] is not None
+                assert out[instr[1][1]] is not None
                 out[instr[1][0]], out[instr[1][1]] = out[instr[1][1]], out[instr[1][0]]
             elif instr[0] == "I":
                 pass
             elif instr[0] == "H":
                 ancilla = Nnode
+                assert out[instr[1]] is not None
                 out[instr[1]], seq = self._h_command(out[instr[1]], ancilla)
                 pattern.extend(seq)
                 Nnode += 1
             elif instr[0] == "S":
                 ancilla = [Nnode, Nnode + 1]
+                assert out[instr[1]] is not None
                 out[instr[1]], seq = self._s_command(out[instr[1]], ancilla)
                 pattern.extend(seq)
                 Nnode += 2
             elif instr[0] == "X":
                 ancilla = [Nnode, Nnode + 1]
+                assert out[instr[1]] is not None
                 out[instr[1]], seq = self._x_command(out[instr[1]], ancilla)
                 pattern.extend(seq)
                 Nnode += 2
             elif instr[0] == "Y":
                 ancilla = [Nnode, Nnode + 1, Nnode + 2, Nnode + 3]
+                assert out[instr[1]] is not None
                 out[instr[1]], seq = self._y_command(out[instr[1]], ancilla)
                 pattern.extend(seq)
                 Nnode += 4
             elif instr[0] == "Z":
                 ancilla = [Nnode, Nnode + 1]
+                assert out[instr[1]] is not None
                 out[instr[1]], seq = self._z_command(out[instr[1]], ancilla)
                 pattern.extend(seq)
                 Nnode += 2
             elif instr[0] == "Rx":
                 ancilla = [Nnode, Nnode + 1]
+                assert out[instr[1]] is not None
                 out[instr[1]], seq = self._rx_command(out[instr[1]], ancilla, instr[2])
                 pattern.extend(seq)
                 Nnode += 2
             elif instr[0] == "Ry":
                 ancilla = [Nnode, Nnode + 1, Nnode + 2, Nnode + 3]
+                assert out[instr[1]] is not None
                 out[instr[1]], seq = self._ry_command(out[instr[1]], ancilla, instr[2])
                 pattern.extend(seq)
                 Nnode += 4
             elif instr[0] == "Rz":
+                assert out[instr[1]] is not None
                 if opt:
                     ancilla = Nnode
                     out[instr[1]], seq = self._rz_command_opt(out[instr[1]], ancilla, instr[2])
@@ -290,6 +347,8 @@ class Circuit:
                     pattern.extend(seq)
                     Nnode += 2
             elif instr[0] == "Rzz":
+                assert out[instr[1][0]] is not None
+                assert out[instr[1][1]] is not None
                 if opt:
                     ancilla = Nnode
                     out[instr[1][0]], out[instr[1][1]], seq = self._rzz_command_opt(
@@ -323,12 +382,21 @@ class Circuit:
                     ) = self._ccx_command(out[instr[1][0]], out[instr[1][1]], out[instr[1][2]], ancilla)
                     pattern.extend(seq)
                     Nnode += 18
+            elif instr[0] == "M":
+                _, circuit_index, plane, angle = instr
+                node_index = out[circuit_index]
+                assert node_index is not None
+                seq = self._m_command(node_index, plane, angle)
+                pattern.extend(seq)
+                classical_outputs.append(node_index)
+                out[instr[1]] = None
             else:
                 raise ValueError("Unknown instruction, commands not added")
+        out = filter(lambda node: node is not None, out)
         pattern.reorder_output_nodes(out)
-        return pattern
+        return TranspileResult(pattern, tuple(classical_outputs))
 
-    def standardize_and_transpile(self, opt: bool = True):
+    def standardize_and_transpile(self, opt: bool = True) -> TranspileResult:
         """gate-to-MBQC transpile function.
         Commutes all byproduct through gates, instead of through measurement
         commands, to generate standardized measurement pattern.
@@ -351,9 +419,12 @@ class Circuit:
         Nnode = self.width
         inputs = [j for j in range(self.width)]
         out = [j for j in range(self.width)]
+        classical_outputs = []
         for instr in self.instruction:
             if instr[0] == "CNOT":
                 ancilla = [Nnode, Nnode + 1]
+                assert out[instr[1][0]] is not None
+                assert out[instr[1][1]] is not None
                 out[instr[1][0]], out[instr[1][1]], seq = self._cnot_command(
                     out[instr[1][0]], out[instr[1][1]], ancilla
                 )
@@ -366,12 +437,15 @@ class Circuit:
                 self._instr.append(["ZC", instr[1][1], seq[8][2]])
                 self._instr.append(["ZC", instr[1][0], seq[9][2]])
             elif instr[0] == "SWAP":
+                assert out[instr[1][0]] is not None
+                assert out[instr[1][1]] is not None
                 out[instr[1][0]], out[instr[1][1]] = out[instr[1][1]], out[instr[1][0]]
                 self._instr.append(instr)
             elif instr[0] == "I":
                 pass
             elif instr[0] == "H":
                 ancilla = Nnode
+                assert out[instr[1]] is not None
                 out[instr[1]], seq = self._h_command(out[instr[1]], ancilla)
                 self._N.append(seq[0])
                 self._E.append(seq[1])
@@ -381,6 +455,7 @@ class Circuit:
                 Nnode += 1
             elif instr[0] == "S":
                 ancilla = [Nnode, Nnode + 1]
+                assert out[instr[1]] is not None
                 out[instr[1]], seq = self._s_command(out[instr[1]], ancilla)
                 self._N.extend(seq[0:2])
                 self._E.extend(seq[2:4])
@@ -391,6 +466,7 @@ class Circuit:
                 Nnode += 2
             elif instr[0] == "X":
                 ancilla = [Nnode, Nnode + 1]
+                assert out[instr[1]] is not None
                 out[instr[1]], seq = self._x_command(out[instr[1]], ancilla)
                 self._N.extend(seq[0:2])
                 self._E.extend(seq[2:4])
@@ -401,6 +477,7 @@ class Circuit:
                 Nnode += 2
             elif instr[0] == "Y":
                 ancilla = [Nnode, Nnode + 1, Nnode + 2, Nnode + 3]
+                assert out[instr[1]] is not None
                 out[instr[1]], seq = self._y_command(out[instr[1]], ancilla)
                 self._N.extend(seq[0:4])
                 self._E.extend(seq[4:8])
@@ -411,6 +488,7 @@ class Circuit:
                 Nnode += 4
             elif instr[0] == "Z":
                 ancilla = [Nnode, Nnode + 1]
+                assert out[instr[1]] is not None
                 out[instr[1]], seq = self._z_command(out[instr[1]], ancilla)
                 self._N.extend(seq[0:2])
                 self._E.extend(seq[2:4])
@@ -421,6 +499,7 @@ class Circuit:
                 Nnode += 2
             elif instr[0] == "Rx":
                 ancilla = [Nnode, Nnode + 1]
+                assert out[instr[1]] is not None
                 out[instr[1]], seq = self._rx_command(out[instr[1]], ancilla, instr[2])
                 self._N.extend(seq[0:2])
                 self._E.extend(seq[2:4])
@@ -433,6 +512,7 @@ class Circuit:
                 Nnode += 2
             elif instr[0] == "Ry":
                 ancilla = [Nnode, Nnode + 1, Nnode + 2, Nnode + 3]
+                assert out[instr[1]] is not None
                 out[instr[1]], seq = self._ry_command(out[instr[1]], ancilla, instr[2])
                 self._N.extend(seq[0:4])
                 self._E.extend(seq[4:8])
@@ -444,6 +524,7 @@ class Circuit:
                 self._instr.append(["ZC", instr[1], seq[13][2]])
                 Nnode += 4
             elif instr[0] == "Rz":
+                assert out[instr[1]] is not None
                 if opt:
                     ancilla = Nnode
                     out[instr[1]], seq = self._rz_command_opt(out[instr[1]], ancilla, instr[2])
@@ -468,6 +549,8 @@ class Circuit:
                     self._instr.append(["ZC", instr[1], seq[7][2]])
                     Nnode += 2
             elif instr[0] == "Rzz":
+                assert out[instr[1][0]] is not None
+                assert out[instr[1][1]] is not None
                 ancilla = Nnode
                 out[instr[1][0]], out[instr[1][1]], seq = self._rzz_command_opt(
                     out[instr[1][0]], out[instr[1][1]], ancilla, instr[2]
@@ -481,6 +564,12 @@ class Circuit:
                 self._instr.append(instr_)
                 self._instr.append(["ZC", instr[1][1], seq[4][2]])
                 self._instr.append(["ZC", instr[1][0], seq[5][2]])
+            elif instr[0] == "M":
+                node_index = out[instr[1]]
+                assert node_index is not None
+                seq = self._m_command(node_index)
+                classical_outputs.append(node_index)
+                out[instr[1]] = None
             else:
                 raise ValueError("Unknown instruction, commands not added")
 
@@ -521,8 +610,9 @@ class Circuit:
             command_seq.append(cmd)
         pattern = Pattern(input_nodes=inputs)
         pattern.extend(command_seq)
+        out = filter(lambda node: node is not None, out)
         pattern.reorder_output_nodes(out)
-        return pattern
+        return TranspileResult(pattern, classical_outputs)
 
     def _commute_with_swap(self, target: int):
         assert self._instr[target][0] in ["XC", "ZC"]
@@ -730,6 +820,29 @@ class Circuit:
         seq.append(["Z", ancilla[1], [target_node]])
         seq.append(["Z", control_node, [target_node]])
         return control_node, ancilla[1], seq
+
+    @classmethod
+    def _m_command(self, input_node: int, plane: graphix.pauli.Plane, angle: float):
+        """MBQC commands for measuring qubit
+
+        Parameters
+        ---------
+        input_node : int
+            target node on graph
+        plane : graphix.pauli.Plane
+            plane of the measure
+        angle : float
+            angle of the measure (unit: pi radian)
+
+        Returns
+        ---------
+        commands : list
+            list of MBQC commands
+        """
+        seq = [
+            ["M", input_node, plane.name, angle, [], []],
+        ]
+        return seq
 
     @classmethod
     def _h_command(self, input_node: int, ancilla: int):
@@ -1253,7 +1366,7 @@ class Circuit:
 
         Returns
         -------
-        stete : :meth:`~graphix.Statevec`
+        state : :meth:`~graphix.Statevec`
             output state of the statevector simulation.
         """
 
@@ -1261,6 +1374,8 @@ class Circuit:
             state = Statevec(nqubit=self.width)
         else:
             state = input_state
+
+        classical_measures = []
 
         for i in range(len(self.instruction)):
             if self.instruction[i][0] == "CNOT":
@@ -1289,7 +1404,11 @@ class Circuit:
                 state.evolve(Ops.Rzz(self.instruction[i][2]), [self.instruction[i][1][0], self.instruction[i][1][1]])
             elif self.instruction[i][0] == "CCX":
                 state.evolve(Ops.ccx, [self.instruction[i][1][0], self.instruction[i][1][1], self.instruction[i][1][2]])
+            elif self.instruction[i][0] == "M":
+                _, qubit, plane, angle = self.instruction[i]
+                result = graphix.sim.base_backend.perform_measure(qubit, plane, angle * np.pi, state, np.random)
+                classical_measures.append(result)
             else:
                 raise ValueError(f"Unknown instruction: {self.instruction[i][0]}")
 
-        return state
+        return SimulateResult(state, classical_measures)

--- a/graphix/transpiler.py
+++ b/graphix/transpiler.py
@@ -247,6 +247,8 @@ class Circuit:
     def m(self, qubit: int, plane: graphix.pauli.Plane, angle: float):
         """measure a quantum qubit
 
+        The measured qubit cannot be used afterwards.
+
         Parameters
         ---------
         qubit : int
@@ -268,7 +270,7 @@ class Circuit:
 
         Returns
         --------
-        pattern : :class:`graphix.pattern.Pattern` object
+        result : :class:`TranspileResult` object
         """
         Nnode = self.width
         input = [j for j in range(self.width)]
@@ -1357,17 +1359,17 @@ class Circuit:
             elif cmd[1] in old_out:
                 cmd[1] = output_nodes[old_out.index(cmd[1])]
 
-    def simulate_statevector(self, input_state: Optional[Statevec] = None):
+    def simulate_statevector(self, input_state: Optional[Statevec] = None) -> SimulateResult:
         """Run statevector simultion of the gate sequence, using graphix.Statevec
 
         Parameters
         ----------
-        input_state : :meth:`~graphix.Statevec`
+        input_state : :class:`graphix.Statevec`
 
         Returns
         -------
-        state : :meth:`~graphix.Statevec`
-            output state of the statevector simulation.
+        result : :class:`SimulateResult`
+            output state of the statevector simulation and results of classical measures.
         """
 
         if input_state is None:

--- a/tests/test_density_matrix.py
+++ b/tests/test_density_matrix.py
@@ -782,7 +782,7 @@ class DensityMatrixBackendTest(unittest.TestCase):
     def test_init_success(self):
         circ = Circuit(1)
         circ.rx(0, np.pi / 2)
-        pattern = circ.transpile()
+        pattern = circ.transpile().pattern
         backend = DensityMatrixBackend(pattern)
         assert backend.pattern == pattern
         assert backend.results == pattern.results
@@ -793,7 +793,7 @@ class DensityMatrixBackendTest(unittest.TestCase):
 
     def test_add_nodes(self):
         circ = Circuit(1)
-        pattern = circ.transpile()
+        pattern = circ.transpile().pattern
         backend = DensityMatrixBackend(pattern)
         backend.add_nodes([0, 1])
         expected_matrix = np.array([0.25] * 16).reshape(4, 4)
@@ -801,7 +801,7 @@ class DensityMatrixBackendTest(unittest.TestCase):
 
     def test_entangle_nodes(self):
         circ = Circuit(1)
-        pattern = circ.transpile()
+        pattern = circ.transpile().pattern
         backend = DensityMatrixBackend(pattern)
         backend.add_nodes([0, 1])
         backend.entangle_nodes((0, 1))
@@ -814,7 +814,7 @@ class DensityMatrixBackendTest(unittest.TestCase):
     def test_measure(self):
         circ = Circuit(1)
         circ.rx(0, np.pi / 2)
-        pattern = circ.transpile()
+        pattern = circ.transpile().pattern
 
         backend = DensityMatrixBackend(pattern)
         backend.add_nodes([0, 1, 2])
@@ -830,7 +830,7 @@ class DensityMatrixBackendTest(unittest.TestCase):
         # circuit there just to provide a measurement command to try out. Weird.
         circ = Circuit(1)
         circ.rx(0, np.pi / 2)
-        pattern = circ.transpile()
+        pattern = circ.transpile().pattern
 
         backend = DensityMatrixBackend(pattern, pr_calc=True)
         backend.add_nodes([0, 1, 2])
@@ -849,7 +849,7 @@ class DensityMatrixBackendTest(unittest.TestCase):
 
         circ = Circuit(1)
         circ.rx(0, np.pi / 2)
-        pattern = circ.transpile()
+        pattern = circ.transpile().pattern
 
         backend = DensityMatrixBackend(pattern)
         backend.add_nodes([0, 1, 2])

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -55,7 +55,7 @@ class TestGenerator(unittest.TestCase):
         pairs = [(0, 1), (1, 2)]
         circuit = rc.generate_gate(nqubits, depth, pairs)
         # transpile into graph
-        pattern = circuit.transpile()
+        pattern = circuit.transpile().pattern
         pattern.standardize()
         pattern.shift_signals()
         # get the graph and generate pattern again with flow algorithm
@@ -73,7 +73,7 @@ class TestGenerator(unittest.TestCase):
         pattern2.standardize()
         pattern2.shift_signals()
         pattern2.minimize_space()
-        state = circuit.simulate_statevector()
+        state = circuit.simulate_statevector().statevec
         state_mbqc = pattern2.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 

--- a/tests/test_gflow.py
+++ b/tests/test_gflow.py
@@ -272,7 +272,7 @@ class TestGflow(unittest.TestCase):
         # test for large graph
         # graph transpiled from circuit always has a flow
         circ = get_rand_circuit(10, 10, seed=seed)
-        pattern = circ.transpile()
+        pattern = circ.transpile().pattern
         nodes, edges = pattern.get_graph()
         graph = nx.Graph()
         graph.add_nodes_from(nodes)
@@ -289,7 +289,7 @@ class TestGflow(unittest.TestCase):
         # test for large graph
         # pauli-node measured graph always has gflow
         circ = get_rand_circuit(5, 5, seed=seed)
-        pattern = circ.transpile()
+        pattern = circ.transpile().pattern
         pattern.standardize()
         pattern.shift_signals()
         pattern.perform_pauli_measurements()

--- a/tests/test_noisy_density_matrix.py
+++ b/tests/test_noisy_density_matrix.py
@@ -90,19 +90,18 @@ class NoisyDensityMatrixBackendTest(unittest.TestCase):
         # Hadamard pattern
         ncirc = Circuit(1)
         ncirc.h(0)
-        self.hadamardpattern = ncirc.transpile()
+        self.hadamardpattern = ncirc.transpile().pattern
 
         # Rz(alpha) pattern
         self.alpha = 2 * np.pi * self.rng.random()
         print(f"alpha is {self.alpha}")
         circ = Circuit(1)
         circ.rz(0, self.alpha)
-        self.rzpattern = circ.transpile()
+        self.rzpattern = circ.transpile().pattern
         self.rz_exact_res = 0.5 * np.array([[1.0, np.exp(-1j * self.alpha)], [np.exp(1j * self.alpha), 1.0]])
 
     # test noiseless noisy vs noiseless
     def test_noiseless_noisy_hadamard(self):
-
         noiselessres = self.hadamardpattern.simulate_pattern(backend="densitymatrix")
         # noiseless noise model
         noisynoiselessres = self.hadamardpattern.simulate_pattern(
@@ -114,7 +113,6 @@ class NoisyDensityMatrixBackendTest(unittest.TestCase):
 
     # test measurement confuse outcome
     def test_noisy_measure_confuse_hadamard(self):
-
         res = self.hadamardpattern.simulate_pattern(
             backend="densitymatrix", noise_model=TestNoiseModel(measure_error_prob=1.0)
         )
@@ -133,7 +131,6 @@ class NoisyDensityMatrixBackendTest(unittest.TestCase):
         )
 
     def test_noisy_measure_channel_hadamard(self):
-
         measure_channel_pr = self.rng.random()
         print(f"measure_channel_pr = {measure_channel_pr}")
         # measurement error only
@@ -147,7 +144,6 @@ class NoisyDensityMatrixBackendTest(unittest.TestCase):
 
     # test Pauli X error
     def test_noisy_X_hadamard(self):
-
         # x error only
         x_error_pr = self.rng.random()
         print(f"x_error_pr = {x_error_pr}")
@@ -163,7 +159,6 @@ class NoisyDensityMatrixBackendTest(unittest.TestCase):
 
     # test entanglement error
     def test_noisy_entanglement_hadamard(self):
-
         entanglement_error_pr = np.random.rand()
         res = self.hadamardpattern.simulate_pattern(
             backend="densitymatrix", noise_model=TestNoiseModel(entanglement_error_prob=entanglement_error_pr)
@@ -192,7 +187,6 @@ class NoisyDensityMatrixBackendTest(unittest.TestCase):
 
     # test preparation error
     def test_noisy_preparation_hadamard(self):
-
         prepare_error_pr = self.rng.random()
         print(f"prepare_error_pr = {prepare_error_pr}")
         res = self.hadamardpattern.simulate_pattern(
@@ -207,7 +201,6 @@ class NoisyDensityMatrixBackendTest(unittest.TestCase):
 
     # test noiseless noisy vs noiseless
     def test_noiseless_noisy_rz(self):
-
         noiselessres = self.rzpattern.simulate_pattern(backend="densitymatrix")
         # noiseless noise model or TestNoiseModel() since all probas are 0
         noisynoiselessres = self.rzpattern.simulate_pattern(
@@ -223,7 +216,6 @@ class NoisyDensityMatrixBackendTest(unittest.TestCase):
 
     # test preparation error
     def test_noisy_preparation_rz(self):
-
         prepare_error_pr = self.rng.random()
         print(f"prepare_error_pr = {prepare_error_pr}")
         res = self.rzpattern.simulate_pattern(
@@ -253,7 +245,6 @@ class NoisyDensityMatrixBackendTest(unittest.TestCase):
 
     # test entanglement error
     def test_noisy_entanglement_rz(self):
-
         entanglement_error_pr = np.random.rand()
         res = self.rzpattern.simulate_pattern(
             backend="densitymatrix", noise_model=TestNoiseModel(entanglement_error_prob=entanglement_error_pr)
@@ -299,7 +290,6 @@ class NoisyDensityMatrixBackendTest(unittest.TestCase):
         )
 
     def test_noisy_measure_channel_rz(self):
-
         measure_channel_pr = self.rng.random()
         print(f"measure_channel_pr = {measure_channel_pr}")
         # measurement error only
@@ -329,7 +319,6 @@ class NoisyDensityMatrixBackendTest(unittest.TestCase):
         )
 
     def test_noisy_X_rz(self):
-
         # x error only
         x_error_pr = self.rng.random()
         print(f"x_error_pr = {x_error_pr}")
@@ -353,7 +342,6 @@ class NoisyDensityMatrixBackendTest(unittest.TestCase):
         )
 
     def test_noisy_Z_rz(self):
-
         # z error only
         z_error_pr = self.rng.random()
         print(f"z_error_pr = {z_error_pr}")
@@ -377,7 +365,6 @@ class NoisyDensityMatrixBackendTest(unittest.TestCase):
         )
 
     def test_noisy_XZ_rz(self):
-
         # x and z errors
         x_error_pr = self.rng.random()
         print(f"x_error_pr = {x_error_pr}")
@@ -424,7 +411,6 @@ class NoisyDensityMatrixBackendTest(unittest.TestCase):
 
     # test measurement confuse outcome
     def test_noisy_measure_confuse_rz(self):
-
         # probability 1 to shift both outcome
         res = self.rzpattern.simulate_pattern(
             backend="densitymatrix", noise_model=TestNoiseModel(measure_error_prob=1.0)

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -60,14 +60,20 @@ class TestPattern(unittest.TestCase):
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_empty_output_nodes(self):
+    @parameterized.expand(["statevector", "densitymatrix", "tensornetwork"])
+    def test_empty_output_nodes(self, backend):
         pattern = Pattern(input_nodes=[0])
         pattern.add(["M", 0, "XY", 0.5, [], []])
 
         def simulate_and_measure():
-            sim = PatternSimulator(pattern)
+            sim = PatternSimulator(pattern, backend)
             sim.run()
-            assert sim.state.dims() == ()
+            if backend == "statevector":
+                assert sim.state.dims() == ()
+            elif backend == "densitymatrix":
+                assert sim.state.dims() == (1, 1)
+            elif backend == "tensornetwork":
+                assert sim.state.to_statevector().shape == (1,)
             return sim.results[0]
 
         nb_shots = 1000

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -7,6 +7,7 @@ from parameterized import parameterized
 import tests.random_circuit as rc
 from graphix.pattern import CommandNode, Pattern
 from graphix.transpiler import Circuit
+from graphix.simulator import PatternSimulator
 
 SEED = 42
 rc.set_seed(SEED)
@@ -58,6 +59,19 @@ class TestPattern(unittest.TestCase):
         state = circuit.simulate_statevector()
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+
+    def test_empty_output_nodes(self):
+        pattern = Pattern(input_nodes=[0])
+        pattern.add(["M", 0, "XY", np.pi / 2, [], []])
+        nb_shots = 100
+        nb_ones = 0
+        for _ in range(nb_shots):
+            sim = PatternSimulator(pattern)
+            sim.run()
+            assert sim.state.dims() == ()
+            if sim.results[0]:
+                nb_ones += 1
+        assert abs(nb_ones - nb_shots / 2) < nb_shots / 20
 
     def test_minimize_space_graph_maxspace_with_flow(self):
         max_qubits = 20

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -64,7 +64,7 @@ class TestPatternRunner(unittest.TestCase):
         circuit.cnot(0, 1)
         circuit.cnot(1, 2)
 
-        pattern = circuit.transpile()
+        pattern = circuit.transpile().pattern
         state = pattern.simulate_pattern()
 
         runner = PatternRunner(pattern, backend="ibmq", save_statevector=True)

--- a/tests/test_tnsim.py
+++ b/tests/test_tnsim.py
@@ -52,7 +52,7 @@ class TestTN(unittest.TestCase):
     def test_entangle_nodes(self):
         random_vec = np.array([1.0, 1.0, 1.0, 1.0]).reshape(2, 2)
         circuit = Circuit(2)
-        pattern = circuit.transpile()
+        pattern = circuit.transpile().pattern
         pattern.add(["E", (0, 1)])
         tn = pattern.simulate_pattern(backend="tensornetwork", graph_prep="sequential")
         dummy_index = [gen_str() for _ in range(2)]
@@ -80,7 +80,7 @@ class TestTN(unittest.TestCase):
         random_vec = np.random.randn(2)
 
         circuit = Circuit(1)
-        pattern = circuit.transpile()
+        pattern = circuit.transpile().pattern
         pattern.results[15] = 1  # X&Z operator will be applied.
         for cmd in cmds:
             pattern.add(cmd)
@@ -104,8 +104,8 @@ class TestTN(unittest.TestCase):
 
     def test_expectation_value1(self):
         circuit = Circuit(1)
-        state = circuit.simulate_statevector()
-        pattern = circuit.transpile()
+        state = circuit.simulate_statevector().statevec
+        pattern = circuit.transpile().pattern
         tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
         random_op1 = random_op(1)
         value1 = state.expectation_value(random_op1, [0])
@@ -114,8 +114,8 @@ class TestTN(unittest.TestCase):
 
     def test_expectation_value2(self):
         circuit = Circuit(2)
-        state = circuit.simulate_statevector()
-        pattern = circuit.transpile()
+        state = circuit.simulate_statevector().statevec
+        pattern = circuit.transpile().pattern
         tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
         random_op2 = random_op(2)
         input = [0, 1]
@@ -126,8 +126,8 @@ class TestTN(unittest.TestCase):
 
     def test_expectation_value3(self):
         circuit = Circuit(3)
-        state = circuit.simulate_statevector()
-        pattern = circuit.transpile()
+        state = circuit.simulate_statevector().statevec
+        pattern = circuit.transpile().pattern
         tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
         random_op3 = random_op(3)
         input = [0, 1, 2]
@@ -138,8 +138,8 @@ class TestTN(unittest.TestCase):
 
     def test_expectation_value3_sequential(self):
         circuit = Circuit(3)
-        state = circuit.simulate_statevector()
-        pattern = circuit.transpile()
+        state = circuit.simulate_statevector().statevec
+        pattern = circuit.transpile().pattern
         tn_mbqc = pattern.simulate_pattern(backend="tensornetwork", graph_prep="sequential")
         random_op3 = random_op(3)
         input = [0, 1, 2]
@@ -150,8 +150,8 @@ class TestTN(unittest.TestCase):
 
     def test_expectation_value3_subspace1(self):
         circuit = Circuit(3)
-        state = circuit.simulate_statevector()
-        pattern = circuit.transpile()
+        state = circuit.simulate_statevector().statevec
+        pattern = circuit.transpile().pattern
         tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
         random_op1 = random_op(1)
         input = [0, 1, 2]
@@ -162,8 +162,8 @@ class TestTN(unittest.TestCase):
 
     def test_expectation_value3_subspace2(self):
         circuit = Circuit(3)
-        state = circuit.simulate_statevector()
-        pattern = circuit.transpile()
+        state = circuit.simulate_statevector().statevec
+        pattern = circuit.transpile().pattern
         tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
         random_op2 = random_op(2)
         input = [0, 1, 2]
@@ -174,8 +174,8 @@ class TestTN(unittest.TestCase):
 
     def test_expectation_value3_subspace2_sequential(self):
         circuit = Circuit(3)
-        state = circuit.simulate_statevector()
-        pattern = circuit.transpile()
+        state = circuit.simulate_statevector().statevec
+        pattern = circuit.transpile().pattern
         tn_mbqc = pattern.simulate_pattern(backend="tensornetwork", graph_prep="sequential")
         random_op2 = random_op(2)
         input = [0, 1, 2]
@@ -187,9 +187,9 @@ class TestTN(unittest.TestCase):
     def test_hadamard(self):
         circuit = Circuit(1)
         circuit.h(0)
-        pattern = circuit.transpile()
+        pattern = circuit.transpile().pattern
         pattern.standardize()
-        state = circuit.simulate_statevector()
+        state = circuit.simulate_statevector().statevec
         tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
         random_op1 = random_op(1)
         value1 = state.expectation_value(random_op1, [0])
@@ -202,8 +202,8 @@ class TestTN(unittest.TestCase):
     def test_s(self):
         circuit = Circuit(1)
         circuit.s(0)
-        pattern = circuit.transpile()
-        state = circuit.simulate_statevector()
+        pattern = circuit.transpile().pattern
+        state = circuit.simulate_statevector().statevec
         tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
         random_op1 = random_op(1)
         value1 = state.expectation_value(random_op1, [0])
@@ -213,8 +213,8 @@ class TestTN(unittest.TestCase):
     def test_x(self):
         circuit = Circuit(1)
         circuit.x(0)
-        pattern = circuit.transpile()
-        state = circuit.simulate_statevector()
+        pattern = circuit.transpile().pattern
+        state = circuit.simulate_statevector().statevec
         tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
         random_op1 = random_op(1)
         value1 = state.expectation_value(random_op1, [0])
@@ -224,8 +224,8 @@ class TestTN(unittest.TestCase):
     def test_y(self):
         circuit = Circuit(1)
         circuit.y(0)
-        pattern = circuit.transpile()
-        state = circuit.simulate_statevector()
+        pattern = circuit.transpile().pattern
+        state = circuit.simulate_statevector().statevec
         tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
         random_op1 = random_op(1)
         value1 = state.expectation_value(random_op1, [0])
@@ -235,8 +235,8 @@ class TestTN(unittest.TestCase):
     def test_z(self):
         circuit = Circuit(1)
         circuit.z(0)
-        pattern = circuit.transpile()
-        state = circuit.simulate_statevector()
+        pattern = circuit.transpile().pattern
+        state = circuit.simulate_statevector().statevec
         tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
         random_op1 = random_op(1)
         value1 = state.expectation_value(random_op1, [0])
@@ -247,8 +247,8 @@ class TestTN(unittest.TestCase):
         theta = np.random.random() * 2 * np.pi
         circuit = Circuit(1)
         circuit.rx(0, theta)
-        pattern = circuit.transpile()
-        state = circuit.simulate_statevector()
+        pattern = circuit.transpile().pattern
+        state = circuit.simulate_statevector().statevec
         tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
         random_op1 = random_op(1)
         value1 = state.expectation_value(random_op1, [0])
@@ -259,8 +259,8 @@ class TestTN(unittest.TestCase):
         theta = np.random.random() * 2 * np.pi
         circuit = Circuit(1)
         circuit.ry(0, theta)
-        pattern = circuit.transpile()
-        state = circuit.simulate_statevector()
+        pattern = circuit.transpile().pattern
+        state = circuit.simulate_statevector().statevec
         tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
         random_op1 = random_op(1)
         value1 = state.expectation_value(random_op1, [0])
@@ -271,8 +271,8 @@ class TestTN(unittest.TestCase):
         theta = np.random.random() * 2 * np.pi
         circuit = Circuit(1)
         circuit.rz(0, theta)
-        pattern = circuit.transpile()
-        state = circuit.simulate_statevector()
+        pattern = circuit.transpile().pattern
+        state = circuit.simulate_statevector().statevec
         tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
         random_op1 = random_op(1)
         value1 = state.expectation_value(random_op1, [0])
@@ -282,8 +282,8 @@ class TestTN(unittest.TestCase):
     def test_i(self):
         circuit = Circuit(1)
         circuit.i(0)
-        pattern = circuit.transpile()
-        state = circuit.simulate_statevector()
+        pattern = circuit.transpile().pattern
+        state = circuit.simulate_statevector().statevec
         tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
         random_op1 = random_op(1)
         value1 = state.expectation_value(random_op1, [0])
@@ -293,9 +293,9 @@ class TestTN(unittest.TestCase):
     def test_cnot(self):
         circuit = Circuit(2)
         circuit.cnot(0, 1)
-        pattern = circuit.transpile()
+        pattern = circuit.transpile().pattern
         pattern.standardize()
-        state = circuit.simulate_statevector()
+        state = circuit.simulate_statevector().statevec
         tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
         random_op2 = random_op(2)
         value1 = state.expectation_value(random_op2, [0, 1])
@@ -308,9 +308,9 @@ class TestTN(unittest.TestCase):
         for _ in range(10):
             circuit = rc.get_rand_circuit(nqubits, depth)
             circuit.ccx(0, 1, 2)
-            pattern = circuit.transpile()
+            pattern = circuit.transpile().pattern
             pattern.minimize_space()
-            state = circuit.simulate_statevector()
+            state = circuit.simulate_statevector().statevec
             tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
             random_op3 = random_op(3)
             value1 = state.expectation_value(random_op3, [0, 1, 2])
@@ -322,11 +322,11 @@ class TestTN(unittest.TestCase):
         depth = 6
         for i in range(10):
             circuit = rc.get_rand_circuit(nqubits, depth)
-            pattern = circuit.transpile()
+            pattern = circuit.transpile().pattern
             pattern.standardize()
             pattern.shift_signals()
             pattern.perform_pauli_measurements()
-            state = circuit.simulate_statevector()
+            state = circuit.simulate_statevector().statevec
             tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
             random_op3 = random_op(3)
             input = [0, 1, 2]
@@ -340,11 +340,11 @@ class TestTN(unittest.TestCase):
         depth = 6
         for i in range(10):
             circuit = rc.get_rand_circuit(nqubits, depth)
-            pattern = circuit.transpile()
+            pattern = circuit.transpile().pattern
             pattern.standardize()
             pattern.shift_signals()
             pattern.perform_pauli_measurements()
-            state = circuit.simulate_statevector()
+            state = circuit.simulate_statevector().statevec
             tn_mbqc = pattern.simulate_pattern(backend="tensornetwork", graph_prep="sequential")
             random_op3 = random_op(3)
             input = [0, 1, 2]
@@ -358,9 +358,9 @@ class TestTN(unittest.TestCase):
         depth = 2
         for i in range(10):
             circuit = rc.get_rand_circuit(nqubits, depth)
-            pattern = circuit.standardize_and_transpile()
+            pattern = circuit.standardize_and_transpile().pattern
 
-            statevec_ref = circuit.simulate_statevector()
+            statevec_ref = circuit.simulate_statevector().statevec
 
             tn = pattern.simulate_pattern("tensornetwork")
             for number in range(len(statevec_ref.flatten())):
@@ -377,8 +377,8 @@ class TestTN(unittest.TestCase):
             self.subTest(nqubit=nqubits)
             for i in range(5):
                 circuit = rc.get_rand_circuit(nqubits, depth)
-                pattern = circuit.standardize_and_transpile()
-                statevec_ref = circuit.simulate_statevector()
+                pattern = circuit.standardize_and_transpile().pattern
+                statevec_ref = circuit.simulate_statevector().statevec
 
                 tn = pattern.simulate_pattern("tensornetwork")
                 statevec_tn = tn.to_statevector()
@@ -391,11 +391,11 @@ class TestTN(unittest.TestCase):
         depth = 6
         for i in range(10):
             circuit = rc.get_rand_circuit(nqubits, depth)
-            pattern = circuit.transpile()
+            pattern = circuit.transpile().pattern
             pattern.standardize()
             pattern.shift_signals()
             pattern.perform_pauli_measurements()
-            state = circuit.simulate_statevector()
+            state = circuit.simulate_statevector().statevec
             tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
             random_op3 = random_op(3)
             random_op3_exp = random_op(3)

--- a/tests/test_transpiler.py
+++ b/tests/test_transpiler.py
@@ -4,6 +4,8 @@ import numpy as np
 
 import tests.random_circuit as rc
 from graphix.transpiler import Circuit
+import graphix.pauli
+import graphix.simulator
 
 SEED = 42
 rc.set_seed(SEED)
@@ -13,48 +15,48 @@ class TestTranspiler_UnitGates(unittest.TestCase):
     def test_cnot(self):
         circuit = Circuit(2)
         circuit.cnot(0, 1)
-        pattern = circuit.transpile()
-        state = circuit.simulate_statevector()
+        pattern = circuit.transpile().pattern
+        state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
     def test_hadamard(self):
         circuit = Circuit(1)
         circuit.h(0)
-        pattern = circuit.transpile()
-        state = circuit.simulate_statevector()
+        pattern = circuit.transpile().pattern
+        state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
     def test_s(self):
         circuit = Circuit(1)
         circuit.s(0)
-        pattern = circuit.transpile()
-        state = circuit.simulate_statevector()
+        pattern = circuit.transpile().pattern
+        state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
     def test_x(self):
         circuit = Circuit(1)
         circuit.x(0)
-        pattern = circuit.transpile()
-        state = circuit.simulate_statevector()
+        pattern = circuit.transpile().pattern
+        state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
     def test_y(self):
         circuit = Circuit(1)
         circuit.y(0)
-        pattern = circuit.transpile()
-        state = circuit.simulate_statevector()
+        pattern = circuit.transpile().pattern
+        state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
     def test_z(self):
         circuit = Circuit(1)
         circuit.z(0)
-        pattern = circuit.transpile()
-        state = circuit.simulate_statevector()
+        pattern = circuit.transpile().pattern
+        state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
@@ -62,8 +64,8 @@ class TestTranspiler_UnitGates(unittest.TestCase):
         theta = np.random.random() * 2 * np.pi
         circuit = Circuit(1)
         circuit.rx(0, theta)
-        pattern = circuit.transpile()
-        state = circuit.simulate_statevector()
+        pattern = circuit.transpile().pattern
+        state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
@@ -71,8 +73,8 @@ class TestTranspiler_UnitGates(unittest.TestCase):
         theta = np.random.random() * 2 * np.pi
         circuit = Circuit(1)
         circuit.ry(0, theta)
-        pattern = circuit.transpile()
-        state = circuit.simulate_statevector()
+        pattern = circuit.transpile().pattern
+        state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
@@ -80,16 +82,16 @@ class TestTranspiler_UnitGates(unittest.TestCase):
         theta = np.random.random() * 2 * np.pi
         circuit = Circuit(1)
         circuit.rz(0, theta)
-        pattern = circuit.transpile()
-        state = circuit.simulate_statevector()
+        pattern = circuit.transpile().pattern
+        state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
     def test_i(self):
         circuit = Circuit(1)
         circuit.i(0)
-        pattern = circuit.transpile()
-        state = circuit.simulate_statevector()
+        pattern = circuit.transpile().pattern
+        state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
@@ -98,9 +100,9 @@ class TestTranspiler_UnitGates(unittest.TestCase):
         depth = 6
         for _ in range(10):
             circuit = rc.get_rand_circuit(nqubits, depth, use_ccx=True)
-            pattern = circuit.transpile()
+            pattern = circuit.transpile().pattern
             pattern.minimize_space()
-            state = circuit.simulate_statevector()
+            state = circuit.simulate_statevector().statevec
             state_mbqc = pattern.simulate_pattern()
             np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
@@ -112,9 +114,9 @@ class TestTranspiler_Opt(unittest.TestCase):
         for _ in range(10):
             circuit = rc.get_rand_circuit(nqubits, depth, use_ccx=True)
             circuit.ccx(0, 1, 2)
-            pattern = circuit.transpile(opt=True)
+            pattern = circuit.transpile(opt=True).pattern
             pattern.minimize_space()
-            state = circuit.simulate_statevector()
+            state = circuit.simulate_statevector().statevec
             state_mbqc = pattern.simulate_pattern()
             np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
@@ -123,8 +125,8 @@ class TestTranspiler_Opt(unittest.TestCase):
         depth = 1
         pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
         circuit = rc.generate_gate(nqubits, depth, pairs, use_rzz=True)
-        pattern = circuit.transpile(opt=True)
-        state = circuit.simulate_statevector()
+        pattern = circuit.transpile(opt=True).pattern
+        state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
@@ -133,8 +135,8 @@ class TestTranspiler_Opt(unittest.TestCase):
         depth = 2
         pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
         circuit = rc.generate_gate(nqubits, depth, pairs, use_rzz=True)
-        pattern = circuit.standardize_and_transpile()
-        state = circuit.simulate_statevector()
+        pattern = circuit.standardize_and_transpile().pattern
+        state = circuit.simulate_statevector().statevec
         pattern.minimize_space()
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
@@ -144,11 +146,27 @@ class TestTranspiler_Opt(unittest.TestCase):
         depth = 2
         pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
         circuit = rc.generate_gate(nqubits, depth, pairs, use_rzz=True)
-        pattern = circuit.standardize_and_transpile(opt=True)
-        state = circuit.simulate_statevector()
+        pattern = circuit.standardize_and_transpile(opt=True).pattern
+        state = circuit.simulate_statevector().statevec
         pattern.minimize_space()
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+
+    def test_measure(self):
+        circuit = Circuit(2)
+        circuit.h(1)
+        circuit.cnot(0, 1)
+        circuit.m(0, graphix.pauli.Plane.XY, 0.5)
+        transpile = circuit.transpile()
+
+        def simulate_and_measure():
+            circuit_simulate = circuit.simulate_statevector()
+            assert circuit_simulate.classical_measures[0] == (circuit_simulate.statevec.psi[0][1].imag > 0)
+            return circuit_simulate.classical_measures[0]
+
+        nb_shots = 1000
+        count = sum(1 for _ in range(nb_shots) if simulate_and_measure())
+        assert abs(count - nb_shots / 2) < nb_shots / 20
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request enables measures to be expressed at circuit level, in order to be able to consider circuits with classical outputs. Patterns are now allowed to measure all their nodes, and have an empty output node set, to enable to consider patterns where only classical outputs are considered.

Transpiled circuits can now have "measure" gates, introduced with the `circ.m(qubit, plane, angle)` method. The measured qubit cannot be used in any subsequent gate. The transpiler now returns a `TranspileResult` dataclass: the pattern is available in the `pattern` field, and the field `classical_outputs` contains the index where the classical measures can be found in the `results` array of the simulator.


