### PR TITLE
Fix circular import between pauli and clifford

### DIFF
--- a/graphix/clifford.py
+++ b/graphix/clifford.py
@@ -275,7 +275,7 @@ class Clifford:
             return get(CLIFFORD_MUL[self.__index, other.__index])
         return NotImplemented
 
-    def measure(self, pauli: graphix.pauli.Pauli) -> graphix.pauli.Pauli:
+    def measure(self, pauli: "graphix.pauli.Pauli") -> "graphix.pauli.Pauli":
         """
         Compute C† P C.
         """


### PR DESCRIPTION
This commit quotes the type reference to `graphix.pauli.Pauli` in `graphix.clifford` to prevent `partially initialized module` errors to appear.