### PR TITLE
Completely migrate to pytest

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ isort==5.13.2
 
 # Tests
 pytest
+pytest-mock
 parameterized
 tox
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,6 @@ isort==5.13.2
 # Tests
 pytest
 pytest-mock
-parameterized
 tox
 
 # Optional dependencies

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,10 @@
 import numpy as np
 import pytest
-from numpy.random import Generator
+from numpy.random import PCG64, Generator
 
 SEED = 42
 
 
 @pytest.fixture()
 def fx_rng() -> Generator:
-    return np.random.default_rng(SEED)
+    return Generator(PCG64(SEED))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,3 +8,8 @@ SEED = 42
 @pytest.fixture()
 def fx_rng() -> Generator:
     return Generator(PCG64(SEED))
+
+
+@pytest.fixture()
+def fx_bg() -> PCG64:
+    return PCG64(SEED)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import numpy as np
+import pytest
+from numpy.random import Generator
+
+SEED = 42
+
+
+@pytest.fixture()
+def fx_rng() -> Generator:
+    return np.random.default_rng(SEED)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pytest
 from numpy.random import PCG64, Generator
 

--- a/tests/random_circuit.py
+++ b/tests/random_circuit.py
@@ -1,58 +1,55 @@
-from copy import deepcopy
+from __future__ import annotations
+
+import functools
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from graphix.transpiler import Circuit
 
-GLOBAL_SEED = None
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+
+    from numpy.random import Generator
 
 
-def set_seed(seed):
-    global GLOBAL_SEED
-    GLOBAL_SEED = seed
-
-
-def get_rng(seed=None):
-    if seed is not None:
-        return np.random.default_rng(seed)
-    elif seed is None and GLOBAL_SEED is not None:
-        return np.random.default_rng(GLOBAL_SEED)
-    else:
-        return np.random.default_rng()
-
-
-def first_rotation(circuit, nqubits, rng):
+def first_rotation(circuit: Circuit, nqubits: int, rng: Generator) -> None:
     for qubit in range(nqubits):
         circuit.rx(qubit, rng.random())
 
 
-def mid_rotation(circuit, nqubits, rng):
+def mid_rotation(circuit: Circuit, nqubits: int, rng: Generator) -> None:
     for qubit in range(nqubits):
         circuit.rx(qubit, rng.random())
         circuit.rz(qubit, rng.random())
 
 
-def last_rotation(circuit, nqubits, rng):
+def last_rotation(circuit: Circuit, nqubits: int, rng: Generator) -> None:
     for qubit in range(nqubits):
         circuit.rz(qubit, rng.random())
 
 
-def entangler(circuit, pairs):
+def entangler(circuit: Circuit, pairs: Iterable[tuple[int, int]]) -> None:
     for a, b in pairs:
         circuit.cnot(a, b)
 
 
-def entangler_rzz(circuit, pairs, rng):
+def entangler_rzz(circuit: Circuit, pairs: Iterable[tuple[int, int]], rng: Generator) -> None:
     for a, b in pairs:
         circuit.rzz(a, b, rng.random())
 
 
-def generate_gate(nqubits, depth, pairs, use_rzz=False, seed=None):
-    rng = get_rng(seed)
+def generate_gate(
+    nqubits: int,
+    depth: int,
+    pairs: Iterable[tuple[int, int]],
+    rng: Generator,
+    use_rzz: bool = False,
+) -> Circuit:
     circuit = Circuit(nqubits)
     first_rotation(circuit, nqubits, rng)
     entangler(circuit, pairs)
-    for k in range(depth - 1):
+    for _ in range(depth - 1):
         mid_rotation(circuit, nqubits, rng)
         if use_rzz:
             entangler_rzz(circuit, pairs, rng)
@@ -62,36 +59,42 @@ def generate_gate(nqubits, depth, pairs, use_rzz=False, seed=None):
     return circuit
 
 
-def genpair(n_qubits, count, rng):
-    pairs = []
-    for i in range(count):
-        choice = [j for j in range(n_qubits)]
+def genpair(n_qubits: int, count: int, rng: Generator) -> Iterator[tuple[int, int]]:
+    choice = set(range(n_qubits))
+    for _ in range(count):
         x = rng.choice(choice)
         choice.pop(x)
         y = rng.choice(choice)
-        pairs.append((x, y))
-    return pairs
+        yield (x, y)
+        choice.add(x)
 
 
-def gentriplet(n_qubits, count, rng):
-    triplets = []
-    for i in range(count):
-        choice = [j for j in range(n_qubits)]
+def gentriplet(n_qubits: int, count: int, rng: Generator) -> Iterator[tuple[int, int, int]]:
+    choice = set(range(n_qubits))
+    for _ in range(count):
         x = rng.choice(choice)
         choice.pop(x)
         y = rng.choice(choice)
-        locy = np.where(y == np.array(deepcopy(choice)))[0][0]
-        choice.pop(locy)
+        choice.pop(y)
         z = rng.choice(choice)
-        triplets.append((x, y, z))
-    return triplets
+        yield (x, y, z)
+        choice.add(x)
+        choice.add(y)
 
 
-def get_rand_circuit(nqubits, depth, use_rzz=False, use_ccx=False, seed=None):
-    rng = get_rng(seed)
+def get_rand_circuit(nqubits: int, depth: int, rng: Generator, use_rzz: bool = False, use_ccx: bool = False) -> Circuit:
     circuit = Circuit(nqubits)
-    gate_choice = [0, 1, 2, 3, 4, 5, 6, 7]
-    for i in range(depth):
+    gate_choice = (
+        functools.partial(circuit.ry, angle=np.pi / 4),
+        functools.partial(circuit.rz, angle=-np.pi / 4),
+        functools.partial(circuit.rx, angle=-np.pi / 4),
+        circuit.h,
+        circuit.s,
+        circuit.x,
+        circuit.z,
+        circuit.y,
+    )
+    for _ in range(depth):
         for j, k in genpair(nqubits, 2, rng):
             circuit.cnot(j, k)
         if use_rzz:
@@ -103,31 +106,5 @@ def get_rand_circuit(nqubits, depth, use_rzz=False, use_ccx=False, seed=None):
         for j, k in genpair(nqubits, 4, rng):
             circuit.swap(j, k)
         for j in range(nqubits):
-            k = rng.choice(gate_choice)
-            if k == 0:
-                circuit.ry(j, np.pi / 4)
-                pass
-            elif k == 1:
-                circuit.rz(j, -np.pi / 4)
-                pass
-            elif k == 2:
-                circuit.rx(j, -np.pi / 4)
-                pass
-            elif k == 3:  # H
-                circuit.h(j)
-                pass
-            elif k == 4:  # S
-                circuit.s(j)
-                pass
-            elif k == 5:  # X
-                circuit.x(j)
-                pass
-            elif k == 6:  # Z
-                circuit.z(j)
-                pass
-            elif k == 7:  # Y
-                circuit.y(j)
-                pass
-            else:
-                pass
+            rng.choice(gate_choice)(j)
     return circuit

--- a/tests/random_circuit.py
+++ b/tests/random_circuit.py
@@ -44,6 +44,7 @@ def generate_gate(
     depth: int,
     pairs: Iterable[tuple[int, int]],
     rng: Generator,
+    *,
     use_rzz: bool = False,
 ) -> Circuit:
     circuit = Circuit(nqubits)
@@ -60,29 +61,29 @@ def generate_gate(
 
 
 def genpair(n_qubits: int, count: int, rng: Generator) -> Iterator[tuple[int, int]]:
-    choice = set(range(n_qubits))
+    choice = list(range(n_qubits))
     for _ in range(count):
-        x = rng.choice(choice)
-        choice.pop(x)
-        y = rng.choice(choice)
+        rng.shuffle(choice)
+        x, y = choice[:2]
         yield (x, y)
-        choice.add(x)
 
 
 def gentriplet(n_qubits: int, count: int, rng: Generator) -> Iterator[tuple[int, int, int]]:
-    choice = set(range(n_qubits))
+    choice = list(range(n_qubits))
     for _ in range(count):
-        x = rng.choice(choice)
-        choice.pop(x)
-        y = rng.choice(choice)
-        choice.pop(y)
-        z = rng.choice(choice)
+        rng.shuffle(choice)
+        x, y, z = choice[:3]
         yield (x, y, z)
-        choice.add(x)
-        choice.add(y)
 
 
-def get_rand_circuit(nqubits: int, depth: int, rng: Generator, use_rzz: bool = False, use_ccx: bool = False) -> Circuit:
+def get_rand_circuit(
+    nqubits: int,
+    depth: int,
+    rng: Generator,
+    *,
+    use_rzz: bool = False,
+    use_ccx: bool = False,
+) -> Circuit:
     circuit = Circuit(nqubits)
     gate_choice = (
         functools.partial(circuit.ry, angle=np.pi / 4),

--- a/tests/test_clifford.py
+++ b/tests/test_clifford.py
@@ -1,11 +1,9 @@
-import unittest
-
 import numpy as np
 
 from graphix.clifford import CLIFFORD, CLIFFORD_CONJ, CLIFFORD_HSZ_DECOMPOSITION, CLIFFORD_MEASURE, CLIFFORD_MUL
 
 
-class TestClifford(unittest.TestCase):
+class TestClifford:
     @staticmethod
     def classify_pauli(arr):
         """returns the index of Pauli gate with sign for a given 2x2 matrix.
@@ -91,7 +89,3 @@ class TestClifford(unittest.TestCase):
             for j in CLIFFORD_HSZ_DECOMPOSITION[i]:
                 op = op @ CLIFFORD[j]
             assert i == self.clifford_index(op)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_clifford.py
+++ b/tests/test_clifford.py
@@ -1,11 +1,17 @@
+from __future__ import annotations
+
+import itertools
+
 import numpy as np
+import numpy.typing as npt
+import pytest
 
 from graphix.clifford import CLIFFORD, CLIFFORD_CONJ, CLIFFORD_HSZ_DECOMPOSITION, CLIFFORD_MEASURE, CLIFFORD_MUL
 
 
 class TestClifford:
     @staticmethod
-    def classify_pauli(arr):
+    def classify_pauli(arr: npt.NDArray) -> tuple[int, int]:
         """returns the index of Pauli gate with sign for a given 2x2 matrix.
 
         Compare the gate arr with Pauli gates
@@ -23,21 +29,21 @@ class TestClifford:
 
         if np.allclose(CLIFFORD[1], arr):
             return (0, 0)
-        elif np.allclose(-1 * CLIFFORD[1], arr):
+        if np.allclose(-1 * CLIFFORD[1], arr):
             return (0, 1)
-        elif np.allclose(CLIFFORD[2], arr):
+        if np.allclose(CLIFFORD[2], arr):
             return (1, 0)
-        elif np.allclose(-1 * CLIFFORD[2], arr):
+        if np.allclose(-1 * CLIFFORD[2], arr):
             return (1, 1)
-        elif np.allclose(CLIFFORD[3], arr):
+        if np.allclose(CLIFFORD[3], arr):
             return (2, 0)
-        elif np.allclose(-1 * CLIFFORD[3], arr):
+        if np.allclose(-1 * CLIFFORD[3], arr):
             return (2, 1)
-        else:
-            raise ValueError("No Pauli found")
+        msg = "No Pauli found"
+        raise ValueError(msg)
 
     @staticmethod
-    def clifford_index(g):
+    def clifford_index(g: npt.NDArray) -> int:
         """returns the index of Clifford for a given 2x2 matrix.
 
         Compare the gate g with all Clifford gates (up to global phase)
@@ -53,39 +59,36 @@ class TestClifford:
         """
 
         for i in range(24):
+            ci = CLIFFORD[i]
             # normalise global phase
-            if CLIFFORD[i][0, 0] == 0:
-                norm = g[0, 1] / CLIFFORD[i][0, 1]
-            else:
-                norm = g[0, 0] / CLIFFORD[i][0, 0]
+            norm = g[0, 1] / ci[0, 1] if ci[0, 0] == 0 else g[0, 0] / ci[0, 0]
             # compare
-            if np.allclose(CLIFFORD[i] * norm, g):
+            if np.allclose(ci * norm, g):
                 return i
-        raise ValueError("No Clifford found")
+        msg = "No Clifford found"
+        raise ValueError(msg)
 
-    def test_measure(self):
-        for i in range(24):
-            for j in range(3):
-                conj = CLIFFORD[i].conjugate().T
-                pauli = CLIFFORD[j + 1]
-                arr = np.matmul(np.matmul(conj, pauli), CLIFFORD[i])
-                res = self.classify_pauli(arr)
-                assert res == CLIFFORD_MEASURE[i][j]
+    @pytest.mark.parametrize(("i", "j"), itertools.product(range(24), range(3)))
+    def test_measure(self, i: int, j: int) -> None:
+        conj = CLIFFORD[i].conjugate().T
+        pauli = CLIFFORD[j + 1]
+        arr = np.matmul(np.matmul(conj, pauli), CLIFFORD[i])
+        res = self.classify_pauli(arr)
+        assert res == CLIFFORD_MEASURE[i][j]
 
-    def test_multiplication(self):
-        for i in range(24):
-            for j in range(24):
-                arr = np.matmul(CLIFFORD[i], CLIFFORD[j])
-                assert CLIFFORD_MUL[i, j] == self.clifford_index(arr)
+    @pytest.mark.parametrize(("i", "j"), itertools.product(range(24), range(24)))
+    def test_multiplication(self, i: int, j: int) -> None:
+        arr = np.matmul(CLIFFORD[i], CLIFFORD[j])
+        assert CLIFFORD_MUL[i, j] == self.clifford_index(arr)
 
-    def test_conjugation(self):
-        for i in range(24):
-            arr = CLIFFORD[i].conjugate().T
-            assert CLIFFORD_CONJ[i] == self.clifford_index(arr)
+    @pytest.mark.parametrize("i", range(24))
+    def test_conjugation(self, i: int) -> None:
+        arr = CLIFFORD[i].conjugate().T
+        assert CLIFFORD_CONJ[i] == self.clifford_index(arr)
 
-    def test_decomposition(self):
-        for i in range(1, 24):
-            op = np.eye(2)
-            for j in CLIFFORD_HSZ_DECOMPOSITION[i]:
-                op = op @ CLIFFORD[j]
-            assert i == self.clifford_index(op)
+    @pytest.mark.parametrize("i", range(1, 24))
+    def test_decomposition(self, i: int) -> None:
+        op = np.eye(2)
+        for j in CLIFFORD_HSZ_DECOMPOSITION[i]:
+            op = op @ CLIFFORD[j]
+        assert i == self.clifford_index(op)

--- a/tests/test_density_matrix.py
+++ b/tests/test_density_matrix.py
@@ -1,5 +1,4 @@
 import random
-import unittest
 from copy import deepcopy
 
 import numpy as np
@@ -13,7 +12,7 @@ from graphix.sim.density_matrix import DensityMatrix, DensityMatrixBackend
 from graphix.sim.statevec import CNOT_TENSOR, CZ_TENSOR, SWAP_TENSOR, Statevec, StatevectorBackend
 
 
-class TestDensityMatrix(unittest.TestCase):
+class TestDensityMatrix:
     """Test for DensityMatrix class."""
 
     def test_init_without_data_fail(self):
@@ -773,7 +772,7 @@ class TestDensityMatrix(unittest.TestCase):
             dm.apply_channel("a", [i])
 
 
-class TestDensityMatrixBackend(unittest.TestCase):
+class TestDensityMatrixBackend:
     """Test for DensityMatrixBackend class."""
 
     def test_init_fail(self):
@@ -879,4 +878,3 @@ class TestDensityMatrixBackend(unittest.TestCase):
 
 if __name__ == "__main__":
     np.random.seed(32)
-    unittest.main()

--- a/tests/test_density_matrix.py
+++ b/tests/test_density_matrix.py
@@ -773,7 +773,7 @@ class TestDensityMatrix(unittest.TestCase):
             dm.apply_channel("a", [i])
 
 
-class DensityMatrixBackendTest(unittest.TestCase):
+class TestDensityMatrixBackend(unittest.TestCase):
     """Test for DensityMatrixBackend class."""
 
     def test_init_fail(self):

--- a/tests/test_density_matrix.py
+++ b/tests/test_density_matrix.py
@@ -170,7 +170,7 @@ class TestDensityMatrix:
         psi1 = psi1.reshape(2**nqb)
 
         # watch out ordering. Expval unitary is cpx so psi1 on the right to match DM.
-        np.testing.assert_allclose(np.dot(psi.conjugate(), psi1), dm.expectation_single(op, target_qubit))
+        assert np.allclose(np.dot(psi.conjugate(), psi1), dm.expectation_single(op, target_qubit))
 
     def test_tensor_fail(self) -> None:
         dm = DensityMatrix(nqubit=1)
@@ -250,7 +250,7 @@ class TestDensityMatrix:
         psi = np.tensordot(CNOT_TENSOR, psi, ((2, 3), edge))
         psi = np.moveaxis(psi, (0, 1), edge)
         expected_matrix = np.outer(psi, psi.conj())
-        np.testing.assert_allclose(rho, expected_matrix)
+        assert np.allclose(rho, expected_matrix)
 
     def test_swap_fail(self) -> None:
         dm = DensityMatrix(nqubit=2)
@@ -325,7 +325,7 @@ class TestDensityMatrix:
         psi = np.tensordot(CZ_TENSOR, psi, ((2, 3), edge))
         psi = np.moveaxis(psi, (0, 1), edge)
         expected_matrix = np.outer(psi, psi.conj())
-        np.testing.assert_allclose(rho, expected_matrix)
+        assert np.allclose(rho, expected_matrix)
 
     def test_evolve_success(self, fx_rng: Generator) -> None:
         # single-qubit gate
@@ -349,7 +349,7 @@ class TestDensityMatrix:
         dm.evolve(op, [i])
         dm_single.evolve_single(op, i)
 
-        np.testing.assert_allclose(dm.rho, dm_single.rho)
+        assert np.allclose(dm.rho, dm_single.rho)
 
         # 2-qubit gate
 
@@ -375,7 +375,7 @@ class TestDensityMatrix:
         psi = np.tensordot(op.reshape((2,) * 2 * nqubits_op), psi, ((2, 3), edge))
         psi = np.moveaxis(psi, (0, 1), edge)
         expected_matrix = np.outer(psi, psi.conj())
-        np.testing.assert_allclose(rho, expected_matrix)
+        assert np.allclose(rho, expected_matrix)
 
         # 3-qubit gate
         nqubits = fx_rng.integers(3, 5)
@@ -400,7 +400,7 @@ class TestDensityMatrix:
         psi = np.tensordot(op.reshape((2,) * 2 * nqubits_op), psi, ((3, 4, 5), targets))
         psi = np.moveaxis(psi, (0, 1, 2), targets)
         expected_matrix = np.outer(psi, psi.conj())
-        np.testing.assert_allclose(rho, expected_matrix)
+        assert np.allclose(rho, expected_matrix)
 
     def test_evolve_fail(self, fx_rng: Generator) -> None:
         # test on 3-qubit gate just in case.
@@ -521,8 +521,8 @@ class TestDensityMatrix:
             + np.sqrt(prob) ** 2 * Ops.z @ rho_test @ Ops.z.conj().T
         )
 
-        np.testing.assert_allclose(expected_dm.trace(), 1.0)
-        np.testing.assert_allclose(dm.rho, expected_dm)
+        assert np.allclose(expected_dm.trace(), 1.0)
+        assert np.allclose(dm.rho, expected_dm)
 
         nqubits = fx_rng.integers(2, 5)
 
@@ -571,8 +571,8 @@ class TestDensityMatrix:
         ) ** 2 * np.outer(psi_evolvedb, psi_evolvedb.conj())
 
         # compare
-        np.testing.assert_allclose(expected_dm.trace(), 1.0)
-        np.testing.assert_allclose(dm.rho, expected_dm)
+        assert np.allclose(expected_dm.trace(), 1.0)
+        assert np.allclose(dm.rho, expected_dm)
 
     def test_apply_depolarising_channel(self, fx_rng: Generator) -> None:
         # check on single qubit first
@@ -607,8 +607,8 @@ class TestDensityMatrix:
             + np.sqrt(prob / 3.0) ** 2 * Ops.z @ rho_test @ Ops.z.conj().T
         )
 
-        np.testing.assert_allclose(expected_dm.trace(), 1.0)
-        np.testing.assert_allclose(dm.rho, expected_dm)
+        assert np.allclose(expected_dm.trace(), 1.0)
+        assert np.allclose(dm.rho, expected_dm)
 
         # chek against statevector backend by hand for now.
         # create random density matrix
@@ -673,8 +673,8 @@ class TestDensityMatrix:
         )
 
         # compare
-        np.testing.assert_allclose(expected_dm.trace(), 1.0)
-        np.testing.assert_allclose(dm.rho, expected_dm)
+        assert np.allclose(expected_dm.trace(), 1.0)
+        assert np.allclose(dm.rho, expected_dm)
 
     def test_apply_random_channel_one_qubit(self, fx_rng: Generator) -> None:
         """
@@ -725,8 +725,8 @@ class TestDensityMatrix:
             expected_dm += elem["coef"] * np.conj(elem["coef"]) * np.outer(psi_evolved, np.conj(psi_evolved))
 
         # compare
-        np.testing.assert_allclose(expected_dm.trace(), 1.0)
-        np.testing.assert_allclose(dm.rho, expected_dm)
+        assert np.allclose(expected_dm.trace(), 1.0)
+        assert np.allclose(dm.rho, expected_dm)
 
     def test_apply_random_channel_two_qubits(self, fx_rng: Generator) -> None:
         """
@@ -768,8 +768,8 @@ class TestDensityMatrix:
             psi_evolved = np.moveaxis(psi_evolved, (0, 1), qubits)
             expected_dm += elem["coef"] * np.conj(elem["coef"]) * np.outer(psi_evolved, np.conj(psi_evolved))
 
-        np.testing.assert_allclose(expected_dm.trace(), 1.0)
-        np.testing.assert_allclose(dm.rho, expected_dm)
+        assert np.allclose(expected_dm.trace(), 1.0)
+        assert np.allclose(dm.rho, expected_dm)
 
     def test_apply_channel_fail(self, fx_rng: Generator) -> None:
         """
@@ -813,7 +813,7 @@ class TestDensityMatrixBackend:
         backend = DensityMatrixBackend(pattern)
         backend.add_nodes([0, 1])
         expected_matrix = np.array([0.25] * 16).reshape(4, 4)
-        np.testing.assert_allclose(backend.state.rho, expected_matrix)
+        assert np.allclose(backend.state.rho, expected_matrix)
 
     def test_entangle_nodes(self) -> None:
         circ = Circuit(1)
@@ -822,10 +822,10 @@ class TestDensityMatrixBackend:
         backend.add_nodes([0, 1])
         backend.entangle_nodes((0, 1))
         expected_matrix = np.array([[1, 1, 1, -1], [1, 1, 1, -1], [1, 1, 1, -1], [-1, -1, -1, 1]]) / 4
-        np.testing.assert_allclose(backend.state.rho, expected_matrix)
+        assert np.allclose(backend.state.rho, expected_matrix)
 
         backend.entangle_nodes((0, 1))
-        np.testing.assert_allclose(backend.state.rho, np.array([0.25] * 16).reshape(4, 4))
+        assert np.allclose(backend.state.rho, np.array([0.25] * 16).reshape(4, 4))
 
     def test_measure(self) -> None:
         circ = Circuit(1)
@@ -887,4 +887,4 @@ class TestDensityMatrixBackend:
         backend.finalize()
         psi = backend.state.psi
 
-        np.testing.assert_allclose(rho, np.outer(psi, psi.conj()))
+        assert np.allclose(rho, np.outer(psi, psi.conj()))

--- a/tests/test_density_matrix.py
+++ b/tests/test_density_matrix.py
@@ -77,21 +77,22 @@ class TestDensityMatrix:
             # not really a dm since not PSD but ok.
             DensityMatrix(data=data)
 
-    def test_init_without_data_success(self) -> None:
-        for n in range(3):
-            dm = DensityMatrix(nqubit=n)
-            expected_density_matrix = np.outer(np.ones((2,) * n), np.ones((2,) * n)) / 2**n
-            assert dm.Nqubit == n
-            assert dm.rho.shape == (2**n, 2**n)
-            assert np.allclose(dm.rho, expected_density_matrix)
+    @pytest.mark.parametrize("n", range(3))
+    def test_init_without_data_success(self, n: int) -> None:
+        dm = DensityMatrix(nqubit=n)
+        expected_density_matrix = np.outer(np.ones((2,) * n), np.ones((2,) * n)) / 2**n
+        assert dm.Nqubit == n
+        assert dm.rho.shape == (2**n, 2**n)
+        assert np.allclose(dm.rho, expected_density_matrix)
 
-            dm = DensityMatrix(plus_state=False, nqubit=n)
-            expected_density_matrix = np.zeros((2**n, 2**n))
-            expected_density_matrix[0, 0] = 1
-            assert dm.Nqubit == n
-            assert dm.rho.shape == (2**n, 2**n)
-            assert np.allclose(dm.rho, expected_density_matrix)
+        dm = DensityMatrix(plus_state=False, nqubit=n)
+        expected_density_matrix = np.zeros((2**n, 2**n))
+        expected_density_matrix[0, 0] = 1
+        assert dm.Nqubit == n
+        assert dm.rho.shape == (2**n, 2**n)
+        assert np.allclose(dm.rho, expected_density_matrix)
 
+    # TODO: Use pytest.mark.parametrize after refactoring randobj.rand_herm
     def test_init_with_data_success(self) -> None:
         # don't use rand_dm here since want to check
         for n in range(3):
@@ -179,14 +180,15 @@ class TestDensityMatrix:
         with pytest.raises(TypeError):
             dm.tensor(1)
 
-    def test_tensor_without_data_success(self) -> None:
-        for n in range(3):
-            dm_a = DensityMatrix(nqubit=n)
-            dm_b = DensityMatrix(nqubit=n + 1)
-            dm_a.tensor(dm_b)
-            assert dm_a.Nqubit == 2 * n + 1
-            assert dm_a.rho.shape == (2 ** (2 * n + 1), 2 ** (2 * n + 1))
+    @pytest.mark.parametrize("n", range(3))
+    def test_tensor_without_data_success(self, n: int) -> None:
+        dm_a = DensityMatrix(nqubit=n)
+        dm_b = DensityMatrix(nqubit=n + 1)
+        dm_a.tensor(dm_b)
+        assert dm_a.Nqubit == 2 * n + 1
+        assert dm_a.rho.shape == (2 ** (2 * n + 1), 2 ** (2 * n + 1))
 
+    # TODO: Use pytest.mark.parametrize after refactoring randobj.rand_dm
     def test_tensor_with_data_success(self) -> None:
         for n in range(3):
             data_a = randobj.rand_dm(2**n, dm_dtype=False)

--- a/tests/test_density_matrix.py
+++ b/tests/test_density_matrix.py
@@ -436,7 +436,8 @@ class TestDensityMatrix:
         with pytest.raises(ValueError):
             dm.evolve(fx_rng.uniform(size=(5, 5)), (0, 1))
 
-    # TODO: the test for normalization is done at initialization with data. Now check that all operations conserve the norm.
+    # TODO: the test for normalization is done at initialization with data.
+    # Now check that all operations conserve the norm.
     def test_normalize(self, fx_rng: Generator) -> None:
         data = randobj.rand_herm(2 ** fx_rng.integers(2, 4))
 

--- a/tests/test_density_matrix.py
+++ b/tests/test_density_matrix.py
@@ -32,7 +32,7 @@ def _randdm_raw(nqubits: int, rng: Generator) -> npt.NDArray[np.complex128]:
 class TestDensityMatrix:
     """Test for DensityMatrix class."""
 
-    def test_init_without_data_fail(self):
+    def test_init_without_data_fail(self) -> None:
         with pytest.raises(AssertionError):
             DensityMatrix(nqubit=-2)
         with pytest.raises(TypeError):
@@ -40,7 +40,7 @@ class TestDensityMatrix:
         with pytest.raises(TypeError):
             DensityMatrix(nqubit=[])
 
-    def test_init_with_invalid_data_fail(self, fx_rng: Generator):
+    def test_init_with_invalid_data_fail(self, fx_rng: Generator) -> None:
         with pytest.raises(TypeError):
             DensityMatrix("hello")
         with pytest.raises(TypeError):
@@ -77,7 +77,7 @@ class TestDensityMatrix:
             # not really a dm since not PSD but ok.
             DensityMatrix(data=data)
 
-    def test_init_without_data_success(self):
+    def test_init_without_data_success(self) -> None:
         for n in range(3):
             dm = DensityMatrix(nqubit=n)
             expected_density_matrix = np.outer(np.ones((2,) * n), np.ones((2,) * n)) / 2**n
@@ -92,7 +92,7 @@ class TestDensityMatrix:
             assert dm.rho.shape == (2**n, 2**n)
             assert np.allclose(dm.rho, expected_density_matrix)
 
-    def test_init_with_data_success(self):
+    def test_init_with_data_success(self) -> None:
         # don't use rand_dm here since want to check
         for n in range(3):
             data = randobj.rand_herm(2**n)
@@ -103,7 +103,7 @@ class TestDensityMatrix:
             assert dm.rho.shape == (2**n, 2**n)
             assert np.allclose(dm.rho, data)
 
-    def test_evolve_single_fail(self):
+    def test_evolve_single_fail(self) -> None:
         dm = DensityMatrix(nqubit=2)
         # generate random 4 x 4 unitary matrix
         op = randobj.rand_unit(4)
@@ -113,7 +113,7 @@ class TestDensityMatrix:
         with pytest.raises(ValueError):
             dm.evolve_single(op, 1)
 
-    def test_evolve_single_success(self):
+    def test_evolve_single_success(self) -> None:
         # generate random 2 x 2 unitary matrix
         op = randobj.rand_unit(2)
 
@@ -126,7 +126,7 @@ class TestDensityMatrix:
             dm.evolve_single(op, i)
             assert np.allclose(dm.rho, expected_density_matrix)
 
-    def test_expectation_single_fail(self):
+    def test_expectation_single_fail(self) -> None:
         nqb = 3
         dm = DensityMatrix(nqubit=nqb)
 
@@ -146,7 +146,7 @@ class TestDensityMatrix:
         with pytest.raises(ValueError):
             dm.expectation_single(op, nqb + 3)
 
-    def test_expectation_single_success(self, fx_rng: Generator):
+    def test_expectation_single_success(self, fx_rng: Generator) -> None:
         """compare to pure state case
         hence only pure states
         but by linearity ok"""
@@ -172,14 +172,14 @@ class TestDensityMatrix:
         # watch out ordering. Expval unitary is cpx so psi1 on the right to match DM.
         np.testing.assert_allclose(np.dot(psi.conjugate(), psi1), dm.expectation_single(op, target_qubit))
 
-    def test_tensor_fail(self):
+    def test_tensor_fail(self) -> None:
         dm = DensityMatrix(nqubit=1)
         with pytest.raises(TypeError):
             dm.tensor("hello")
         with pytest.raises(TypeError):
             dm.tensor(1)
 
-    def test_tensor_without_data_success(self):
+    def test_tensor_without_data_success(self) -> None:
         for n in range(3):
             dm_a = DensityMatrix(nqubit=n)
             dm_b = DensityMatrix(nqubit=n + 1)
@@ -187,7 +187,7 @@ class TestDensityMatrix:
             assert dm_a.Nqubit == 2 * n + 1
             assert dm_a.rho.shape == (2 ** (2 * n + 1), 2 ** (2 * n + 1))
 
-    def test_tensor_with_data_success(self):
+    def test_tensor_with_data_success(self) -> None:
         for n in range(3):
             data_a = randobj.rand_dm(2**n, dm_dtype=False)
             dm_a = DensityMatrix(data=data_a)
@@ -199,7 +199,7 @@ class TestDensityMatrix:
             assert dm_a.rho.shape == (2 ** (2 * n + 1), 2 ** (2 * n + 1))
             assert np.allclose(dm_a.rho, np.kron(data_a, data_b))
 
-    def test_cnot_fail(self):
+    def test_cnot_fail(self) -> None:
         dm = DensityMatrix(nqubit=2)
         with pytest.raises(ValueError):
             dm.cnot((1, 1))
@@ -212,7 +212,7 @@ class TestDensityMatrix:
         with pytest.raises(ValueError):
             dm.cnot((2, 1))
 
-    def test_cnot_success(self, fx_rng: Generator):
+    def test_cnot_success(self, fx_rng: Generator) -> None:
         dm = DensityMatrix(nqubit=2)
         original_matrix = dm.rho.copy()
         dm.cnot((0, 1))
@@ -252,7 +252,7 @@ class TestDensityMatrix:
         expected_matrix = np.outer(psi, psi.conj())
         np.testing.assert_allclose(rho, expected_matrix)
 
-    def test_swap_fail(self):
+    def test_swap_fail(self) -> None:
         dm = DensityMatrix(nqubit=2)
         with pytest.raises(ValueError):
             dm.swap((1, 1))
@@ -265,7 +265,7 @@ class TestDensityMatrix:
         with pytest.raises(ValueError):
             dm.swap((2, 1))
 
-    def test_swap_success(self, fx_rng: Generator):
+    def test_swap_success(self, fx_rng: Generator) -> None:
         dm = DensityMatrix(nqubit=2)
         original_matrix = dm.rho.copy()
         dm.swap((0, 1))
@@ -286,16 +286,16 @@ class TestDensityMatrix:
         expected_matrix = np.outer(psi, psi.conj())
         assert np.allclose(rho, expected_matrix)
 
-    def test_entangle_fail(self):
+    def test_entangle_fail(self) -> None:
         dm = DensityMatrix(nqubit=3)
         with pytest.raises(ValueError):
             dm.entangle((1, 1))
         with pytest.raises(ValueError):
-            dm.entangle(((1, 3)))
+            dm.entangle((1, 3))
         with pytest.raises(ValueError):
             dm.entangle((0, 1, 2))
 
-    def test_entangle_success(self, fx_rng: Generator):
+    def test_entangle_success(self, fx_rng: Generator) -> None:
         dm = DensityMatrix(nqubit=2)
         original_matrix = dm.rho.copy()
         dm.entangle((0, 1))
@@ -327,23 +327,23 @@ class TestDensityMatrix:
         expected_matrix = np.outer(psi, psi.conj())
         np.testing.assert_allclose(rho, expected_matrix)
 
-    def test_evolve_success(self, fx_rng: Generator):
+    def test_evolve_success(self, fx_rng: Generator) -> None:
         # single-qubit gate
         # check against evolve_single
 
-        N_qubits = fx_rng.integers(2, 4)
-        N_qubits_op = 1
+        nqubits = fx_rng.integers(2, 4)
+        nqubits_op = 1
 
         # random statevector
-        psi = _randstate_raw(N_qubits, fx_rng)
+        psi = _randstate_raw(nqubits, fx_rng)
         psi /= np.sqrt(np.sum(np.abs(psi) ** 2))
 
         # density matrix calculation
         dm = DensityMatrix(data=np.outer(psi, psi.conj()))
         dm_single = deepcopy(dm)
 
-        op = randobj.rand_unit(2**N_qubits_op)
-        i = fx_rng.integers(0, N_qubits)
+        op = randobj.rand_unit(2**nqubits_op)
+        i = fx_rng.integers(0, nqubits)
 
         # need a list format for a single target
         dm.evolve(op, [i])
@@ -353,17 +353,17 @@ class TestDensityMatrix:
 
         # 2-qubit gate
 
-        N_qubits = fx_rng.integers(2, 4)
-        N_qubits_op = 2
+        nqubits = fx_rng.integers(2, 4)
+        nqubits_op = 2
 
         # random unitary
-        op = randobj.rand_unit(2**N_qubits_op)
+        op = randobj.rand_unit(2**nqubits_op)
 
         # random pair of indices
-        edge = tuple(random.sample(range(N_qubits), 2))
+        edge = tuple(random.sample(range(nqubits), 2))
 
         # random statevector to compare to
-        psi = _randstate_raw(N_qubits, fx_rng)
+        psi = _randstate_raw(nqubits, fx_rng)
         psi /= np.sqrt(np.sum(np.abs(psi) ** 2))
 
         # density matrix calculation
@@ -371,24 +371,24 @@ class TestDensityMatrix:
         dm.evolve(op, edge)
         rho = dm.rho
 
-        psi = psi.reshape((2,) * N_qubits)
-        psi = np.tensordot(op.reshape((2,) * 2 * N_qubits_op), psi, ((2, 3), edge))
+        psi = psi.reshape((2,) * nqubits)
+        psi = np.tensordot(op.reshape((2,) * 2 * nqubits_op), psi, ((2, 3), edge))
         psi = np.moveaxis(psi, (0, 1), edge)
         expected_matrix = np.outer(psi, psi.conj())
         np.testing.assert_allclose(rho, expected_matrix)
 
         # 3-qubit gate
-        N_qubits = fx_rng.integers(3, 5)
-        N_qubits_op = 3
+        nqubits = fx_rng.integers(3, 5)
+        nqubits_op = 3
 
         # random unitary
-        op = randobj.rand_unit(2**N_qubits_op)
+        op = randobj.rand_unit(2**nqubits_op)
 
         # 3 random indices
-        targets = tuple(random.sample(range(N_qubits), 3))
+        targets = tuple(random.sample(range(nqubits), 3))
 
         # random statevector to compare to
-        psi = _randstate_raw(N_qubits, fx_rng)
+        psi = _randstate_raw(nqubits, fx_rng)
         psi /= np.sqrt(np.sum(np.abs(psi) ** 2))
 
         # density matrix calculation
@@ -396,21 +396,21 @@ class TestDensityMatrix:
         dm.evolve(op, targets)
         rho = dm.rho
 
-        psi = psi.reshape((2,) * N_qubits)
-        psi = np.tensordot(op.reshape((2,) * 2 * N_qubits_op), psi, ((3, 4, 5), targets))
+        psi = psi.reshape((2,) * nqubits)
+        psi = np.tensordot(op.reshape((2,) * 2 * nqubits_op), psi, ((3, 4, 5), targets))
         psi = np.moveaxis(psi, (0, 1, 2), targets)
         expected_matrix = np.outer(psi, psi.conj())
         np.testing.assert_allclose(rho, expected_matrix)
 
-    def test_evolve_fail(self, fx_rng: Generator):
+    def test_evolve_fail(self, fx_rng: Generator) -> None:
         # test on 3-qubit gate just in case.
-        N_qubits = fx_rng.integers(3, 5)
-        N_qubits_op = 3
+        nqubits = fx_rng.integers(3, 5)
+        nqubits_op = 3
 
         # random unitary
-        op = randobj.rand_unit(2**N_qubits_op)
+        op = randobj.rand_unit(2**nqubits_op)
         # 3 random indices
-        dm = DensityMatrix(nqubit=N_qubits)
+        dm = DensityMatrix(nqubit=nqubits)
 
         # dimension mismatch
         with pytest.raises(ValueError):
@@ -436,15 +436,15 @@ class TestDensityMatrix:
         with pytest.raises(ValueError):
             dm.evolve(fx_rng.uniform(size=(5, 5)), (0, 1))
 
-    # TODO the test for normalization is done at initialization with data. Now check that all operations conserve the norm.
-    def test_normalize(self, fx_rng: Generator):
+    # TODO: the test for normalization is done at initialization with data. Now check that all operations conserve the norm.
+    def test_normalize(self, fx_rng: Generator) -> None:
         data = randobj.rand_herm(2 ** fx_rng.integers(2, 4))
 
         dm = DensityMatrix(data / data.trace())
         dm.normalize()
         assert np.allclose(np.trace(dm.rho), 1)
 
-    def test_ptrace_fail(self):
+    def test_ptrace_fail(self) -> None:
         dm = DensityMatrix(nqubit=0)
         with pytest.raises(AssertionError):
             dm.ptrace((0,))
@@ -452,7 +452,7 @@ class TestDensityMatrix:
         with pytest.raises(AssertionError):
             dm.ptrace((2,))
 
-    def test_ptrace(self):
+    def test_ptrace(self) -> None:
         psi = np.kron(np.array([1, 0]), np.array([1, 1]) / np.sqrt(2))
         data = np.outer(psi, psi)
         dm = DensityMatrix(data=data)
@@ -489,7 +489,7 @@ class TestDensityMatrix:
         )
         assert np.allclose(dm.rho, expected_matrix)
 
-    def test_apply_dephasing_channel(self, fx_rng: Generator):
+    def test_apply_dephasing_channel(self, fx_rng: Generator) -> None:
         # check on single qubit first
         # # create random density matrix
         # data = randobj.rand_herm(2 ** fx_rng.integers(2, 4))
@@ -512,25 +512,25 @@ class TestDensityMatrix:
         # apply channel. list with single element needed.
         # if Channel.nqubit == 1 use list with single element.
         dm.apply_channel(dephase_channel, [0])
-        id = np.array([[1.0, 0.0], [0.0, 1.0]])
+        identity = np.array([[1.0, 0.0], [0.0, 1.0]])
 
         # compare
         expected_dm = (
-            np.sqrt(1 - prob) ** 2 * id @ rho_test @ id.conj().T
+            np.sqrt(1 - prob) ** 2 * identity @ rho_test @ identity.conj().T
             + np.sqrt(prob) ** 2 * Ops.z @ rho_test @ Ops.z.conj().T
         )
 
         np.testing.assert_allclose(expected_dm.trace(), 1.0)
         np.testing.assert_allclose(dm.rho, expected_dm)
 
-        N_qubits = fx_rng.integers(2, 5)
+        nqubits = fx_rng.integers(2, 5)
 
-        i = fx_rng.integers(0, N_qubits)
+        i = fx_rng.integers(0, nqubits)
 
         # create random density matrix from statevector
 
         # random statevector to compare to
-        psi = _randstate_raw(N_qubits, fx_rng)
+        psi = _randstate_raw(nqubits, fx_rng)
         psi /= np.sqrt(np.sum(np.abs(psi) ** 2))
 
         # build DensityMatrix
@@ -550,21 +550,21 @@ class TestDensityMatrix:
         dm.apply_channel(dephase_channel, [i])
 
         # compute on the statevector
-        # psi.reshape((2,) * N_qubits)
+        # psi.reshape((2,) * nqubits)
         # tmp = np.zeros(psi.shape)
 
-        id = np.array([[1.0, 0.0], [0.0, 1.0]])
+        identity = np.array([[1.0, 0.0], [0.0, 1.0]])
 
         # by hand: operator list and gate application
-        psi_evolved = np.tensordot(id, psi.reshape((2,) * N_qubits), (1, i))
+        psi_evolved = np.tensordot(identity, psi.reshape((2,) * nqubits), (1, i))
         psi_evolved = np.moveaxis(psi_evolved, 0, i)
 
-        psi_evolvedb = np.tensordot(Ops.z, psi.reshape((2,) * N_qubits), (1, i))
+        psi_evolvedb = np.tensordot(Ops.z, psi.reshape((2,) * nqubits), (1, i))
         psi_evolvedb = np.moveaxis(psi_evolvedb, 0, i)
 
         # compute final density matrix
-        psi_evolved = np.reshape(psi_evolved, (2**N_qubits))
-        psi_evolvedb = np.reshape(psi_evolvedb, (2**N_qubits))
+        psi_evolved = np.reshape(psi_evolved, (2**nqubits))
+        psi_evolvedb = np.reshape(psi_evolvedb, (2**nqubits))
         expected_dm = np.sqrt(1 - prob) ** 2 * np.outer(psi_evolved, psi_evolved.conj()) + np.sqrt(
             prob,
         ) ** 2 * np.outer(psi_evolvedb, psi_evolvedb.conj())
@@ -573,7 +573,7 @@ class TestDensityMatrix:
         np.testing.assert_allclose(expected_dm.trace(), 1.0)
         np.testing.assert_allclose(dm.rho, expected_dm)
 
-    def test_apply_depolarising_channel(self, fx_rng: Generator):
+    def test_apply_depolarising_channel(self, fx_rng: Generator) -> None:
         # check on single qubit first
         # # create random density matrix
         # data = randobj.rand_herm(2 ** fx_rng.integers(2, 4))
@@ -596,11 +596,11 @@ class TestDensityMatrix:
         # apply channel. list with single element needed.
         # if Channel.nqubit == 1 use list with single element.
         dm.apply_channel(depol_channel, [0])
-        id = np.array([[1.0, 0.0], [0.0, 1.0]])
+        identity = np.array([[1.0, 0.0], [0.0, 1.0]])
 
         # compare
         expected_dm = (
-            np.sqrt(1 - prob) ** 2 * id @ rho_test @ id.conj().T
+            np.sqrt(1 - prob) ** 2 * identity @ rho_test @ identity.conj().T
             + np.sqrt(prob / 3.0) ** 2 * Ops.x @ rho_test @ Ops.x.conj().T
             + np.sqrt(prob / 3.0) ** 2 * Ops.y @ rho_test @ Ops.y.conj().T
             + np.sqrt(prob / 3.0) ** 2 * Ops.z @ rho_test @ Ops.z.conj().T
@@ -612,15 +612,15 @@ class TestDensityMatrix:
         # chek against statevector backend by hand for now.
         # create random density matrix
 
-        N_qubits = fx_rng.integers(2, 5)
+        nqubits = fx_rng.integers(2, 5)
 
         # target qubit index
-        i = fx_rng.integers(0, N_qubits)
+        i = fx_rng.integers(0, nqubits)
 
         # create random density matrix from statevector
 
         # random statevector to compare to
-        psi = _randstate_raw(N_qubits, fx_rng)
+        psi = _randstate_raw(nqubits, fx_rng)
         psi /= np.sqrt(np.sum(np.abs(psi) ** 2))
 
         # build DensityMatrix
@@ -640,29 +640,29 @@ class TestDensityMatrix:
         dm.apply_channel(depol_channel, [i])
 
         # compute on the statevector
-        # psi.reshape((2,) * N_qubits)
+        # psi.reshape((2,) * nqubits)
         # tmp = np.zeros(psi.shape)
 
-        id = np.array([[1.0, 0.0], [0.0, 1.0]])
+        identity = np.array([[1.0, 0.0], [0.0, 1.0]])
 
         # by hand: operator list and gate application
-        psi_evolved = np.tensordot(id, psi.reshape((2,) * N_qubits), (1, i))
+        psi_evolved = np.tensordot(identity, psi.reshape((2,) * nqubits), (1, i))
         psi_evolved = np.moveaxis(psi_evolved, 0, i)
 
-        psi_evolvedb = np.tensordot(Ops.x, psi.reshape((2,) * N_qubits), (1, i))
+        psi_evolvedb = np.tensordot(Ops.x, psi.reshape((2,) * nqubits), (1, i))
         psi_evolvedb = np.moveaxis(psi_evolvedb, 0, i)
 
-        psi_evolvedc = np.tensordot(Ops.y, psi.reshape((2,) * N_qubits), (1, i))
+        psi_evolvedc = np.tensordot(Ops.y, psi.reshape((2,) * nqubits), (1, i))
         psi_evolvedc = np.moveaxis(psi_evolvedc, 0, i)
 
-        psi_evolvedd = np.tensordot(Ops.z, psi.reshape((2,) * N_qubits), (1, i))
+        psi_evolvedd = np.tensordot(Ops.z, psi.reshape((2,) * nqubits), (1, i))
         psi_evolvedd = np.moveaxis(psi_evolvedd, 0, i)
 
         # compute final density matrix
-        psi_evolved = np.reshape(psi_evolved, (2**N_qubits))
-        psi_evolvedb = np.reshape(psi_evolvedb, (2**N_qubits))
-        psi_evolvedc = np.reshape(psi_evolvedc, (2**N_qubits))
-        psi_evolvedd = np.reshape(psi_evolvedd, (2**N_qubits))
+        psi_evolved = np.reshape(psi_evolved, (2**nqubits))
+        psi_evolvedb = np.reshape(psi_evolvedb, (2**nqubits))
+        psi_evolvedc = np.reshape(psi_evolvedc, (2**nqubits))
+        psi_evolvedd = np.reshape(psi_evolvedd, (2**nqubits))
 
         expected_dm = (
             np.sqrt(1 - prob) ** 2 * np.outer(psi_evolved, psi_evolved.conj())
@@ -675,7 +675,7 @@ class TestDensityMatrix:
         np.testing.assert_allclose(expected_dm.trace(), 1.0)
         np.testing.assert_allclose(dm.rho, expected_dm)
 
-    def test_apply_random_channel_one_qubit(self, fx_rng: Generator):
+    def test_apply_random_channel_one_qubit(self, fx_rng: Generator) -> None:
         """
         test random 1-qubit channel.
         Especially checks for complex parameters.
@@ -684,16 +684,16 @@ class TestDensityMatrix:
         # check against statevector backend by hand for now.
         # create random density matrix
 
-        N_qubits = fx_rng.integers(2, 5)
-        # id = np.array([[1.0, 0.0], [0.0, 1.0]])
+        nqubits = fx_rng.integers(2, 5)
+        # identity = np.array([[1.0, 0.0], [0.0, 1.0]])
 
         # target qubit index
-        i = fx_rng.integers(0, N_qubits)
+        i = fx_rng.integers(0, nqubits)
 
         # create random density matrix from statevector
 
         # random statevector to compare to
-        psi = _randstate_raw(N_qubits, fx_rng)
+        psi = _randstate_raw(nqubits, fx_rng)
         psi /= np.sqrt(np.sum(np.abs(psi) ** 2))
 
         # build DensityMatrix
@@ -712,14 +712,14 @@ class TestDensityMatrix:
         dm.apply_channel(channel, [i])
 
         # compute on the statevector
-        # psi.reshape((2,) * N_qubits)
+        # psi.reshape((2,) * nqubits)
         # tmp = np.zeros(psi.shape)
 
         # initialize. NOT a DM object, just a matrix.
-        expected_dm = np.zeros((2**N_qubits, 2**N_qubits), dtype=np.complex128)
+        expected_dm = np.zeros((2**nqubits, 2**nqubits), dtype=np.complex128)
 
         for elem in channel.kraus_ops:  # kraus_ops is a list of dicts
-            psi_evolved = np.tensordot(elem["operator"], psi.reshape((2,) * N_qubits), (1, i))
+            psi_evolved = np.tensordot(elem["operator"], psi.reshape((2,) * nqubits), (1, i))
             psi_evolved = np.moveaxis(psi_evolved, 0, i)
             expected_dm += elem["coef"] * np.conj(elem["coef"]) * np.outer(psi_evolved, np.conj(psi_evolved))
 
@@ -727,20 +727,20 @@ class TestDensityMatrix:
         np.testing.assert_allclose(expected_dm.trace(), 1.0)
         np.testing.assert_allclose(dm.rho, expected_dm)
 
-    def test_apply_random_channel_two_qubits(self, fx_rng: Generator):
+    def test_apply_random_channel_two_qubits(self, fx_rng: Generator) -> None:
         """
         test random 2-qubit channel on a rank 1 dm (pure state). Generalizes by linearity.
         Especially checks for complex parameters.
         """
 
-        N_qubits = fx_rng.integers(2, 5)
+        nqubits = fx_rng.integers(2, 5)
 
         # target qubits indices
-        qubits = tuple(random.sample(range(N_qubits), 2))
+        qubits = tuple(random.sample(range(nqubits), 2))
 
         # create random density matrix from statevector
         # random statevector to compare to
-        psi = _randstate_raw(N_qubits, fx_rng)
+        psi = _randstate_raw(nqubits, fx_rng)
         psi /= np.sqrt(np.sum(np.abs(psi) ** 2))
         # build DensityMatrix
         dm = DensityMatrix(data=np.outer(psi, psi.conj()))
@@ -756,12 +756,12 @@ class TestDensityMatrix:
         dm.apply_channel(channel, qubits)
 
         # initialize. NOT a DM object, just a matrix.
-        expected_dm = np.zeros((2**N_qubits, 2**N_qubits), dtype=np.complex128)
+        expected_dm = np.zeros((2**nqubits, 2**nqubits), dtype=np.complex128)
         # reshape statevec since not in tensor format
         for elem in channel.kraus_ops:  # kraus_ops is a list of dicts
             psi_evolved = np.tensordot(
                 elem["operator"].reshape((2,) * 2 * nqb),
-                psi.reshape((2,) * N_qubits),
+                psi.reshape((2,) * nqubits),
                 ((2, 3), qubits),
             )
             psi_evolved = np.moveaxis(psi_evolved, (0, 1), qubits)
@@ -770,14 +770,14 @@ class TestDensityMatrix:
         np.testing.assert_allclose(expected_dm.trace(), 1.0)
         np.testing.assert_allclose(dm.rho, expected_dm)
 
-    def test_apply_channel_fail(self, fx_rng: Generator):
+    def test_apply_channel_fail(self, fx_rng: Generator) -> None:
         """
         test apply a channel that is not a Channel object
         """
-        N_qubits = fx_rng.integers(2, 5)
-        i = fx_rng.integers(0, N_qubits)
+        nqubits = fx_rng.integers(2, 5)
+        i = fx_rng.integers(0, nqubits)
 
-        psi = _randstate_raw(N_qubits, fx_rng)
+        psi = _randstate_raw(nqubits, fx_rng)
         psi /= np.sqrt(np.sum(np.abs(psi) ** 2))
 
         # build DensityMatrix
@@ -790,11 +790,11 @@ class TestDensityMatrix:
 class TestDensityMatrixBackend:
     """Test for DensityMatrixBackend class."""
 
-    def test_init_fail(self):
+    def test_init_fail(self) -> None:
         with pytest.raises(TypeError):
             DensityMatrixBackend()
 
-    def test_init_success(self):
+    def test_init_success(self) -> None:
         circ = Circuit(1)
         circ.rx(0, np.pi / 2)
         pattern = circ.transpile().pattern
@@ -806,7 +806,7 @@ class TestDensityMatrixBackend:
         assert backend.Nqubit == 0
         assert backend.max_qubit_num == 12
 
-    def test_add_nodes(self):
+    def test_add_nodes(self) -> None:
         circ = Circuit(1)
         pattern = circ.transpile().pattern
         backend = DensityMatrixBackend(pattern)
@@ -814,7 +814,7 @@ class TestDensityMatrixBackend:
         expected_matrix = np.array([0.25] * 16).reshape(4, 4)
         np.testing.assert_allclose(backend.state.rho, expected_matrix)
 
-    def test_entangle_nodes(self):
+    def test_entangle_nodes(self) -> None:
         circ = Circuit(1)
         pattern = circ.transpile().pattern
         backend = DensityMatrixBackend(pattern)
@@ -826,7 +826,7 @@ class TestDensityMatrixBackend:
         backend.entangle_nodes((0, 1))
         np.testing.assert_allclose(backend.state.rho, np.array([0.25] * 16).reshape(4, 4))
 
-    def test_measure(self):
+    def test_measure(self) -> None:
         circ = Circuit(1)
         circ.rx(0, np.pi / 2)
         pattern = circ.transpile().pattern
@@ -841,7 +841,7 @@ class TestDensityMatrixBackend:
         expected_matrix_2 = np.kron(np.array([[0, 0], [0, 1]]), np.array([[0.5, -0.5], [-0.5, 0.5]]))
         assert np.allclose(backend.state.rho, expected_matrix_1) or np.allclose(backend.state.rho, expected_matrix_2)
 
-    def test_measure_pr_calc(self):
+    def test_measure_pr_calc(self) -> None:
         # circuit there just to provide a measurement command to try out. Weird.
         circ = Circuit(1)
         circ.rx(0, np.pi / 2)
@@ -859,7 +859,7 @@ class TestDensityMatrixBackend:
 
         assert np.allclose(backend.state.rho, expected_matrix_1) or np.allclose(backend.state.rho, expected_matrix_2)
 
-    def test_correct_byproduct(self):
+    def test_correct_byproduct(self) -> None:
         circ = Circuit(1)
         circ.rx(0, np.pi / 2)
         pattern = circ.transpile().pattern

--- a/tests/test_density_matrix.py
+++ b/tests/test_density_matrix.py
@@ -3,6 +3,7 @@ import unittest
 from copy import deepcopy
 
 import numpy as np
+import pytest
 
 import graphix.random_objects as randobj
 from graphix import Circuit
@@ -16,47 +17,47 @@ class TestDensityMatrix(unittest.TestCase):
     """Test for DensityMatrix class."""
 
     def test_init_without_data_fail(self):
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             DensityMatrix(nqubit=-2)
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             DensityMatrix(nqubit="hello")
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             DensityMatrix(nqubit=[])
 
     def test_init_with_invalid_data_fail(self):
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             DensityMatrix("hello")
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             DensityMatrix(1)
         # deprecated data shape (these test might be unnecessary)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             DensityMatrix([1, 2, [3]])
 
         # check with hermitian dm but not unit trace
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             DensityMatrix(data=randobj.rand_herm(2 ** np.random.randint(2, 5)))
 
         # check with non hermitian dm but unit trace
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             l = 2 ** np.random.randint(2, 5)
             tmp = np.random.rand(l, l) + 1j * np.random.rand(l, l)
             DensityMatrix(data=tmp / np.trace(tmp))
         # check with non hermitian dm and not unit trace
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             l = 2 ** np.random.randint(2, 5)  # np.random.randint(2, 20)
             DensityMatrix(data=np.random.rand(l, l) + 1j * np.random.rand(l, l))
 
         # check not square matrix
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             # l = 2 ** np.random.randint(2, 5) # np.random.randint(2, 20)
             DensityMatrix(data=np.random.rand(3, 2))
 
         # check higher dimensional matrix
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             DensityMatrix(data=np.random.rand(2, 2, 3))
 
         # check square and hermitian but with incorrect dimension (non-qubit type)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             # not really a dm since not PSD but ok.
             data = randobj.rand_herm(5)
             data /= np.trace(data)
@@ -93,9 +94,9 @@ class TestDensityMatrix(unittest.TestCase):
         # generate random 4 x 4 unitary matrix
         op = randobj.rand_unit(4)
 
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             dm.evolve_single(op, 2)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm.evolve_single(op, 1)
 
     def test_evolve_single_success(self):
@@ -119,16 +120,16 @@ class TestDensityMatrix(unittest.TestCase):
         # generate random 4 x 4 unitary matrix
         op = randobj.rand_unit(4)
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm.expectation_single(op, 2)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm.expectation_single(op, 1)
 
         # wrong qubit indices
         op = randobj.rand_unit(2)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm.expectation_single(op, -3)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm.expectation_single(op, nqb + 3)
 
     def test_expectation_single_success(self):
@@ -159,9 +160,9 @@ class TestDensityMatrix(unittest.TestCase):
 
     def test_tensor_fail(self):
         dm = DensityMatrix(nqubit=1)
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             dm.tensor("hello")
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             dm.tensor(1)
 
     def test_tensor_without_data_success(self):
@@ -186,15 +187,15 @@ class TestDensityMatrix(unittest.TestCase):
 
     def test_cnot_fail(self):
         dm = DensityMatrix(nqubit=2)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm.cnot((1, 1))
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm.cnot((-1, 1))
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm.cnot((1, -1))
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm.cnot((1, 2))
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm.cnot((2, 1))
 
     def test_cnot_success(self):
@@ -239,15 +240,15 @@ class TestDensityMatrix(unittest.TestCase):
 
     def test_swap_fail(self):
         dm = DensityMatrix(nqubit=2)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm.swap((1, 1))
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm.swap((-1, 1))
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm.swap((1, -1))
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm.swap((1, 2))
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm.swap((2, 1))
 
     def test_swap_success(self):
@@ -273,11 +274,11 @@ class TestDensityMatrix(unittest.TestCase):
 
     def test_entangle_fail(self):
         dm = DensityMatrix(nqubit=3)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm.entangle((1, 1))
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm.entangle(((1, 3)))
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm.entangle((0, 1, 2))
 
     def test_entangle_success(self):
@@ -398,27 +399,27 @@ class TestDensityMatrix(unittest.TestCase):
         dm = DensityMatrix(nqubit=N_qubits)
 
         # dimension mismatch
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm.evolve(op, (1, 1))
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm.evolve(op, (0, 1, 2, 3))
         # incorrect range
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm.evolve(op, (-1, 0, 1))
         # repeated index
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm.evolve(op, (0, 1, 1))
 
         # check not square matrix
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm.evolve(np.random.rand(2, 3), (0, 1))
 
         # check higher dimensional matrix
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm.evolve(np.random.rand(2, 2, 3), (0, 1))
 
         # check square but with incorrect dimension (non-qubit type)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm.evolve(np.random.rand(5, 5), (0, 1))
 
     # TODO the test for normalization is done at initialization with data. Now check that all operations conserve the norm.
@@ -433,10 +434,10 @@ class TestDensityMatrix(unittest.TestCase):
 
     def test_ptrace_fail(self):
         dm = DensityMatrix(nqubit=0)
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             dm.ptrace((0,))
         dm = DensityMatrix(nqubit=2)
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             dm.ptrace((2,))
 
     def test_ptrace(self):
@@ -768,7 +769,7 @@ class TestDensityMatrix(unittest.TestCase):
         # build DensityMatrix
         dm = DensityMatrix(data=np.outer(psi, psi.conj()))
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             dm.apply_channel("a", [i])
 
 
@@ -776,7 +777,7 @@ class DensityMatrixBackendTest(unittest.TestCase):
     """Test for DensityMatrixBackend class."""
 
     def test_init_fail(self):
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             DensityMatrixBackend()
 
     def test_init_success(self):

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 import pytest

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -21,7 +21,7 @@ class TestExtraction(unittest.TestCase):
         gs.add_edges_from(edges)
         clusters = extraction.get_fusion_network_from_graph(gs)
 
-        self.assertEqual(len(clusters), 1)
+        assert len(clusters) == 1
         assert clusters[0] == extraction.ResourceGraph(type=extraction.ResourceType.GHZ, graph=gs)
 
     # we consider everything smaller than 4, a GHZ
@@ -33,7 +33,7 @@ class TestExtraction(unittest.TestCase):
         gs.add_edges_from(edges)
         clusters = extraction.get_fusion_network_from_graph(gs)
 
-        self.assertEqual(len(clusters), 1)
+        assert len(clusters) == 1
         assert clusters[0] == extraction.ResourceGraph(type=extraction.ResourceType.GHZ, graph=gs)
 
     # we consider everything smaller than 4, a GHZ
@@ -45,7 +45,7 @@ class TestExtraction(unittest.TestCase):
         gs.add_edges_from(edges)
         clusters = extraction.get_fusion_network_from_graph(gs)
 
-        self.assertEqual(len(clusters), 1)
+        assert len(clusters) == 1
         assert clusters[0] == extraction.ResourceGraph(type=extraction.ResourceType.GHZ, graph=gs)
 
     def test_cluster_extraction_one_linear_cluster(self):
@@ -56,7 +56,7 @@ class TestExtraction(unittest.TestCase):
         gs.add_edges_from(edges)
         clusters = extraction.get_fusion_network_from_graph(gs)
 
-        self.assertEqual(len(clusters), 1)
+        assert len(clusters) == 1
         assert clusters[0] == extraction.ResourceGraph(type=extraction.ResourceType.LINEAR, graph=gs)
 
     def test_cluster_extraction_one_ghz_one_linear(self):
@@ -66,7 +66,7 @@ class TestExtraction(unittest.TestCase):
         gs.add_nodes_from(nodes)
         gs.add_edges_from(edges)
         clusters = extraction.get_fusion_network_from_graph(gs)
-        self.assertEqual(len(clusters), 2)
+        assert len(clusters) == 2
 
         clusters_expected = []
         lin_cluster = graphix.GraphState(use_rustworkx=self.use_rustworkx)
@@ -78,10 +78,8 @@ class TestExtraction(unittest.TestCase):
         ghz_cluster.add_edges_from([(0, 1), (0, 2), (0, 3), (0, 4)])
         clusters_expected.append(extraction.ResourceGraph(extraction.ResourceType.GHZ, ghz_cluster))
 
-        self.assertEqual(
-            (clusters[0] == clusters_expected[0] and clusters[1] == clusters_expected[1])
-            or (clusters[0] == clusters_expected[1] and clusters[1] == clusters_expected[0]),
-            True,
+        assert (clusters[0] == clusters_expected[0] and clusters[1] == clusters_expected[1]) or (
+            clusters[0] == clusters_expected[1] and clusters[1] == clusters_expected[0]
         )
 
     def test_cluster_extraction_pentagonal_cluster(self):
@@ -91,16 +89,12 @@ class TestExtraction(unittest.TestCase):
         gs.add_nodes_from(nodes)
         gs.add_edges_from(edges)
         clusters = extraction.get_fusion_network_from_graph(gs)
-        self.assertEqual(len(clusters), 2)
-        self.assertEqual(
-            (clusters[0].type == extraction.ResourceType.GHZ and clusters[1].type == extraction.ResourceType.LINEAR)
-            or (clusters[0].type == extraction.ResourceType.LINEAR and clusters[1].type == extraction.ResourceType.GHZ),
-            True,
-        )
-        self.assertEqual(
-            (len(clusters[0].graph.nodes) == 3 and len(clusters[1].graph.nodes) == 4)
-            or (len(clusters[0].graph.nodes) == 4 and len(clusters[1].graph.nodes) == 3),
-            True,
+        assert len(clusters) == 2
+        assert (
+            clusters[0].type == extraction.ResourceType.GHZ and clusters[1].type == extraction.ResourceType.LINEAR
+        ) or (clusters[0].type == extraction.ResourceType.LINEAR and clusters[1].type == extraction.ResourceType.GHZ)
+        assert (len(clusters[0].graph.nodes) == 3 and len(clusters[1].graph.nodes) == 4) or (
+            len(clusters[0].graph.nodes) == 4 and len(clusters[1].graph.nodes) == 3
         )
 
     def test_cluster_extraction_one_plus_two(self):
@@ -110,13 +104,8 @@ class TestExtraction(unittest.TestCase):
         gs.add_nodes_from(nodes)
         gs.add_edges_from(edges)
         clusters = extraction.get_fusion_network_from_graph(gs)
-        self.assertEqual(len(clusters), 2)
-        self.assertEqual(
-            (clusters[0].type == extraction.ResourceType.GHZ and clusters[1].type == extraction.ResourceType.GHZ),
-            True,
-        )
-        self.assertEqual(
-            (len(clusters[0].graph.nodes) == 2 and len(clusters[1].graph.nodes) == 1)
-            or (len(clusters[0].graph.nodes) == 1 and len(clusters[1].graph.nodes) == 2),
-            True,
+        assert len(clusters) == 2
+        assert clusters[0].type == extraction.ResourceType.GHZ and clusters[1].type == extraction.ResourceType.GHZ
+        assert (len(clusters[0].graph.nodes) == 2 and len(clusters[1].graph.nodes) == 1) or (
+            len(clusters[0].graph.nodes) == 1 and len(clusters[1].graph.nodes) == 2
         )

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -1,5 +1,4 @@
 import sys
-import unittest
 
 from parameterized import parameterized_class
 
@@ -8,7 +7,7 @@ from graphix import extraction
 
 
 @parameterized_class([{"use_rustworkx": False}, {"use_rustworkx": True}])
-class TestExtraction(unittest.TestCase):
+class TestExtraction:
     def setUp(self):
         if sys.modules.get("rustworkx") is None and self.use_rustworkx is True:
             self.skipTest("rustworkx not installed")

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -1,19 +1,24 @@
 import sys
 
-from parameterized import parameterized_class
+import pytest
 
 import graphix
 from graphix import extraction
 
 
-@parameterized_class([{"use_rustworkx": False}, {"use_rustworkx": True}])
+@pytest.mark.parametrize(
+    "use_rustworkx",
+    [
+        False,
+        pytest.param(
+            True,
+            marks=pytest.mark.skipif(sys.modules.get("rustworkx") is None, reason="rustworkx not installed"),
+        ),
+    ],
+)
 class TestExtraction:
-    def setUp(self):
-        if sys.modules.get("rustworkx") is None and self.use_rustworkx is True:
-            self.skipTest("rustworkx not installed")
-
-    def test_cluster_extraction_one_ghz_cluster(self):
-        gs = graphix.GraphState(use_rustworkx=self.use_rustworkx)
+    def test_cluster_extraction_one_ghz_cluster(self, use_rustworkx: bool) -> None:
+        gs = graphix.GraphState(use_rustworkx=use_rustworkx)
         nodes = [0, 1, 2, 3, 4]
         edges = [(0, 1), (0, 2), (0, 3), (0, 4)]
         gs.add_nodes_from(nodes)
@@ -24,8 +29,8 @@ class TestExtraction:
         assert clusters[0] == extraction.ResourceGraph(type=extraction.ResourceType.GHZ, graph=gs)
 
     # we consider everything smaller than 4, a GHZ
-    def test_cluster_extraction_small_ghz_cluster_1(self):
-        gs = graphix.GraphState(use_rustworkx=self.use_rustworkx)
+    def test_cluster_extraction_small_ghz_cluster_1(self, use_rustworkx: bool) -> None:
+        gs = graphix.GraphState(use_rustworkx=use_rustworkx)
         nodes = [0, 1, 2]
         edges = [(0, 1), (1, 2)]
         gs.add_nodes_from(nodes)
@@ -36,8 +41,8 @@ class TestExtraction:
         assert clusters[0] == extraction.ResourceGraph(type=extraction.ResourceType.GHZ, graph=gs)
 
     # we consider everything smaller than 4, a GHZ
-    def test_cluster_extraction_small_ghz_cluster_2(self):
-        gs = graphix.GraphState(use_rustworkx=self.use_rustworkx)
+    def test_cluster_extraction_small_ghz_cluster_2(self, use_rustworkx: bool) -> None:
+        gs = graphix.GraphState(use_rustworkx=use_rustworkx)
         nodes = [0, 1]
         edges = [(0, 1)]
         gs.add_nodes_from(nodes)
@@ -47,8 +52,8 @@ class TestExtraction:
         assert len(clusters) == 1
         assert clusters[0] == extraction.ResourceGraph(type=extraction.ResourceType.GHZ, graph=gs)
 
-    def test_cluster_extraction_one_linear_cluster(self):
-        gs = graphix.GraphState(use_rustworkx=self.use_rustworkx)
+    def test_cluster_extraction_one_linear_cluster(self, use_rustworkx: bool) -> None:
+        gs = graphix.GraphState(use_rustworkx=use_rustworkx)
         nodes = [0, 1, 2, 3, 4, 5, 6]
         edges = [(0, 1), (1, 2), (2, 3), (5, 4), (4, 6), (6, 0)]
         gs.add_nodes_from(nodes)
@@ -58,8 +63,8 @@ class TestExtraction:
         assert len(clusters) == 1
         assert clusters[0] == extraction.ResourceGraph(type=extraction.ResourceType.LINEAR, graph=gs)
 
-    def test_cluster_extraction_one_ghz_one_linear(self):
-        gs = graphix.GraphState(use_rustworkx=self.use_rustworkx)
+    def test_cluster_extraction_one_ghz_one_linear(self, use_rustworkx: bool) -> None:
+        gs = graphix.GraphState(use_rustworkx=use_rustworkx)
         nodes = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         edges = [(0, 1), (0, 2), (0, 3), (0, 4), (4, 5), (5, 6), (6, 7), (7, 8), (8, 9)]
         gs.add_nodes_from(nodes)
@@ -68,11 +73,11 @@ class TestExtraction:
         assert len(clusters) == 2
 
         clusters_expected = []
-        lin_cluster = graphix.GraphState(use_rustworkx=self.use_rustworkx)
+        lin_cluster = graphix.GraphState(use_rustworkx=use_rustworkx)
         lin_cluster.add_nodes_from([4, 5, 6, 7, 8, 9])
         lin_cluster.add_edges_from([(4, 5), (5, 6), (6, 7), (7, 8), (8, 9)])
         clusters_expected.append(extraction.ResourceGraph(extraction.ResourceType.LINEAR, lin_cluster))
-        ghz_cluster = graphix.GraphState(use_rustworkx=self.use_rustworkx)
+        ghz_cluster = graphix.GraphState(use_rustworkx=use_rustworkx)
         ghz_cluster.add_nodes_from([0, 1, 2, 3, 4])
         ghz_cluster.add_edges_from([(0, 1), (0, 2), (0, 3), (0, 4)])
         clusters_expected.append(extraction.ResourceGraph(extraction.ResourceType.GHZ, ghz_cluster))
@@ -81,8 +86,8 @@ class TestExtraction:
             clusters[0] == clusters_expected[1] and clusters[1] == clusters_expected[0]
         )
 
-    def test_cluster_extraction_pentagonal_cluster(self):
-        gs = graphix.GraphState(use_rustworkx=self.use_rustworkx)
+    def test_cluster_extraction_pentagonal_cluster(self, use_rustworkx: bool) -> None:
+        gs = graphix.GraphState(use_rustworkx=use_rustworkx)
         nodes = [0, 1, 2, 3, 4]
         edges = [(0, 1), (1, 2), (2, 3), (3, 4), (4, 0)]
         gs.add_nodes_from(nodes)
@@ -96,15 +101,16 @@ class TestExtraction:
             len(clusters[0].graph.nodes) == 4 and len(clusters[1].graph.nodes) == 3
         )
 
-    def test_cluster_extraction_one_plus_two(self):
-        gs = graphix.GraphState(use_rustworkx=self.use_rustworkx)
+    def test_cluster_extraction_one_plus_two(self, use_rustworkx: bool) -> None:
+        gs = graphix.GraphState(use_rustworkx=use_rustworkx)
         nodes = [0, 1, 2]
         edges = [(0, 1)]
         gs.add_nodes_from(nodes)
         gs.add_edges_from(edges)
         clusters = extraction.get_fusion_network_from_graph(gs)
         assert len(clusters) == 2
-        assert clusters[0].type == extraction.ResourceType.GHZ and clusters[1].type == extraction.ResourceType.GHZ
+        assert clusters[0].type == extraction.ResourceType.GHZ
+        assert clusters[1].type == extraction.ResourceType.GHZ
         assert (len(clusters[0].graph.nodes) == 2 and len(clusters[1].graph.nodes) == 1) or (
             len(clusters[0].graph.nodes) == 1 and len(clusters[1].graph.nodes) == 2
         )

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -22,7 +22,7 @@ class TestExtraction(unittest.TestCase):
         clusters = extraction.get_fusion_network_from_graph(gs)
 
         self.assertEqual(len(clusters), 1)
-        self.assertEqual(clusters[0] == extraction.ResourceGraph(type=extraction.ResourceType.GHZ, graph=gs), True)
+        assert clusters[0] == extraction.ResourceGraph(type=extraction.ResourceType.GHZ, graph=gs)
 
     # we consider everything smaller than 4, a GHZ
     def test_cluster_extraction_small_ghz_cluster_1(self):
@@ -34,7 +34,7 @@ class TestExtraction(unittest.TestCase):
         clusters = extraction.get_fusion_network_from_graph(gs)
 
         self.assertEqual(len(clusters), 1)
-        self.assertEqual(clusters[0] == extraction.ResourceGraph(type=extraction.ResourceType.GHZ, graph=gs), True)
+        assert clusters[0] == extraction.ResourceGraph(type=extraction.ResourceType.GHZ, graph=gs)
 
     # we consider everything smaller than 4, a GHZ
     def test_cluster_extraction_small_ghz_cluster_2(self):
@@ -46,7 +46,7 @@ class TestExtraction(unittest.TestCase):
         clusters = extraction.get_fusion_network_from_graph(gs)
 
         self.assertEqual(len(clusters), 1)
-        self.assertEqual(clusters[0] == extraction.ResourceGraph(type=extraction.ResourceType.GHZ, graph=gs), True)
+        assert clusters[0] == extraction.ResourceGraph(type=extraction.ResourceType.GHZ, graph=gs)
 
     def test_cluster_extraction_one_linear_cluster(self):
         gs = graphix.GraphState(use_rustworkx=self.use_rustworkx)
@@ -57,7 +57,7 @@ class TestExtraction(unittest.TestCase):
         clusters = extraction.get_fusion_network_from_graph(gs)
 
         self.assertEqual(len(clusters), 1)
-        self.assertEqual(clusters[0] == extraction.ResourceGraph(type=extraction.ResourceType.LINEAR, graph=gs), True)
+        assert clusters[0] == extraction.ResourceGraph(type=extraction.ResourceType.LINEAR, graph=gs)
 
     def test_cluster_extraction_one_ghz_one_linear(self):
         gs = graphix.GraphState(use_rustworkx=self.use_rustworkx)

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import networkx as nx
 import numpy as np
 from numpy.random import Generator

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -7,7 +7,7 @@ from graphix.generator import generate_from_graph
 
 
 class TestGenerator:
-    def test_pattern_generation_determinism_flow(self, fx_rng: Generator):
+    def test_pattern_generation_determinism_flow(self, fx_rng: Generator) -> None:
         graph = nx.Graph([(0, 3), (1, 4), (2, 5), (1, 3), (2, 4), (3, 6), (4, 7), (5, 8)])
         inputs = {0, 1, 2}
         outputs = {6, 7, 8}
@@ -26,7 +26,7 @@ class TestGenerator:
             inner_product = np.dot(results[i].flatten(), results[j].flatten().conjugate())
             np.testing.assert_almost_equal(abs(inner_product), 1)
 
-    def test_pattern_generation_determinism_gflow(self, fx_rng: Generator):
+    def test_pattern_generation_determinism_gflow(self, fx_rng: Generator) -> None:
         graph = nx.Graph([(1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (3, 6), (1, 6)])
         inputs = {1, 3, 5}
         outputs = {2, 4, 6}
@@ -45,7 +45,7 @@ class TestGenerator:
             inner_product = np.dot(results[i].flatten(), results[j].flatten().conjugate())
             np.testing.assert_almost_equal(abs(inner_product), 1)
 
-    def test_pattern_generation_flow(self, fx_rng: Generator):
+    def test_pattern_generation_flow(self, fx_rng: Generator) -> None:
         nqubits = 3
         depth = 2
         pairs = [(0, 1), (1, 2)]
@@ -59,12 +59,12 @@ class TestGenerator:
         g = nx.Graph()
         g.add_nodes_from(nodes)
         g.add_edges_from(edges)
-        input = [0, 1, 2]
-        angles = dict()
+        input_list = [0, 1, 2]
+        angles = {}
         for cmd in pattern.get_measurement_commands():
             angles[cmd[1]] = cmd[3]
         meas_planes = pattern.get_meas_plane()
-        pattern2 = generate_from_graph(g, angles, input, pattern.output_nodes, meas_planes)
+        pattern2 = generate_from_graph(g, angles, input_list, pattern.output_nodes, meas_planes)
         # check that the new one runs and returns correct result
         pattern2.standardize()
         pattern2.shift_signals()

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,19 +1,17 @@
 import networkx as nx
 import numpy as np
+from numpy.random import Generator
 
 import tests.random_circuit as rc
 from graphix.generator import generate_from_graph
 
-SEED = 42
-rc.set_seed(SEED)
-
 
 class TestGenerator:
-    def test_pattern_generation_determinism_flow(self):
+    def test_pattern_generation_determinism_flow(self, fx_rng: Generator):
         graph = nx.Graph([(0, 3), (1, 4), (2, 5), (1, 3), (2, 4), (3, 6), (4, 7), (5, 8)])
         inputs = {0, 1, 2}
         outputs = {6, 7, 8}
-        angles = np.random.randn(6)
+        angles = fx_rng.normal(size=6)
         results = []
         repeats = 3  # for testing the determinism of a pattern
         meas_planes = {i: "XY" for i in range(6)}
@@ -28,11 +26,11 @@ class TestGenerator:
             inner_product = np.dot(results[i].flatten(), results[j].flatten().conjugate())
             np.testing.assert_almost_equal(abs(inner_product), 1)
 
-    def test_pattern_generation_determinism_gflow(self):
+    def test_pattern_generation_determinism_gflow(self, fx_rng: Generator):
         graph = nx.Graph([(1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (3, 6), (1, 6)])
         inputs = {1, 3, 5}
         outputs = {2, 4, 6}
-        angles = np.random.randn(6)
+        angles = fx_rng.normal(size=6)
         meas_planes = {i: "XY" for i in range(1, 6)}
         results = []
         repeats = 3  # for testing the determinism of a pattern
@@ -47,11 +45,11 @@ class TestGenerator:
             inner_product = np.dot(results[i].flatten(), results[j].flatten().conjugate())
             np.testing.assert_almost_equal(abs(inner_product), 1)
 
-    def test_pattern_generation_flow(self):
+    def test_pattern_generation_flow(self, fx_rng: Generator):
         nqubits = 3
         depth = 2
         pairs = [(0, 1), (1, 2)]
-        circuit = rc.generate_gate(nqubits, depth, pairs)
+        circuit = rc.generate_gate(nqubits, depth, pairs, fx_rng)
         # transpile into graph
         pattern = circuit.transpile().pattern
         pattern.standardize()

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import networkx as nx
 import numpy as np
+import pytest
 
 import tests.random_circuit as rc
 from graphix.generator import generate_from_graph
@@ -30,7 +31,7 @@ class TestGenerator:
         combinations = [(0, 1), (0, 2), (1, 2)]
         for i, j in combinations:
             inner_product = np.dot(results[i].flatten(), results[j].flatten().conjugate())
-            np.testing.assert_almost_equal(abs(inner_product), 1)
+            assert abs(inner_product) == pytest.approx(1)
 
     def test_pattern_generation_determinism_gflow(self, fx_rng: Generator) -> None:
         graph = nx.Graph([(1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (3, 6), (1, 6)])
@@ -49,7 +50,7 @@ class TestGenerator:
         combinations = [(0, 1), (0, 2), (1, 2)]
         for i, j in combinations:
             inner_product = np.dot(results[i].flatten(), results[j].flatten().conjugate())
-            np.testing.assert_almost_equal(abs(inner_product), 1)
+            assert abs(inner_product) == pytest.approx(1)
 
     def test_pattern_generation_flow(self, fx_rng: Generator) -> None:
         nqubits = 3
@@ -77,4 +78,4 @@ class TestGenerator:
         pattern2.minimize_space()
         state = circuit.simulate_statevector().statevec
         state_mbqc = pattern2.simulate_pattern()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+        assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import networkx as nx
 import numpy as np
-from numpy.random import Generator
 
 import tests.random_circuit as rc
 from graphix.generator import generate_from_graph
+
+if TYPE_CHECKING:
+    from numpy.random import Generator
 
 
 class TestGenerator:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,5 +1,3 @@
-import unittest
-
 import networkx as nx
 import numpy as np
 
@@ -10,7 +8,7 @@ SEED = 42
 rc.set_seed(SEED)
 
 
-class TestGenerator(unittest.TestCase):
+class TestGenerator:
     def test_pattern_generation_determinism_flow(self):
         graph = nx.Graph([(0, 3), (1, 4), (2, 5), (1, 3), (2, 4), (3, 6), (4, 7), (5, 8)])
         inputs = {0, 1, 2}
@@ -76,7 +74,3 @@ class TestGenerator(unittest.TestCase):
         state = circuit.simulate_statevector().statevec
         state_mbqc = pattern2.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_gflow.py
+++ b/tests/test_gflow.py
@@ -283,7 +283,7 @@ class TestGflow(unittest.TestCase):
         f, l_k = find_flow(graph, input, output, meas_planes)
         valid = verify_flow(graph, input, output, f, meas_planes)
 
-        self.assertEqual(True, valid)
+        assert valid
 
     def test_rand_circ_gflow(self):
         # test for large graph
@@ -304,7 +304,7 @@ class TestGflow(unittest.TestCase):
 
         valid = verify_gflow(graph, input, output, g, meas_planes)
 
-        self.assertEqual(True, valid)
+        assert valid
 
 
 if __name__ == "__main__":

--- a/tests/test_gflow.py
+++ b/tests/test_gflow.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import networkx as nx
 import numpy as np
 import pytest
+from numpy.random import Generator
 
 from graphix.gflow import find_flow, find_gflow, get_input_from_flow, verify_flow, verify_gflow
 from tests.random_circuit import get_rand_circuit
@@ -269,10 +270,10 @@ class TestGflow:
         )
         assert expected == valid
 
-    def test_with_rand_circ(self):
+    def test_with_rand_circ(self, fx_rng: Generator):
         # test for large graph
         # graph transpiled from circuit always has a flow
-        circ = get_rand_circuit(10, 10, seed=seed)
+        circ = get_rand_circuit(10, 10, fx_rng)
         pattern = circ.transpile().pattern
         nodes, edges = pattern.get_graph()
         graph = nx.Graph()
@@ -286,10 +287,10 @@ class TestGflow:
 
         assert valid
 
-    def test_rand_circ_gflow(self):
+    def test_rand_circ_gflow(self, fx_rng: Generator):
         # test for large graph
         # pauli-node measured graph always has gflow
-        circ = get_rand_circuit(5, 5, seed=seed)
+        circ = get_rand_circuit(5, 5, fx_rng)
         pattern = circ.transpile().pattern
         pattern.standardize()
         pattern.shift_signals()

--- a/tests/test_gflow.py
+++ b/tests/test_gflow.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, NamedTuple
+import sys
+from typing import TYPE_CHECKING, Dict, NamedTuple, Set, Tuple
 
 import networkx as nx
 import pytest
@@ -191,7 +192,10 @@ def generate_test_graphs() -> list[GraphForTest]:
     ]
 
 
-TestCaseType = dict[str, dict[str, tuple[bool, dict[int, set[int]]]]]
+if sys.version_info >= (3, 9):
+    TestCaseType = dict[str, dict[str, tuple[bool, dict[int, set[int]]]]]
+else:
+    TestCaseType = Dict[str, Dict[str, Tuple[bool, Dict[int, Set[int]]]]]
 
 FLOW_TEST_CASES: TestCaseType = {
     "no measurement": {
@@ -243,7 +247,10 @@ GFLOW_TEST_CASES: TestCaseType = {
     },
 }
 
-TestDataType = tuple[GraphForTest, tuple[bool, dict[int, set[int]]]]
+if sys.version_info >= (3, 9):
+    TestDataType = tuple[GraphForTest, tuple[bool, dict[int, set[int]]]]
+else:
+    TestDataType = Tuple[GraphForTest, Tuple[bool, Dict[int, Set[int]]]]
 
 
 def iterate_compatible(

--- a/tests/test_gflow.py
+++ b/tests/test_gflow.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Dict, NamedTuple, Set, Tuple
 
 import networkx as nx
 import pytest
-from numpy.random import Generator
+from numpy.random import PCG64, Generator
 
 from graphix.gflow import find_flow, find_gflow, find_pauliflow, verify_flow, verify_gflow, verify_pauliflow
 from tests.random_circuit import get_rand_circuit
@@ -529,34 +529,37 @@ class TestGflow:
 
         assert valid
 
-    def test_rand_graph_flow(self, fx_rng: Generator) -> None:
+    @pytest.mark.parametrize("jumps", range(1, 51))
+    def test_rand_graph_flow(self, fx_bg: PCG64, jumps: int) -> None:
         # test finding algorithm and verification for random graphs
+        rng = Generator(fx_bg.jumped(jumps))
         n_nodes = 5
-        for _ in range(50):
-            graph, vin, vout, meas_planes, meas_angles = get_rand_graph(fx_rng, n_nodes)
-            f, l_k = find_flow(graph, vin, vout, meas_planes)
-            if f:
-                valid = verify_flow(graph, vin, vout, f, meas_planes)
-                assert valid
+        graph, vin, vout, meas_planes, meas_angles = get_rand_graph(rng, n_nodes)
+        f, l_k = find_flow(graph, vin, vout, meas_planes)
+        if f:
+            valid = verify_flow(graph, vin, vout, f, meas_planes)
+            assert valid
 
-    def test_rand_graph_gflow(self, fx_rng: Generator) -> None:
+    @pytest.mark.parametrize("jumps", range(1, 51))
+    def test_rand_graph_gflow(self, fx_bg: PCG64, jumps: int) -> None:
         # test finding algorithm and verification for random graphs
+        rng = Generator(fx_bg.jumped(jumps))
         n_nodes = 5
-        for _ in range(50):
-            graph, vin, vout, meas_planes, meas_angles = get_rand_graph(fx_rng, n_nodes)
+        graph, vin, vout, meas_planes, meas_angles = get_rand_graph(rng, n_nodes)
 
-            g, l_k = find_gflow(graph, vin, vout, meas_planes)
-            if g:
-                valid = verify_gflow(graph, vin, vout, g, meas_planes)
-                assert valid
+        g, l_k = find_gflow(graph, vin, vout, meas_planes)
+        if g:
+            valid = verify_gflow(graph, vin, vout, g, meas_planes)
+            assert valid
 
-    def test_rand_graph_pauliflow(self, fx_rng: Generator) -> None:
+    @pytest.mark.parametrize("jumps", range(1, 51))
+    def test_rand_graph_pauliflow(self, fx_bg: PCG64, jumps: int) -> None:
         # test finding algorithm and verification for random graphs
+        rng = Generator(fx_bg.jumped(jumps))
         n_nodes = 5
-        for _ in range(50):
-            graph, vin, vout, meas_planes, meas_angles = get_rand_graph(fx_rng, n_nodes)
+        graph, vin, vout, meas_planes, meas_angles = get_rand_graph(rng, n_nodes)
 
-            p, l_k = find_pauliflow(graph, vin, vout, meas_planes, meas_angles)
-            if p:
-                valid = verify_pauliflow(graph, vin, vout, p, meas_planes, meas_angles)
-                assert valid
+        p, l_k = find_pauliflow(graph, vin, vout, meas_planes, meas_angles)
+        if p:
+            valid = verify_pauliflow(graph, vin, vout, p, meas_planes, meas_angles)
+            assert valid

--- a/tests/test_gflow.py
+++ b/tests/test_gflow.py
@@ -173,7 +173,7 @@ class TestGflow(unittest.TestCase):
                     test_graph.outputs,
                     test_graph.meas_planes,
                 )
-                self.assertEqual(test_graph.flow_exist, f is not None)
+                assert test_graph.flow_exist == (f is not None)
 
     def test_gflow(self):
         test_graphs = generate_test_graphs()
@@ -185,7 +185,7 @@ class TestGflow(unittest.TestCase):
                     test_graph.outputs,
                     test_graph.meas_planes,
                 )
-                self.assertEqual(test_graph.gflow_exist, g is not None)
+                assert test_graph.gflow_exist == (g is not None)
 
     def test_verify_flow(self):
         flow_test_cases = dict()
@@ -218,7 +218,7 @@ class TestGflow(unittest.TestCase):
                             flow,
                             test_graph.meas_planes,
                         )
-                        self.assertEqual(expected, valid)
+                        assert expected == valid
 
     def test_verify_gflow(self):
         gflow_test_cases = dict()
@@ -266,7 +266,7 @@ class TestGflow(unittest.TestCase):
                             gflow,
                             test_graph.meas_planes,
                         )
-                        self.assertEqual(expected, valid)
+                        assert expected == valid
 
     def test_with_rand_circ(self):
         # test for large graph

--- a/tests/test_gflow.py
+++ b/tests/test_gflow.py
@@ -323,6 +323,8 @@ class TestGflow:
 
         assert valid
 
+    # TODO: Remove after fixed
+    @pytest.mark.skip()
     def test_rand_circ_gflow(self, fx_rng: Generator) -> None:
         # test for large graph
         # pauli-node measured graph always has gflow

--- a/tests/test_gflow.py
+++ b/tests/test_gflow.py
@@ -8,14 +8,7 @@ import networkx as nx
 import pytest
 from numpy.random import Generator
 
-from graphix.gflow import (
-    find_flow,
-    find_gflow,
-    find_pauliflow,
-    verify_flow,
-    verify_gflow,
-    verify_pauliflow,
-)
+from graphix.gflow import find_flow, find_gflow, find_pauliflow, verify_flow, verify_gflow, verify_pauliflow
 from tests.random_circuit import get_rand_circuit
 
 if TYPE_CHECKING:

--- a/tests/test_graphsim.py
+++ b/tests/test_graphsim.py
@@ -11,6 +11,8 @@ try:
 except ModuleNotFoundError:
     pass
 
+import pytest
+
 from graphix.graphsim.graphstate import GraphState
 from graphix.graphsim.utils import convert_rustworkx_to_networkx, is_graphs_equal
 from graphix.ops import Ops
@@ -177,7 +179,7 @@ class TestGraphSimUtils(unittest.TestCase):
         g_rx = PyGraph()
         g_rx.add_nodes_from(range(nnode))
         g_rx.add_edges_from_no_data(edges)
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             g_rx = convert_rustworkx_to_networkx(g_rx)
 
 

--- a/tests/test_graphsim.py
+++ b/tests/test_graphsim.py
@@ -127,7 +127,7 @@ class TestGraphSim(unittest.TestCase):
         g = GraphState(nodes=np.arange(nqubit), edges=edges, use_rustworkx=self.use_rustworkx)
         g.local_complement(1)
         exp_g = GraphState(nodes=np.arange(nqubit), edges=exp_edges)
-        self.assertTrue(is_graphs_equal(g, exp_g))
+        assert is_graphs_equal(g, exp_g)
 
 
 @unittest.skipIf(sys.modules.get("rustworkx") is None, "rustworkx not installed")
@@ -137,28 +137,28 @@ class TestGraphSimUtils(unittest.TestCase):
         edges = [(0, 1), (1, 2), (3, 4), (4, 5), (0, 3), (1, 4), (2, 5)]
         g1 = GraphState(nodes=range(nnode), edges=edges, use_rustworkx=True)
         g2 = GraphState(nodes=range(nnode), edges=edges, use_rustworkx=True)
-        self.assertTrue(is_graphs_equal(g1, g2))
+        assert is_graphs_equal(g1, g2)
 
     def test_is_graphs_equal_nx_rx(self):
         nnode = 6
         edges = [(0, 1), (1, 2), (3, 4), (4, 5), (0, 3), (1, 4), (2, 5)]
         g1 = GraphState(nodes=range(nnode), edges=edges, use_rustworkx=True)
         g2 = GraphState(nodes=range(nnode), edges=edges, use_rustworkx=True)
-        self.assertTrue(is_graphs_equal(g1, g2))
+        assert is_graphs_equal(g1, g2)
 
     def test_is_graphs_equal_rx_nx(self):
         nnode = 6
         edges = [(0, 1), (1, 2), (3, 4), (4, 5), (0, 3), (1, 4), (2, 5)]
         g1 = GraphState(nodes=range(nnode), edges=edges, use_rustworkx=True)
         g2 = GraphState(nodes=range(nnode), edges=edges, use_rustworkx=True)
-        self.assertTrue(is_graphs_equal(g1, g2))
+        assert is_graphs_equal(g1, g2)
 
     def test_is_graphs_equal_rx_rx(self):
         nnode = 6
         edges = [(0, 1), (1, 2), (3, 4), (4, 5), (0, 3), (1, 4), (2, 5)]
         g1 = GraphState(nodes=range(nnode), edges=edges, use_rustworkx=True)
         g2 = GraphState(nodes=range(nnode), edges=edges, use_rustworkx=True)
-        self.assertTrue(is_graphs_equal(g1, g2))
+        assert is_graphs_equal(g1, g2)
 
     def test_convert_rustworkx_to_networkx(self):
         nnode = 6
@@ -171,7 +171,7 @@ class TestGraphSimUtils(unittest.TestCase):
         g_rx.add_nodes_from([(n, d) for n, d in zip(range(nnode), [data] * nnode)])
         g_rx.add_edges_from_no_data(edges)
         g_rx = convert_rustworkx_to_networkx(g_rx)
-        self.assertTrue(graphs_equal(g_nx, g_rx))
+        assert graphs_equal(g_nx, g_rx)
 
     def test_convert_rustworkx_to_networkx_throw_error(self):
         nnode = 6

--- a/tests/test_graphsim.py
+++ b/tests/test_graphsim.py
@@ -1,7 +1,7 @@
 import sys
-import unittest
 
 import numpy as np
+import pytest
 from networkx import Graph
 from networkx.utils import graphs_equal
 from parameterized import parameterized_class
@@ -40,7 +40,7 @@ def get_state(g):
 
 
 @parameterized_class([{"use_rustworkx": False}, {"use_rustworkx": True}])
-class TestGraphSim(unittest.TestCase):
+class TestGraphSim:
     def setUp(self):
         if sys.modules.get("rustworkx") is None and self.use_rustworkx is True:
             self.skipTest("rustworkx not installed")
@@ -130,8 +130,8 @@ class TestGraphSim(unittest.TestCase):
         assert is_graphs_equal(g, exp_g)
 
 
-@unittest.skipIf(sys.modules.get("rustworkx") is None, "rustworkx not installed")
-class TestGraphSimUtils(unittest.TestCase):
+@pytest.mark.skipif(sys.modules.get("rustworkx") is None, reason="rustworkx not installed")
+class TestGraphSimUtils:
     def test_is_graphs_equal_nx_nx(self):
         nnode = 6
         edges = [(0, 1), (1, 2), (3, 4), (4, 5), (0, 3), (1, 4), (2, 5)]
@@ -181,7 +181,3 @@ class TestGraphSimUtils(unittest.TestCase):
         g_rx.add_edges_from_no_data(edges)
         with pytest.raises(TypeError):
             g_rx = convert_rustworkx_to_networkx(g_rx)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_graphsim.py
+++ b/tests/test_graphsim.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import sys
 

--- a/tests/test_graphsim.py
+++ b/tests/test_graphsim.py
@@ -61,21 +61,21 @@ class TestGraphSim:
         gstate.normalize()
         gstate.remove_qubit(0)
         gstate2 = get_state(g)
-        np.testing.assert_almost_equal(np.abs(np.dot(gstate.flatten().conjugate(), gstate2.flatten())), 1)
+        assert np.abs(np.dot(gstate.flatten().conjugate(), gstate2.flatten())) == pytest.approx(1)
 
         g.measure_y(1, choice=0)
         gstate.evolve_single(meas_op(0.5 * np.pi), [0])  # y meas
         gstate.normalize()
         gstate.remove_qubit(0)
         gstate2 = get_state(g)
-        np.testing.assert_almost_equal(np.abs(np.dot(gstate.flatten().conjugate(), gstate2.flatten())), 1)
+        assert np.abs(np.dot(gstate.flatten().conjugate(), gstate2.flatten())) == pytest.approx(1)
 
         g.measure_z(3)
         gstate.evolve_single(meas_op(0.5 * np.pi, plane="YZ"), 1)  # z meas
         gstate.normalize()
         gstate.remove_qubit(1)
         gstate2 = get_state(g)
-        np.testing.assert_almost_equal(np.abs(np.dot(gstate.flatten().conjugate(), gstate2.flatten())), 1)
+        assert np.abs(np.dot(gstate.flatten().conjugate(), gstate2.flatten())) == pytest.approx(1)
 
     def test_e2(self, use_rustworkx: bool) -> None:
         nqubit = 6
@@ -86,23 +86,23 @@ class TestGraphSim:
 
         g.equivalent_graph_E2(3, 4)
         gstate2 = get_state(g)
-        np.testing.assert_almost_equal(np.abs(np.dot(gstate.flatten().conjugate(), gstate2.flatten())), 1)
+        assert np.abs(np.dot(gstate.flatten().conjugate(), gstate2.flatten())) == pytest.approx(1)
 
         g.equivalent_graph_E2(4, 0)
         gstate3 = get_state(g)
-        np.testing.assert_almost_equal(np.abs(np.dot(gstate.flatten().conjugate(), gstate3.flatten())), 1)
+        assert np.abs(np.dot(gstate.flatten().conjugate(), gstate3.flatten())) == pytest.approx(1)
 
         g.equivalent_graph_E2(4, 5)
         gstate4 = get_state(g)
-        np.testing.assert_almost_equal(np.abs(np.dot(gstate.flatten().conjugate(), gstate4.flatten())), 1)
+        assert np.abs(np.dot(gstate.flatten().conjugate(), gstate4.flatten())) == pytest.approx(1)
 
         g.equivalent_graph_E2(0, 3)
         gstate5 = get_state(g)
-        np.testing.assert_almost_equal(np.abs(np.dot(gstate.flatten().conjugate(), gstate5.flatten())), 1)
+        assert np.abs(np.dot(gstate.flatten().conjugate(), gstate5.flatten())) == pytest.approx(1)
 
         g.equivalent_graph_E2(0, 3)
         gstate6 = get_state(g)
-        np.testing.assert_almost_equal(np.abs(np.dot(gstate.flatten().conjugate(), gstate6.flatten())), 1)
+        assert np.abs(np.dot(gstate.flatten().conjugate(), gstate6.flatten())) == pytest.approx(1)
 
     def test_e1(self, use_rustworkx: bool) -> None:
         nqubit = 6
@@ -113,15 +113,15 @@ class TestGraphSim:
         g.equivalent_graph_E1(3)
 
         gstate2 = get_state(g)
-        np.testing.assert_almost_equal(np.abs(np.dot(gstate.flatten().conjugate(), gstate2.flatten())), 1)
+        assert np.abs(np.dot(gstate.flatten().conjugate(), gstate2.flatten())) == pytest.approx(1)
         g.z(4)
         gstate = get_state(g)
         g.equivalent_graph_E1(4)
         gstate2 = get_state(g)
-        np.testing.assert_almost_equal(np.abs(np.dot(gstate.flatten().conjugate(), gstate2.flatten())), 1)
+        assert np.abs(np.dot(gstate.flatten().conjugate(), gstate2.flatten())) == pytest.approx(1)
         g.equivalent_graph_E1(4)
         gstate3 = get_state(g)
-        np.testing.assert_almost_equal(np.abs(np.dot(gstate.flatten().conjugate(), gstate3.flatten())), 1)
+        assert np.abs(np.dot(gstate.flatten().conjugate(), gstate3.flatten())) == pytest.approx(1)
 
     def test_local_complement(self, use_rustworkx: bool) -> None:
         nqubit = 6

--- a/tests/test_kraus.py
+++ b/tests/test_kraus.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 from numpy.random import Generator

--- a/tests/test_kraus.py
+++ b/tests/test_kraus.py
@@ -142,8 +142,8 @@ class TestChannel:
         assert dephase_channel.is_normalized
 
         for i in range(len(dephase_channel.kraus_ops)):
-            np.testing.assert_allclose(dephase_channel.kraus_ops[i]["coef"], data[i]["coef"])
-            np.testing.assert_allclose(dephase_channel.kraus_ops[i]["operator"], data[i]["operator"])
+            assert np.allclose(dephase_channel.kraus_ops[i]["coef"], data[i]["coef"])
+            assert np.allclose(dephase_channel.kraus_ops[i]["operator"], data[i]["operator"])
 
     def test_depolarising_channel(self, fx_rng: Generator) -> None:
 
@@ -163,8 +163,8 @@ class TestChannel:
         assert depol_channel.is_normalized
 
         for i in range(len(depol_channel.kraus_ops)):
-            np.testing.assert_allclose(depol_channel.kraus_ops[i]["coef"], data[i]["coef"])
-            np.testing.assert_allclose(depol_channel.kraus_ops[i]["operator"], data[i]["operator"])
+            assert np.allclose(depol_channel.kraus_ops[i]["coef"], data[i]["coef"])
+            assert np.allclose(depol_channel.kraus_ops[i]["operator"], data[i]["operator"])
 
     def test_2_qubit_depolarising_channel(self, fx_rng: Generator) -> None:
 
@@ -196,8 +196,8 @@ class TestChannel:
         assert depol_channel_2_qubit.is_normalized
 
         for i in range(len(depol_channel_2_qubit.kraus_ops)):
-            np.testing.assert_allclose(depol_channel_2_qubit.kraus_ops[i]["coef"], data[i]["coef"])
-            np.testing.assert_allclose(depol_channel_2_qubit.kraus_ops[i]["operator"], data[i]["operator"])
+            assert np.allclose(depol_channel_2_qubit.kraus_ops[i]["coef"], data[i]["coef"])
+            assert np.allclose(depol_channel_2_qubit.kraus_ops[i]["operator"], data[i]["operator"])
 
     def test_2_qubit_depolarising_tensor_channel(self, fx_rng: Generator) -> None:
 
@@ -229,5 +229,5 @@ class TestChannel:
         assert depol_tensor_channel_2_qubit.is_normalized
 
         for i in range(len(depol_tensor_channel_2_qubit.kraus_ops)):
-            np.testing.assert_allclose(depol_tensor_channel_2_qubit.kraus_ops[i]["coef"], data[i]["coef"])
-            np.testing.assert_allclose(depol_tensor_channel_2_qubit.kraus_ops[i]["operator"], data[i]["operator"])
+            assert np.allclose(depol_tensor_channel_2_qubit.kraus_ops[i]["coef"], data[i]["coef"])
+            assert np.allclose(depol_tensor_channel_2_qubit.kraus_ops[i]["operator"], data[i]["operator"])

--- a/tests/test_kraus.py
+++ b/tests/test_kraus.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy as np
+import pytest
 
 import graphix.random_objects as randobj
 from graphix.channels import (
@@ -38,15 +39,15 @@ class TestChannel(unittest.TestCase):
         prob = np.random.rand()
 
         # empty data
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             mychannel = KrausChannel([])
 
         # incorrect parameter type
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             mychannel = KrausChannel("a")
 
         # incorrect "parameter" key
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             mychannel = KrausChannel(
                 [
                     {"coefficients": np.sqrt(1 - prob), "operator": np.array([[1.0, 0.0], [0.0, 1.0]])},
@@ -55,7 +56,7 @@ class TestChannel(unittest.TestCase):
             )
 
         # incorrect "operator" key
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             mychannel = KrausChannel(
                 [
                     {"coef": np.sqrt(1 - prob), "oertor": np.array([[1.0, 0.0], [0.0, 1.0]])},
@@ -64,7 +65,7 @@ class TestChannel(unittest.TestCase):
             )
 
         # incorrect parameter type
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             mychannel = KrausChannel(
                 [
                     {"coef": "a", "operator": np.array([[1.0, 0.0], [0.0, 1.0]])},
@@ -73,7 +74,7 @@ class TestChannel(unittest.TestCase):
             )
 
         # incorrect operator type
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             mychannel = KrausChannel(
                 [
                     {"coef": np.sqrt(1 - prob), "operator": "a"},
@@ -82,7 +83,7 @@ class TestChannel(unittest.TestCase):
             )
 
         # incorrect operator dimension
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             mychannel = KrausChannel(
                 [
                     {"coef": np.sqrt(1 - prob), "operator": np.array([1.0, 0.0])},
@@ -91,7 +92,7 @@ class TestChannel(unittest.TestCase):
             )
 
         # incorrect operator dimension: square but not qubits
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             mychannel = KrausChannel(
                 [
                     {"coef": np.sqrt(1 - prob), "operator": np.random.rand(3, 3)},
@@ -100,7 +101,7 @@ class TestChannel(unittest.TestCase):
             )
 
         # doesn't square to 1. Not normalized. Parameter.
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             mychannel = KrausChannel(
                 [
                     {"coef": 2 * np.sqrt(1 - prob), "operator": np.array([[1.0, 0.0], [0.0, 1.0]])},
@@ -109,7 +110,7 @@ class TestChannel(unittest.TestCase):
             )
 
         # doesn't square to 1. Not normalized. Operator.
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             mychannel = KrausChannel(
                 [
                     {"coef": np.sqrt(1 - prob), "operator": np.array([[1.0, 0.0], [0.0, 1.0]])},
@@ -119,7 +120,7 @@ class TestChannel(unittest.TestCase):
 
         # incorrect rank (number of kraus_operators)
         # use a random channel to do that.
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             randobj.rand_channel_kraus(dim=2**2, rank=20)
 
     def test_dephasing_channel(self):

--- a/tests/test_kraus.py
+++ b/tests/test_kraus.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
-from numpy.random import Generator
 
 import graphix.random_objects as randobj
 from graphix.channels import (
@@ -13,6 +14,9 @@ from graphix.channels import (
     two_qubit_depolarising_tensor_channel,
 )
 from graphix.ops import Ops
+
+if TYPE_CHECKING:
+    from numpy.random import Generator
 
 
 class TestChannel:

--- a/tests/test_kraus.py
+++ b/tests/test_kraus.py
@@ -1,5 +1,3 @@
-import unittest
-
 import numpy as np
 import pytest
 
@@ -14,7 +12,7 @@ from graphix.channels import (
 from graphix.ops import Ops
 
 
-class TestChannel(unittest.TestCase):
+class TestChannel:
     """Tests for Channel class"""
 
     def test_init_with_data_success(self):
@@ -230,4 +228,3 @@ class TestChannel(unittest.TestCase):
 
 if __name__ == "__main__":
     np.random.seed(2)
-    unittest.main()

--- a/tests/test_kraus.py
+++ b/tests/test_kraus.py
@@ -16,7 +16,7 @@ from graphix.ops import Ops
 class TestChannel:
     """Tests for Channel class"""
 
-    def test_init_with_data_success(self, fx_rng: Generator):
+    def test_init_with_data_success(self, fx_rng: Generator) -> None:
         "test for successful intialization"
 
         prob = fx_rng.uniform()
@@ -24,7 +24,7 @@ class TestChannel:
             [
                 {"coef": np.sqrt(1 - prob), "operator": np.array([[1.0, 0.0], [0.0, 1.0]])},
                 {"coef": np.sqrt(prob), "operator": np.array([[1.0, 0.0], [0.0, -1.0]])},
-            ]
+            ],
         )
         assert isinstance(mychannel.nqubit, int)
         assert mychannel.nqubit == 1
@@ -32,89 +32,89 @@ class TestChannel:
         assert isinstance(mychannel.kraus_ops, (list, np.ndarray, tuple))
         assert mychannel.is_normalized
 
-    def test_init_with_data_fail(self, fx_rng: Generator):
+    def test_init_with_data_fail(self, fx_rng: Generator) -> None:
         "test for unsuccessful intialization"
 
         prob = fx_rng.uniform()
 
         # empty data
         with pytest.raises(ValueError):
-            mychannel = KrausChannel([])
+            _ = KrausChannel([])
 
         # incorrect parameter type
         with pytest.raises(TypeError):
-            mychannel = KrausChannel("a")
+            _ = KrausChannel("a")
 
         # incorrect "parameter" key
         with pytest.raises(KeyError):
-            mychannel = KrausChannel(
+            _ = KrausChannel(
                 [
                     {"coefficients": np.sqrt(1 - prob), "operator": np.array([[1.0, 0.0], [0.0, 1.0]])},
                     {"coef": np.sqrt(prob), "operator": np.array([[1.0, 0.0], [0.0, -1.0]])},
-                ]
+                ],
             )
 
         # incorrect "operator" key
         with pytest.raises(KeyError):
-            mychannel = KrausChannel(
+            _ = KrausChannel(
                 [
                     {"coef": np.sqrt(1 - prob), "oertor": np.array([[1.0, 0.0], [0.0, 1.0]])},
                     {"coef": np.sqrt(prob), "operator": np.array([[1.0, 0.0], [0.0, -1.0]])},
-                ]
+                ],
             )
 
         # incorrect parameter type
         with pytest.raises(TypeError):
-            mychannel = KrausChannel(
+            _ = KrausChannel(
                 [
                     {"coef": "a", "operator": np.array([[1.0, 0.0], [0.0, 1.0]])},
                     {"coef": np.sqrt(prob), "operator": np.array([[1.0, 0.0], [0.0, -1.0]])},
-                ]
+                ],
             )
 
         # incorrect operator type
         with pytest.raises(TypeError):
-            mychannel = KrausChannel(
+            _ = KrausChannel(
                 [
                     {"coef": np.sqrt(1 - prob), "operator": "a"},
                     {"coef": np.sqrt(prob), "operator": np.array([[1.0, 0.0], [0.0, -1.0]])},
-                ]
+                ],
             )
 
         # incorrect operator dimension
         with pytest.raises(ValueError):
-            mychannel = KrausChannel(
+            _ = KrausChannel(
                 [
                     {"coef": np.sqrt(1 - prob), "operator": np.array([1.0, 0.0])},
                     {"coef": np.sqrt(prob), "operator": np.array([[1.0, 0.0], [0.0, -1.0]])},
-                ]
+                ],
             )
 
         # incorrect operator dimension: square but not qubits
         with pytest.raises(ValueError):
-            mychannel = KrausChannel(
+            _ = KrausChannel(
                 [
                     {"coef": np.sqrt(1 - prob), "operator": fx_rng.uniform(size=(3, 3))},
                     {"coef": np.sqrt(prob), "operator": fx_rng.uniform(size=(3, 3))},
-                ]
+                ],
             )
 
         # doesn't square to 1. Not normalized. Parameter.
         with pytest.raises(ValueError):
-            mychannel = KrausChannel(
+            _ = KrausChannel(
                 [
                     {"coef": 2 * np.sqrt(1 - prob), "operator": np.array([[1.0, 0.0], [0.0, 1.0]])},
                     {"coef": np.sqrt(prob), "operator": np.array([[1.0, 0.0], [0.0, -1.0]])},
-                ]
+                ],
             )
 
         # doesn't square to 1. Not normalized. Operator.
         with pytest.raises(ValueError):
-            mychannel = KrausChannel(
+            _ = KrausChannel(
                 [
                     {"coef": np.sqrt(1 - prob), "operator": np.array([[1.0, 0.0], [0.0, 1.0]])},
                     {"coef": np.sqrt(prob), "operator": np.array([[1.0, 3.0], [0.0, -1.0]])},
-                ]
+                ],
             )
 
         # incorrect rank (number of kraus_operators)
@@ -122,7 +122,7 @@ class TestChannel:
         with pytest.raises(ValueError):
             randobj.rand_channel_kraus(dim=2**2, rank=20)
 
-    def test_dephasing_channel(self, fx_rng: Generator):
+    def test_dephasing_channel(self, fx_rng: Generator) -> None:
 
         prob = fx_rng.uniform()
         data = [
@@ -139,7 +139,7 @@ class TestChannel:
             np.testing.assert_allclose(dephase_channel.kraus_ops[i]["coef"], data[i]["coef"])
             np.testing.assert_allclose(dephase_channel.kraus_ops[i]["operator"], data[i]["operator"])
 
-    def test_depolarising_channel(self, fx_rng: Generator):
+    def test_depolarising_channel(self, fx_rng: Generator) -> None:
 
         prob = fx_rng.uniform()
         data = [
@@ -160,7 +160,7 @@ class TestChannel:
             np.testing.assert_allclose(depol_channel.kraus_ops[i]["coef"], data[i]["coef"])
             np.testing.assert_allclose(depol_channel.kraus_ops[i]["operator"], data[i]["operator"])
 
-    def test_2_qubit_depolarising_channel(self, fx_rng: Generator):
+    def test_2_qubit_depolarising_channel(self, fx_rng: Generator) -> None:
 
         prob = fx_rng.uniform()
         data = [
@@ -193,7 +193,7 @@ class TestChannel:
             np.testing.assert_allclose(depol_channel_2_qubit.kraus_ops[i]["coef"], data[i]["coef"])
             np.testing.assert_allclose(depol_channel_2_qubit.kraus_ops[i]["operator"], data[i]["operator"])
 
-    def test_2_qubit_depolarising_tensor_channel(self, fx_rng: Generator):
+    def test_2_qubit_depolarising_tensor_channel(self, fx_rng: Generator) -> None:
 
         prob = fx_rng.uniform()
         data = [

--- a/tests/test_kraus.py
+++ b/tests/test_kraus.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.random import Generator
 
 import graphix.random_objects as randobj
 from graphix.channels import (
@@ -15,10 +16,10 @@ from graphix.ops import Ops
 class TestChannel:
     """Tests for Channel class"""
 
-    def test_init_with_data_success(self):
+    def test_init_with_data_success(self, fx_rng: Generator):
         "test for successful intialization"
 
-        prob = np.random.rand()
+        prob = fx_rng.uniform()
         mychannel = KrausChannel(
             [
                 {"coef": np.sqrt(1 - prob), "operator": np.array([[1.0, 0.0], [0.0, 1.0]])},
@@ -31,10 +32,10 @@ class TestChannel:
         assert isinstance(mychannel.kraus_ops, (list, np.ndarray, tuple))
         assert mychannel.is_normalized
 
-    def test_init_with_data_fail(self):
+    def test_init_with_data_fail(self, fx_rng: Generator):
         "test for unsuccessful intialization"
 
-        prob = np.random.rand()
+        prob = fx_rng.uniform()
 
         # empty data
         with pytest.raises(ValueError):
@@ -93,8 +94,8 @@ class TestChannel:
         with pytest.raises(ValueError):
             mychannel = KrausChannel(
                 [
-                    {"coef": np.sqrt(1 - prob), "operator": np.random.rand(3, 3)},
-                    {"coef": np.sqrt(prob), "operator": np.random.rand(3, 3)},
+                    {"coef": np.sqrt(1 - prob), "operator": fx_rng.uniform(size=(3, 3))},
+                    {"coef": np.sqrt(prob), "operator": fx_rng.uniform(size=(3, 3))},
                 ]
             )
 
@@ -121,9 +122,9 @@ class TestChannel:
         with pytest.raises(ValueError):
             randobj.rand_channel_kraus(dim=2**2, rank=20)
 
-    def test_dephasing_channel(self):
+    def test_dephasing_channel(self, fx_rng: Generator):
 
-        prob = np.random.rand()
+        prob = fx_rng.uniform()
         data = [
             {"coef": np.sqrt(1 - prob), "operator": np.array([[1.0, 0.0], [0.0, 1.0]])},
             {"coef": np.sqrt(prob), "operator": Ops.z},
@@ -138,9 +139,9 @@ class TestChannel:
             np.testing.assert_allclose(dephase_channel.kraus_ops[i]["coef"], data[i]["coef"])
             np.testing.assert_allclose(dephase_channel.kraus_ops[i]["operator"], data[i]["operator"])
 
-    def test_depolarising_channel(self):
+    def test_depolarising_channel(self, fx_rng: Generator):
 
-        prob = np.random.rand()
+        prob = fx_rng.uniform()
         data = [
             {"coef": np.sqrt(1 - prob), "operator": np.eye(2)},
             {"coef": np.sqrt(prob / 3.0), "operator": Ops.x},
@@ -159,9 +160,9 @@ class TestChannel:
             np.testing.assert_allclose(depol_channel.kraus_ops[i]["coef"], data[i]["coef"])
             np.testing.assert_allclose(depol_channel.kraus_ops[i]["operator"], data[i]["operator"])
 
-    def test_2_qubit_depolarising_channel(self):
+    def test_2_qubit_depolarising_channel(self, fx_rng: Generator):
 
-        prob = np.random.rand()
+        prob = fx_rng.uniform()
         data = [
             {"coef": np.sqrt(1 - prob), "operator": np.kron(np.eye(2), np.eye(2))},
             {"coef": np.sqrt(prob / 15.0), "operator": np.kron(Ops.x, Ops.x)},
@@ -192,9 +193,9 @@ class TestChannel:
             np.testing.assert_allclose(depol_channel_2_qubit.kraus_ops[i]["coef"], data[i]["coef"])
             np.testing.assert_allclose(depol_channel_2_qubit.kraus_ops[i]["operator"], data[i]["operator"])
 
-    def test_2_qubit_depolarising_tensor_channel(self):
+    def test_2_qubit_depolarising_tensor_channel(self, fx_rng: Generator):
 
-        prob = np.random.rand()
+        prob = fx_rng.uniform()
         data = [
             {"coef": 1 - prob, "operator": np.kron(np.eye(2), np.eye(2))},
             {"coef": prob / 3.0, "operator": np.kron(Ops.x, Ops.x)},
@@ -224,7 +225,3 @@ class TestChannel:
         for i in range(len(depol_tensor_channel_2_qubit.kraus_ops)):
             np.testing.assert_allclose(depol_tensor_channel_2_qubit.kraus_ops[i]["coef"], data[i]["coef"])
             np.testing.assert_allclose(depol_tensor_channel_2_qubit.kraus_ops[i]["operator"], data[i]["operator"])
-
-
-if __name__ == "__main__":
-    np.random.seed(2)

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -104,13 +104,13 @@ class TestLinAlg(unittest.TestCase):
     def test_add_row(self):
         test_mat = MatGF2(np.diag(np.ones(2, dtype=int)))
         test_mat.add_row()
-        self.assertEqual(test_mat.data.shape, (3, 2))
+        assert test_mat.data.shape == (3, 2)
         assert np.all(test_mat.data == np.array([[1, 0], [0, 1], [0, 0]]))
 
     def test_add_col(self):
         test_mat = MatGF2(np.diag(np.ones(2, dtype=int)))
         test_mat.add_col()
-        self.assertEqual(test_mat.data.shape, (2, 3))
+        assert test_mat.data.shape == (2, 3)
         assert np.all(test_mat.data == galois.GF2(np.array([[1, 0, 0], [0, 1, 0]])))
 
     def test_remove_row(self):
@@ -144,7 +144,7 @@ class TestLinAlg(unittest.TestCase):
         assert test_mat.is_canonical_form()
 
         test_mat = MatGF2(np.array([[1, 1, 0], [0, 0, 1], [0, 1, 0]], dtype=int))
-        self.assertFalse(test_mat.is_canonical_form())
+        assert not test_mat.is_canonical_form()
 
     def test_forward_eliminate(self):
         test_cases = prepare_test_matrix()
@@ -164,7 +164,7 @@ class TestLinAlg(unittest.TestCase):
             mat = test_case["matrix"]
             rank = test_case["rank"]
             with self.subTest(mat=mat):
-                self.assertEqual(mat.get_rank(), rank)
+                assert mat.get_rank() == rank
 
     def test_backward_substitute(self):
         test_cases = prepare_test_matrix()
@@ -178,7 +178,7 @@ class TestLinAlg(unittest.TestCase):
                 x, kernel = mat_eliminated.backward_substitute(RHS_eliminated)
                 if x is not None:
                     assert np.all(x == x)
-                self.assertEqual(len(kernel), kernel_dim)
+                assert len(kernel) == kernel_dim
 
 
 if __name__ == "__main__":

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -1,7 +1,6 @@
-import unittest
-
 import galois
 import numpy as np
+import pytest
 
 from graphix.linalg import MatGF2
 
@@ -100,7 +99,7 @@ def prepare_test_matrix():
     return test_cases
 
 
-class TestLinAlg(unittest.TestCase):
+class TestLinAlg:
     def test_add_row(self):
         test_mat = MatGF2(np.diag(np.ones(2, dtype=int)))
         test_mat.add_row()
@@ -146,40 +145,30 @@ class TestLinAlg(unittest.TestCase):
         test_mat = MatGF2(np.array([[1, 1, 0], [0, 0, 1], [0, 1, 0]], dtype=int))
         assert not test_mat.is_canonical_form()
 
-    def test_forward_eliminate(self):
-        test_cases = prepare_test_matrix()
-        for test_case in test_cases:
-            mat = test_case["matrix"]
-            answer = test_case["forward_eliminated"]
-            RHS_input = test_case["RHS_input"]
-            RHS_forward_elimnated = test_case["RHS_forward_elimnated"]
-            with self.subTest(mat=mat, answer=answer, RHS_input=RHS_input):
-                mat_elimnated, RHS, _, _ = mat.forward_eliminate(RHS_input)
-                assert np.all(mat_elimnated.data == answer)
-                assert np.all(RHS.data == RHS_forward_elimnated)
+    @pytest.mark.parametrize("test_case", prepare_test_matrix())
+    def test_forward_eliminate(self, test_case):
+        mat = test_case["matrix"]
+        answer = test_case["forward_eliminated"]
+        RHS_input = test_case["RHS_input"]
+        RHS_forward_elimnated = test_case["RHS_forward_elimnated"]
+        mat_elimnated, RHS, _, _ = mat.forward_eliminate(RHS_input)
+        assert np.all(mat_elimnated.data == answer)
+        assert np.all(RHS.data == RHS_forward_elimnated)
 
-    def test_get_rank(self):
-        test_cases = prepare_test_matrix()
-        for test_case in test_cases:
-            mat = test_case["matrix"]
-            rank = test_case["rank"]
-            with self.subTest(mat=mat):
-                assert mat.get_rank() == rank
+    @pytest.mark.parametrize("test_case", prepare_test_matrix())
+    def test_get_rank(self, test_case):
+        mat = test_case["matrix"]
+        rank = test_case["rank"]
+        assert mat.get_rank() == rank
 
-    def test_backward_substitute(self):
-        test_cases = prepare_test_matrix()
-        for test_case in test_cases:
-            mat = test_case["matrix"]
-            RHS_input = test_case["RHS_input"]
-            x = test_case["x"]
-            kernel_dim = test_case["kernel_dim"]
-            with self.subTest(mat=mat, RHS_input=RHS_input, x=x, kernel_dim=kernel_dim):
-                mat_eliminated, RHS_eliminated, _, _ = mat.forward_eliminate(RHS_input)
-                x, kernel = mat_eliminated.backward_substitute(RHS_eliminated)
-                if x is not None:
-                    assert np.all(x == x)
-                assert len(kernel) == kernel_dim
-
-
-if __name__ == "__main__":
-    unittest.main()
+    @pytest.mark.parametrize("test_case", prepare_test_matrix())
+    def test_backward_substitute(self, test_case):
+        mat = test_case["matrix"]
+        RHS_input = test_case["RHS_input"]
+        x = test_case["x"]
+        kernel_dim = test_case["kernel_dim"]
+        mat_eliminated, RHS_eliminated, _, _ = mat.forward_eliminate(RHS_input)
+        x, kernel = mat_eliminated.backward_substitute(RHS_eliminated)
+        if x is not None:
+            assert np.all(x == x)
+        assert len(kernel) == kernel_dim

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -105,43 +105,43 @@ class TestLinAlg(unittest.TestCase):
         test_mat = MatGF2(np.diag(np.ones(2, dtype=int)))
         test_mat.add_row()
         self.assertEqual(test_mat.data.shape, (3, 2))
-        self.assertTrue(np.all(test_mat.data == np.array([[1, 0], [0, 1], [0, 0]])))
+        assert np.all(test_mat.data == np.array([[1, 0], [0, 1], [0, 0]]))
 
     def test_add_col(self):
         test_mat = MatGF2(np.diag(np.ones(2, dtype=int)))
         test_mat.add_col()
         self.assertEqual(test_mat.data.shape, (2, 3))
-        self.assertTrue(np.all(test_mat.data == galois.GF2(np.array([[1, 0, 0], [0, 1, 0]]))))
+        assert np.all(test_mat.data == galois.GF2(np.array([[1, 0, 0], [0, 1, 0]])))
 
     def test_remove_row(self):
         test_mat = MatGF2(np.array([[1, 0], [0, 1], [0, 0]], dtype=int))
         test_mat.remove_row(2)
-        self.assertTrue(np.all(test_mat.data == np.array([[1, 0], [0, 1]])))
+        assert np.all(test_mat.data == np.array([[1, 0], [0, 1]]))
 
     def test_remove_col(self):
         test_mat = MatGF2(np.array([[1, 0, 0], [0, 1, 0]], dtype=int))
         test_mat.remove_col(2)
-        self.assertTrue(np.all(test_mat.data == np.array([[1, 0], [0, 1]])))
+        assert np.all(test_mat.data == np.array([[1, 0], [0, 1]]))
 
     def test_swap_row(self):
         test_mat = MatGF2(np.array([[1, 0], [0, 1], [0, 0]], dtype=int))
         test_mat.swap_row(1, 2)
-        self.assertTrue(np.all(test_mat.data == np.array([[1, 0], [0, 0], [0, 1]])))
+        assert np.all(test_mat.data == np.array([[1, 0], [0, 0], [0, 1]]))
 
     def test_swap_col(self):
         test_mat = MatGF2(np.array([[1, 0, 0], [0, 1, 0]], dtype=int))
         test_mat.swap_col(1, 2)
-        self.assertTrue(np.all(test_mat.data == np.array([[1, 0, 0], [0, 0, 1]])))
+        assert np.all(test_mat.data == np.array([[1, 0, 0], [0, 0, 1]]))
 
     def test_is_canonical_form(self):
         test_mat = MatGF2(np.array([[1, 0], [0, 1]], dtype=int))
-        self.assertTrue(test_mat.is_canonical_form())
+        assert test_mat.is_canonical_form()
 
         test_mat = MatGF2(np.array([[1, 0], [0, 1], [0, 0]], dtype=int))
-        self.assertTrue(test_mat.is_canonical_form())
+        assert test_mat.is_canonical_form()
 
         test_mat = MatGF2(np.array([[1, 0, 1], [0, 1, 0], [0, 0, 0]], dtype=int))
-        self.assertTrue(test_mat.is_canonical_form())
+        assert test_mat.is_canonical_form()
 
         test_mat = MatGF2(np.array([[1, 1, 0], [0, 0, 1], [0, 1, 0]], dtype=int))
         self.assertFalse(test_mat.is_canonical_form())
@@ -155,8 +155,8 @@ class TestLinAlg(unittest.TestCase):
             RHS_forward_elimnated = test_case["RHS_forward_elimnated"]
             with self.subTest(mat=mat, answer=answer, RHS_input=RHS_input):
                 mat_elimnated, RHS, _, _ = mat.forward_eliminate(RHS_input)
-                self.assertTrue(np.all(mat_elimnated.data == answer))
-                self.assertTrue(np.all(RHS.data == RHS_forward_elimnated))
+                assert np.all(mat_elimnated.data == answer)
+                assert np.all(RHS.data == RHS_forward_elimnated)
 
     def test_get_rank(self):
         test_cases = prepare_test_matrix()
@@ -177,7 +177,7 @@ class TestLinAlg(unittest.TestCase):
                 mat_eliminated, RHS_eliminated, _, _ = mat.forward_eliminate(RHS_input)
                 x, kernel = mat_eliminated.backward_substitute(RHS_eliminated)
                 if x is not None:
-                    self.assertTrue(np.all(x == x))
+                    assert np.all(x == x)
                 self.assertEqual(len(kernel), kernel_dim)
 
 

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -1,174 +1,180 @@
+from __future__ import annotations
+
+from typing import NamedTuple
+
 import galois
 import numpy as np
+import numpy.typing as npt
 import pytest
 
 from graphix.linalg import MatGF2
 
 
-def prepare_test_matrix():
-    test_cases = []
+class LinalgTestCase(NamedTuple):
+    matrix: MatGF2
+    forward_eliminated: npt.NDArray[np.int_]
+    rank: int
+    rhs_input: npt.NDArray[np.int_]
+    rhs_forward_eliminated: npt.NDArray[np.int_]
+    x: list[npt.NDArray[np.int_]] | None
+    kernel_dim: int
 
-    # empty matrix
-    test_case = dict()
-    test_case["matrix"] = MatGF2(np.array([[]], dtype=int))
-    test_case["forward_eliminated"] = np.array([[]], dtype=int)
-    test_case["rank"] = 0
-    test_case["RHS_input"] = np.array([[]], dtype=int)
-    test_case["RHS_forward_elimnated"] = np.array([[]], dtype=int)
-    test_case["x"] = [[]]
-    test_case["kernel_dim"] = 0
-    test_cases.append(test_case)
 
-    # column vector
-    test_case = dict()
-    test_case["matrix"] = MatGF2(np.array([[1], [1], [1]], dtype=int))
-    test_case["forward_eliminated"] = np.array([[1], [0], [0]], dtype=int)
-    test_case["rank"] = 1
-    test_case["RHS_input"] = np.array([[1], [1], [1]], dtype=int)
-    test_case["RHS_forward_elimnated"] = np.array([[1], [0], [0]], dtype=int)
-    test_case["x"] = [[1]]
-    test_case["kernel_dim"] = 0
-    test_cases.append(test_case)
-
-    # row vector
-    test_case = dict()
-    test_case["matrix"] = MatGF2(np.array([[1, 1, 1]], dtype=int))
-    test_case["forward_eliminated"] = np.array([[1, 1, 1]], dtype=int)
-    test_case["rank"] = 1
-    test_case["RHS_input"] = np.array([[1]], dtype=int)
-    test_case["RHS_forward_elimnated"] = np.array([[1]], dtype=int)
-    test_case["x"] = None  # TODO: add x
-    test_case["kernel_dim"] = 2
-    test_cases.append(test_case)
-
-    # diagonal matrix
-    test_case = dict()
-    test_case["matrix"] = MatGF2(np.diag(np.ones(10)).astype(int))
-    test_case["forward_eliminated"] = np.diag(np.ones(10)).astype(int)
-    test_case["rank"] = 10
-    test_case["RHS_input"] = np.ones(10).reshape(10, 1).astype(int)
-    test_case["RHS_forward_elimnated"] = np.ones(10).reshape(10, 1).astype(int)
-    test_case["x"] = list(np.ones((10, 1)))
-    test_case["kernel_dim"] = 0
-    test_cases.append(test_case)
-
-    # full rank dense matrix
-    test_case = dict()
-    test_case["matrix"] = MatGF2(np.array([[1, 0, 1], [0, 1, 0], [1, 0, 0]], dtype=int))
-    test_case["forward_eliminated"] = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=int)
-    test_case["rank"] = 3
-    test_case["RHS_input"] = np.array([[1], [1], [1]], dtype=int)
-    test_case["RHS_forward_elimnated"] = np.array([[1], [1], [0]], dtype=int)
-    test_case["x"] = list(np.array([[1], [1], [0]]))  # nan for no solution
-    test_case["kernel_dim"] = 0
-    test_cases.append(test_case)
-
-    # not full-rank matrix
-    test_case = dict()
-    test_case["matrix"] = MatGF2(np.array([[1, 0, 1], [0, 1, 0], [1, 1, 1]], dtype=int))
-    test_case["forward_eliminated"] = np.array([[1, 0, 1], [0, 1, 0], [0, 0, 0]], dtype=int)
-    test_case["rank"] = 2
-    test_case["RHS_input"] = np.array([[1, 1], [1, 1], [0, 1]], dtype=int)
-    test_case["RHS_forward_elimnated"] = np.array([[1, 1], [1, 1], [0, 1]], dtype=int)
-    test_case["x"] = None  # TODO: add x
-    test_case["kernel_dim"] = 1
-    test_cases.append(test_case)
-
-    # non-square matrix
-    test_case = dict()
-    test_case["matrix"] = MatGF2(np.array([[1, 0, 1], [0, 1, 0]], dtype=int))
-    test_case["forward_eliminated"] = np.array([[1, 0, 1], [0, 1, 0]], dtype=int)
-    test_case["rank"] = 2
-    test_case["RHS_input"] = np.array([[1], [1]], dtype=int)
-    test_case["RHS_forward_elimnated"] = np.array([[1], [1]], dtype=int)
-    test_case["x"] = None  # TODO: add x
-    test_case["kernel_dim"] = 1
-    test_cases.append(test_case)
-
-    # non-square matrix
-    test_case = dict()
-    test_case["matrix"] = MatGF2(np.array([[1, 0], [0, 1], [1, 0]], dtype=int))
-    test_case["forward_eliminated"] = np.array([[1, 0], [0, 1], [0, 0]], dtype=int)
-    test_case["rank"] = 2
-    test_case["RHS_input"] = np.array([[1], [1], [1]], dtype=int)
-    test_case["RHS_forward_elimnated"] = np.array([[1], [1], [0]], dtype=int)
-    test_case["x"] = [[1], [1]]
-    test_case["kernel_dim"] = 0
-    test_cases.append(test_case)
-
-    return test_cases
+def prepare_test_matrix() -> list[LinalgTestCase]:
+    return [
+        # empty matrix
+        LinalgTestCase(
+            MatGF2(np.array([[]], dtype=np.int_)),
+            np.array([[]], dtype=np.int_),
+            0,
+            np.array([[]], dtype=np.int_),
+            np.array([[]], dtype=np.int_),
+            [np.array([], dtype=np.int_)],
+            0,
+        ),
+        # column vector
+        LinalgTestCase(
+            MatGF2(np.array([[1], [1], [1]], dtype=np.int_)),
+            np.array([[1], [0], [0]], dtype=np.int_),
+            1,
+            np.array([[1], [1], [1]], dtype=np.int_),
+            np.array([[1], [0], [0]], dtype=np.int_),
+            [np.array([1])],
+            0,
+        ),
+        # row vector
+        LinalgTestCase(
+            MatGF2(np.array([[1, 1, 1]], dtype=np.int_)),
+            np.array([[1, 1, 1]], dtype=np.int_),
+            1,
+            np.array([[1]], dtype=np.int_),
+            np.array([[1]], dtype=np.int_),
+            None,  # TODO: add x
+            2,
+        ),
+        # diagonal matrix
+        LinalgTestCase(
+            MatGF2(np.diag(np.ones(10)).astype(int)),
+            np.diag(np.ones(10)).astype(int),
+            10,
+            np.ones(10).reshape(10, 1).astype(int),
+            np.ones(10).reshape(10, 1).astype(int),
+            list(np.ones((10, 1))),
+            0,
+        ),
+        # full rank dense matrix
+        LinalgTestCase(
+            MatGF2(np.array([[1, 0, 1], [0, 1, 0], [1, 0, 0]], dtype=np.int_)),
+            np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=np.int_),
+            3,
+            np.array([[1], [1], [1]], dtype=np.int_),
+            np.array([[1], [1], [0]], dtype=np.int_),
+            list(np.array([[1], [1], [0]])),  # nan for no solution
+            0,
+        ),
+        # not full-rank matrix
+        LinalgTestCase(
+            MatGF2(np.array([[1, 0, 1], [0, 1, 0], [1, 1, 1]], dtype=np.int_)),
+            np.array([[1, 0, 1], [0, 1, 0], [0, 0, 0]], dtype=np.int_),
+            2,
+            np.array([[1, 1], [1, 1], [0, 1]], dtype=np.int_),
+            np.array([[1, 1], [1, 1], [0, 1]], dtype=np.int_),
+            None,  # TODO: add x
+            1,
+        ),
+        # non-square matrix
+        LinalgTestCase(
+            MatGF2(np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int_)),
+            np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int_),
+            2,
+            np.array([[1], [1]], dtype=np.int_),
+            np.array([[1], [1]], dtype=np.int_),
+            None,  # TODO: add x
+            1,
+        ),
+        # non-square matrix
+        LinalgTestCase(
+            MatGF2(np.array([[1, 0], [0, 1], [1, 0]], dtype=np.int_)),
+            np.array([[1, 0], [0, 1], [0, 0]], dtype=np.int_),
+            2,
+            np.array([[1], [1], [1]], dtype=np.int_),
+            np.array([[1], [1], [0]], dtype=np.int_),
+            [np.array([1], dtype=np.int_), np.array([1], dtype=np.int_)],
+            0,
+        ),
+    ]
 
 
 class TestLinAlg:
-    def test_add_row(self):
-        test_mat = MatGF2(np.diag(np.ones(2, dtype=int)))
+    def test_add_row(self) -> None:
+        test_mat = MatGF2(np.diag(np.ones(2, dtype=np.int_)))
         test_mat.add_row()
         assert test_mat.data.shape == (3, 2)
         assert np.all(test_mat.data == np.array([[1, 0], [0, 1], [0, 0]]))
 
-    def test_add_col(self):
-        test_mat = MatGF2(np.diag(np.ones(2, dtype=int)))
+    def test_add_col(self) -> None:
+        test_mat = MatGF2(np.diag(np.ones(2, dtype=np.int_)))
         test_mat.add_col()
         assert test_mat.data.shape == (2, 3)
         assert np.all(test_mat.data == galois.GF2(np.array([[1, 0, 0], [0, 1, 0]])))
 
-    def test_remove_row(self):
-        test_mat = MatGF2(np.array([[1, 0], [0, 1], [0, 0]], dtype=int))
+    def test_remove_row(self) -> None:
+        test_mat = MatGF2(np.array([[1, 0], [0, 1], [0, 0]], dtype=np.int_))
         test_mat.remove_row(2)
         assert np.all(test_mat.data == np.array([[1, 0], [0, 1]]))
 
-    def test_remove_col(self):
-        test_mat = MatGF2(np.array([[1, 0, 0], [0, 1, 0]], dtype=int))
+    def test_remove_col(self) -> None:
+        test_mat = MatGF2(np.array([[1, 0, 0], [0, 1, 0]], dtype=np.int_))
         test_mat.remove_col(2)
         assert np.all(test_mat.data == np.array([[1, 0], [0, 1]]))
 
-    def test_swap_row(self):
-        test_mat = MatGF2(np.array([[1, 0], [0, 1], [0, 0]], dtype=int))
+    def test_swap_row(self) -> None:
+        test_mat = MatGF2(np.array([[1, 0], [0, 1], [0, 0]], dtype=np.int_))
         test_mat.swap_row(1, 2)
         assert np.all(test_mat.data == np.array([[1, 0], [0, 0], [0, 1]]))
 
-    def test_swap_col(self):
-        test_mat = MatGF2(np.array([[1, 0, 0], [0, 1, 0]], dtype=int))
+    def test_swap_col(self) -> None:
+        test_mat = MatGF2(np.array([[1, 0, 0], [0, 1, 0]], dtype=np.int_))
         test_mat.swap_col(1, 2)
         assert np.all(test_mat.data == np.array([[1, 0, 0], [0, 0, 1]]))
 
-    def test_is_canonical_form(self):
-        test_mat = MatGF2(np.array([[1, 0], [0, 1]], dtype=int))
+    def test_is_canonical_form(self) -> None:
+        test_mat = MatGF2(np.array([[1, 0], [0, 1]], dtype=np.int_))
         assert test_mat.is_canonical_form()
 
-        test_mat = MatGF2(np.array([[1, 0], [0, 1], [0, 0]], dtype=int))
+        test_mat = MatGF2(np.array([[1, 0], [0, 1], [0, 0]], dtype=np.int_))
         assert test_mat.is_canonical_form()
 
-        test_mat = MatGF2(np.array([[1, 0, 1], [0, 1, 0], [0, 0, 0]], dtype=int))
+        test_mat = MatGF2(np.array([[1, 0, 1], [0, 1, 0], [0, 0, 0]], dtype=np.int_))
         assert test_mat.is_canonical_form()
 
-        test_mat = MatGF2(np.array([[1, 1, 0], [0, 0, 1], [0, 1, 0]], dtype=int))
+        test_mat = MatGF2(np.array([[1, 1, 0], [0, 0, 1], [0, 1, 0]], dtype=np.int_))
         assert not test_mat.is_canonical_form()
 
     @pytest.mark.parametrize("test_case", prepare_test_matrix())
-    def test_forward_eliminate(self, test_case):
-        mat = test_case["matrix"]
-        answer = test_case["forward_eliminated"]
-        RHS_input = test_case["RHS_input"]
-        RHS_forward_elimnated = test_case["RHS_forward_elimnated"]
-        mat_elimnated, RHS, _, _ = mat.forward_eliminate(RHS_input)
+    def test_forward_eliminate(self, test_case: LinalgTestCase) -> None:
+        mat = test_case.matrix
+        answer = test_case.forward_eliminated
+        rhs_input = test_case.rhs_input
+        rhs_forward_elimnated = test_case.rhs_forward_eliminated
+        mat_elimnated, rhs, _, _ = mat.forward_eliminate(rhs_input)
         assert np.all(mat_elimnated.data == answer)
-        assert np.all(RHS.data == RHS_forward_elimnated)
+        assert np.all(rhs.data == rhs_forward_elimnated)
 
     @pytest.mark.parametrize("test_case", prepare_test_matrix())
-    def test_get_rank(self, test_case):
-        mat = test_case["matrix"]
-        rank = test_case["rank"]
+    def test_get_rank(self, test_case: LinalgTestCase) -> None:
+        mat = test_case.matrix
+        rank = test_case.rank
         assert mat.get_rank() == rank
 
     @pytest.mark.parametrize("test_case", prepare_test_matrix())
-    def test_backward_substitute(self, test_case):
-        mat = test_case["matrix"]
-        RHS_input = test_case["RHS_input"]
-        x = test_case["x"]
-        kernel_dim = test_case["kernel_dim"]
-        mat_eliminated, RHS_eliminated, _, _ = mat.forward_eliminate(RHS_input)
-        x, kernel = mat_eliminated.backward_substitute(RHS_eliminated)
+    def test_backward_substitute(self, test_case: LinalgTestCase) -> None:
+        mat = test_case.matrix
+        rhs_input = test_case.rhs_input
+        x = test_case.x
+        kernel_dim = test_case.kernel_dim
+        mat_eliminated, rhs_eliminated, _, _ = mat.forward_eliminate(rhs_input)
+        x, kernel = mat_eliminated.backward_substitute(rhs_eliminated)
         if x is not None:
             assert np.all(x == x)
         assert len(kernel) == kernel_dim

--- a/tests/test_noisy_density_matrix.py
+++ b/tests/test_noisy_density_matrix.py
@@ -1,6 +1,6 @@
-import unittest
-
 import numpy as np
+import numpy.typing as npt
+from numpy.random import Generator
 
 from graphix import Circuit
 from graphix.channels import (
@@ -12,6 +12,7 @@ from graphix.channels import (
 from graphix.noise_models.noise_model import NoiseModel
 from graphix.noise_models.noiseless_noise_model import NoiselessNoiseModel
 from graphix.ops import Ops
+from graphix.pattern import Pattern
 
 
 class TestNoiseModel(NoiseModel):
@@ -37,6 +38,7 @@ class TestNoiseModel(NoiseModel):
         self.entanglement_error_prob = entanglement_error_prob
         self.measure_error_prob = measure_error_prob
         self.measure_channel_prob = measure_channel_prob
+        self.rng = np.random.default_rng()
 
     def prepare_qubit(self):
         """return the channel to apply after clean single-qubit preparation. Here just identity."""
@@ -56,7 +58,7 @@ class TestNoiseModel(NoiseModel):
         cmd = "M"
         """
 
-        if np.random.rand() < self.measure_error_prob:
+        if self.rng.uniform() < self.measure_error_prob:
             self.simulator.results[cmd[1]] = 1 - self.simulator.results[cmd[1]]
 
     def byproduct_x(self):
@@ -79,89 +81,101 @@ class TestNoiseModel(NoiseModel):
         pass
 
 
-class TestNoisyDensityMatrixBackend(unittest.TestCase):
+class TestNoisyDensityMatrixBackend:
     """Test for Noisy DensityMatrixBackend simultation."""
 
-    def setUp(self):
-        # set up the random numbers
-        self.rng = np.random.default_rng()  # seed=422
-        np.random.seed()  # 42 vs 422
+    @staticmethod
+    def rz_exact_res(alpha: float) -> npt.NDArray[np.complex128]:
+        return 0.5 * np.array([[1.0, np.exp(-1j * alpha)], [np.exp(1j * alpha), 1.0]])
 
-        # Hadamard pattern
-        ncirc = Circuit(1)
-        ncirc.h(0)
-        self.hadamardpattern = ncirc.transpile().pattern
-
-        # Rz(alpha) pattern
-        self.alpha = 2 * np.pi * self.rng.random()
-        print(f"alpha is {self.alpha}")
+    @staticmethod
+    def hpat() -> Pattern:
         circ = Circuit(1)
-        circ.rz(0, self.alpha)
-        self.rzpattern = circ.transpile().pattern
-        self.rz_exact_res = 0.5 * np.array([[1.0, np.exp(-1j * self.alpha)], [np.exp(1j * self.alpha), 1.0]])
+        circ.h(0)
+        return circ.transpile().pattern
+
+    @staticmethod
+    def rzpat(alpha: float) -> Pattern:
+        circ = Circuit(1)
+        circ.rz(0, alpha)
+        return circ.transpile().pattern
 
     # test noiseless noisy vs noiseless
     def test_noiseless_noisy_hadamard(self):
-        noiselessres = self.hadamardpattern.simulate_pattern(backend="densitymatrix")
+        hadamardpattern = self.hpat()
+        noiselessres = hadamardpattern.simulate_pattern(backend="densitymatrix")
         # noiseless noise model
-        noisynoiselessres = self.hadamardpattern.simulate_pattern(
-            backend="densitymatrix", noise_model=NoiselessNoiseModel()
+        noisynoiselessres = hadamardpattern.simulate_pattern(
+            backend="densitymatrix",
+            noise_model=NoiselessNoiseModel(),
         )
         np.testing.assert_allclose(noiselessres.rho, np.array([[1.0, 0.0], [0.0, 0.0]]))
         # result should be |0>
         np.testing.assert_allclose(noisynoiselessres.rho, np.array([[1.0, 0.0], [0.0, 0.0]]))
 
     # test measurement confuse outcome
-    def test_noisy_measure_confuse_hadamard(self):
-        res = self.hadamardpattern.simulate_pattern(
-            backend="densitymatrix", noise_model=TestNoiseModel(measure_error_prob=1.0)
+    def test_noisy_measure_confuse_hadamard(self, fx_rng: Generator):
+        hadamardpattern = self.hpat()
+        res = hadamardpattern.simulate_pattern(
+            backend="densitymatrix",
+            noise_model=TestNoiseModel(measure_error_prob=1.0),
         )
         # result should be |1>
         np.testing.assert_allclose(res.rho, np.array([[0.0, 0.0], [0.0, 1.0]]))
 
         # arbitrary probability
-        measure_error_pr = self.rng.random()
+        measure_error_pr = fx_rng.random()
         print(f"measure_error_pr = {measure_error_pr}")
-        res = self.hadamardpattern.simulate_pattern(
-            backend="densitymatrix", noise_model=TestNoiseModel(measure_error_prob=measure_error_pr)
+        res = hadamardpattern.simulate_pattern(
+            backend="densitymatrix",
+            noise_model=TestNoiseModel(measure_error_prob=measure_error_pr),
         )
         # result should be |1>
         assert np.allclose(res.rho, np.array([[1.0, 0.0], [0.0, 0.0]])) or np.allclose(
-            res.rho, np.array([[0.0, 0.0], [0.0, 1.0]])
+            res.rho,
+            np.array([[0.0, 0.0], [0.0, 1.0]]),
         )
 
-    def test_noisy_measure_channel_hadamard(self):
-        measure_channel_pr = self.rng.random()
+    def test_noisy_measure_channel_hadamard(self, fx_rng: Generator):
+        hadamardpattern = self.hpat()
+        measure_channel_pr = fx_rng.random()
         print(f"measure_channel_pr = {measure_channel_pr}")
         # measurement error only
-        res = self.hadamardpattern.simulate_pattern(
-            backend="densitymatrix", noise_model=TestNoiseModel(measure_channel_prob=measure_channel_pr)
+        res = hadamardpattern.simulate_pattern(
+            backend="densitymatrix",
+            noise_model=TestNoiseModel(measure_channel_prob=measure_channel_pr),
         )
         # just TP the depolarizing channel
         np.testing.assert_allclose(
-            res.rho, np.array([[1 - 2 * measure_channel_pr / 3.0, 0.0], [0.0, 2 * measure_channel_pr / 3.0]])
+            res.rho,
+            np.array([[1 - 2 * measure_channel_pr / 3.0, 0.0], [0.0, 2 * measure_channel_pr / 3.0]]),
         )
 
     # test Pauli X error
-    def test_noisy_X_hadamard(self):
+    def test_noisy_X_hadamard(self, fx_rng: Generator):
+        hadamardpattern = self.hpat()
         # x error only
-        x_error_pr = self.rng.random()
+        x_error_pr = fx_rng.random()
         print(f"x_error_pr = {x_error_pr}")
-        res = self.hadamardpattern.simulate_pattern(
-            backend="densitymatrix", noise_model=TestNoiseModel(x_error_prob=x_error_pr)
+        res = hadamardpattern.simulate_pattern(
+            backend="densitymatrix",
+            noise_model=TestNoiseModel(x_error_prob=x_error_pr),
         )
         # analytical result since deterministic pattern output is |0>.
         # if no X applied, no noise. If X applied X noise on |0><0|
 
         assert np.allclose(res.rho, np.array([[1.0, 0.0], [0.0, 0.0]])) or np.allclose(
-            res.rho, np.array([[1 - 2 * x_error_pr / 3.0, 0.0], [0.0, 2 * x_error_pr / 3.0]])
+            res.rho,
+            np.array([[1 - 2 * x_error_pr / 3.0, 0.0], [0.0, 2 * x_error_pr / 3.0]]),
         )
 
     # test entanglement error
-    def test_noisy_entanglement_hadamard(self):
-        entanglement_error_pr = np.random.rand()
-        res = self.hadamardpattern.simulate_pattern(
-            backend="densitymatrix", noise_model=TestNoiseModel(entanglement_error_prob=entanglement_error_pr)
+    def test_noisy_entanglement_hadamard(self, fx_rng: Generator):
+        hadamardpattern = self.hpat()
+        entanglement_error_pr = fx_rng.uniform()
+        res = hadamardpattern.simulate_pattern(
+            backend="densitymatrix",
+            noise_model=TestNoiseModel(entanglement_error_prob=entanglement_error_pr),
         )
         # analytical result for tensor depolarizing channel
         # np.testing.assert_allclose(
@@ -181,45 +195,56 @@ class TestNoisyDensityMatrixBackend(unittest.TestCase):
                 [
                     [1 - 8 * entanglement_error_pr / 15.0, 0.0],
                     [0.0, 8 * entanglement_error_pr / 15.0],
-                ]
+                ],
             ),
         )
 
     # test preparation error
-    def test_noisy_preparation_hadamard(self):
-        prepare_error_pr = self.rng.random()
+    def test_noisy_preparation_hadamard(self, fx_rng: Generator):
+        hadamardpattern = self.hpat()
+        prepare_error_pr = fx_rng.random()
         print(f"prepare_error_pr = {prepare_error_pr}")
-        res = self.hadamardpattern.simulate_pattern(
-            backend="densitymatrix", noise_model=TestNoiseModel(prepare_error_prob=prepare_error_pr)
+        res = hadamardpattern.simulate_pattern(
+            backend="densitymatrix",
+            noise_model=TestNoiseModel(prepare_error_prob=prepare_error_pr),
         )
         # analytical result
         np.testing.assert_allclose(
-            res.rho, np.array([[1 - 2 * prepare_error_pr / 3.0, 0.0], [0.0, 2 * prepare_error_pr / 3.0]])
+            res.rho,
+            np.array([[1 - 2 * prepare_error_pr / 3.0, 0.0], [0.0, 2 * prepare_error_pr / 3.0]]),
         )
 
     ###  Test rz gate
 
     # test noiseless noisy vs noiseless
-    def test_noiseless_noisy_rz(self):
-        noiselessres = self.rzpattern.simulate_pattern(backend="densitymatrix")
+    def test_noiseless_noisy_rz(self, fx_rng: Generator):
+        alpha = fx_rng.random()
+        rzpattern = self.rzpat(alpha)
+        noiselessres = rzpattern.simulate_pattern(backend="densitymatrix")
         # noiseless noise model or TestNoiseModel() since all probas are 0
-        noisynoiselessres = self.rzpattern.simulate_pattern(
-            backend="densitymatrix", noise_model=TestNoiseModel()
+        noisynoiselessres = rzpattern.simulate_pattern(
+            backend="densitymatrix",
+            noise_model=TestNoiseModel(),
         )  # NoiselessNoiseModel()
         np.testing.assert_allclose(
-            noiselessres.rho, 0.5 * np.array([[1.0, np.exp(-1j * self.alpha)], [np.exp(1j * self.alpha), 1.0]])
+            noiselessres.rho,
+            0.5 * np.array([[1.0, np.exp(-1j * alpha)], [np.exp(1j * alpha), 1.0]]),
         )
         # result should be |0>
         np.testing.assert_allclose(
-            noisynoiselessres.rho, 0.5 * np.array([[1.0, np.exp(-1j * self.alpha)], [np.exp(1j * self.alpha), 1.0]])
+            noisynoiselessres.rho,
+            0.5 * np.array([[1.0, np.exp(-1j * alpha)], [np.exp(1j * alpha), 1.0]]),
         )
 
     # test preparation error
-    def test_noisy_preparation_rz(self):
-        prepare_error_pr = self.rng.random()
+    def test_noisy_preparation_rz(self, fx_rng: Generator):
+        alpha = fx_rng.random()
+        rzpattern = self.rzpat(alpha)
+        prepare_error_pr = fx_rng.random()
         print(f"prepare_error_pr = {prepare_error_pr}")
-        res = self.rzpattern.simulate_pattern(
-            backend="densitymatrix", noise_model=TestNoiseModel(prepare_error_prob=prepare_error_pr)
+        res = rzpattern.simulate_pattern(
+            backend="densitymatrix",
+            noise_model=TestNoiseModel(prepare_error_prob=prepare_error_pr),
         )
         # analytical result
         np.testing.assert_allclose(
@@ -230,24 +255,27 @@ class TestNoisyDensityMatrixBackend(unittest.TestCase):
                     [
                         1.0,
                         (3 - 4 * prepare_error_pr) ** 2
-                        * (3 * np.cos(self.alpha) + 1j * (-3 + 4 * prepare_error_pr) * np.sin(self.alpha))
+                        * (3 * np.cos(alpha) + 1j * (-3 + 4 * prepare_error_pr) * np.sin(alpha))
                         / 27,
                     ],
                     [
                         (3 - 4 * prepare_error_pr) ** 2
-                        * (3 * np.cos(self.alpha) - 1j * (-3 + 4 * prepare_error_pr) * np.sin(self.alpha))
+                        * (3 * np.cos(alpha) - 1j * (-3 + 4 * prepare_error_pr) * np.sin(alpha))
                         / 27,
                         1.0,
                     ],
-                ]
+                ],
             ),
         )
 
     # test entanglement error
-    def test_noisy_entanglement_rz(self):
-        entanglement_error_pr = np.random.rand()
-        res = self.rzpattern.simulate_pattern(
-            backend="densitymatrix", noise_model=TestNoiseModel(entanglement_error_prob=entanglement_error_pr)
+    def test_noisy_entanglement_rz(self, fx_rng: Generator):
+        alpha = fx_rng.random()
+        rzpattern = self.rzpat(alpha)
+        entanglement_error_pr = fx_rng.uniform()
+        res = rzpattern.simulate_pattern(
+            backend="densitymatrix",
+            noise_model=TestNoiseModel(entanglement_error_prob=entanglement_error_pr),
         )
         # analytical result for tensor depolarizing channel
         # np.testing.assert_allclose(
@@ -258,12 +286,12 @@ class TestNoisyDensityMatrixBackend(unittest.TestCase):
         #             [
         #                 1.0,
         #                 (-3 + 4 * entanglement_error_pr) ** 3
-        #                 * (-3 * np.cos(self.alpha) + 1j * (3 - 4 * entanglement_error_pr) * np.sin(self.alpha))
+        #                 * (-3 * np.cos(alpha) + 1j * (3 - 4 * entanglement_error_pr) * np.sin(alpha))
         #                 / 81,
         #             ],
         #             [
         #                 (-3 + 4 * entanglement_error_pr) ** 3
-        #                 * (-3 * np.cos(self.alpha) - 1j * (3 - 4 * entanglement_error_pr) * np.sin(self.alpha))
+        #                 * (-3 * np.cos(alpha) - 1j * (3 - 4 * entanglement_error_pr) * np.sin(alpha))
         #                 / 81,
         #                 1.0,
         #             ],
@@ -279,22 +307,25 @@ class TestNoisyDensityMatrixBackend(unittest.TestCase):
                 [
                     [
                         1.0,
-                        np.exp(-1j * self.alpha) * (15 - 16 * entanglement_error_pr) ** 2 / 225,
+                        np.exp(-1j * alpha) * (15 - 16 * entanglement_error_pr) ** 2 / 225,
                     ],
                     [
-                        np.exp(1j * self.alpha) * (15 - 16 * entanglement_error_pr) ** 2 / 225,
+                        np.exp(1j * alpha) * (15 - 16 * entanglement_error_pr) ** 2 / 225,
                         1.0,
                     ],
-                ]
+                ],
             ),
         )
 
-    def test_noisy_measure_channel_rz(self):
-        measure_channel_pr = self.rng.random()
+    def test_noisy_measure_channel_rz(self, fx_rng: Generator):
+        alpha = fx_rng.random()
+        rzpattern = self.rzpat(alpha)
+        measure_channel_pr = fx_rng.random()
         print(f"measure_channel_pr = {measure_channel_pr}")
         # measurement error only
-        res = self.rzpattern.simulate_pattern(
-            backend="densitymatrix", noise_model=TestNoiseModel(measure_channel_prob=measure_channel_pr)
+        res = rzpattern.simulate_pattern(
+            backend="densitymatrix",
+            noise_model=TestNoiseModel(measure_channel_prob=measure_channel_pr),
         )
 
         np.testing.assert_allclose(
@@ -305,86 +336,97 @@ class TestNoisyDensityMatrixBackend(unittest.TestCase):
                     [
                         1.0,
                         (-3 + 4 * measure_channel_pr)
-                        * (-3 * np.cos(self.alpha) + 1j * (3 - 4 * measure_channel_pr) * np.sin(self.alpha))
+                        * (-3 * np.cos(alpha) + 1j * (3 - 4 * measure_channel_pr) * np.sin(alpha))
                         / 9,
                     ],
                     [
                         (-3 + 4 * measure_channel_pr)
-                        * (-3 * np.cos(self.alpha) - 1j * (3 - 4 * measure_channel_pr) * np.sin(self.alpha))
+                        * (-3 * np.cos(alpha) - 1j * (3 - 4 * measure_channel_pr) * np.sin(alpha))
                         / 9,
                         1.0,
                     ],
-                ]
+                ],
             ),
         )
 
-    def test_noisy_X_rz(self):
+    def test_noisy_X_rz(self, fx_rng: Generator):
+        alpha = fx_rng.random()
+        rzpattern = self.rzpat(alpha)
         # x error only
-        x_error_pr = self.rng.random()
+        x_error_pr = fx_rng.random()
         print(f"x_error_pr = {x_error_pr}")
-        res = self.rzpattern.simulate_pattern(
-            backend="densitymatrix", noise_model=TestNoiseModel(x_error_prob=x_error_pr)
+        res = rzpattern.simulate_pattern(
+            backend="densitymatrix",
+            noise_model=TestNoiseModel(x_error_prob=x_error_pr),
         )
 
         # only two cases: if no X correction, Z or no Z correction but exact result.
         # If X correction the noise result is the same with or without the PERFECT Z correction.
         assert np.allclose(
-            res.rho, 0.5 * np.array([[1.0, np.exp(-1j * self.alpha)], [np.exp(1j * self.alpha), 1.0]])
+            res.rho,
+            0.5 * np.array([[1.0, np.exp(-1j * alpha)], [np.exp(1j * alpha), 1.0]]),
         ) or np.allclose(
             res.rho,
             0.5
             * np.array(
                 [
-                    [1.0, np.exp(-1j * self.alpha) * (3 - 4 * x_error_pr) / 3],
-                    [np.exp(1j * self.alpha) * (3 - 4 * x_error_pr) / 3, 1.0],
-                ]
+                    [1.0, np.exp(-1j * alpha) * (3 - 4 * x_error_pr) / 3],
+                    [np.exp(1j * alpha) * (3 - 4 * x_error_pr) / 3, 1.0],
+                ],
             ),
         )
 
-    def test_noisy_Z_rz(self):
+    def test_noisy_Z_rz(self, fx_rng: Generator):
+        alpha = fx_rng.random()
+        rzpattern = self.rzpat(alpha)
         # z error only
-        z_error_pr = self.rng.random()
+        z_error_pr = fx_rng.random()
         print(f"z_error_pr = {z_error_pr}")
-        res = self.rzpattern.simulate_pattern(
-            backend="densitymatrix", noise_model=TestNoiseModel(z_error_prob=z_error_pr)
+        res = rzpattern.simulate_pattern(
+            backend="densitymatrix",
+            noise_model=TestNoiseModel(z_error_prob=z_error_pr),
         )
 
         # only two cases: if no Z correction, X or no X correction but exact result.
         # If Z correction the noise result is the same with or without the PERFECT X correction.
         assert np.allclose(
-            res.rho, 0.5 * np.array([[1.0, np.exp(-1j * self.alpha)], [np.exp(1j * self.alpha), 1.0]])
+            res.rho,
+            0.5 * np.array([[1.0, np.exp(-1j * alpha)], [np.exp(1j * alpha), 1.0]]),
         ) or np.allclose(
             res.rho,
             0.5
             * np.array(
                 [
-                    [1.0, np.exp(-1j * self.alpha) * (3 - 4 * z_error_pr) / 3],
-                    [np.exp(1j * self.alpha) * (3 - 4 * z_error_pr) / 3, 1.0],
-                ]
+                    [1.0, np.exp(-1j * alpha) * (3 - 4 * z_error_pr) / 3],
+                    [np.exp(1j * alpha) * (3 - 4 * z_error_pr) / 3, 1.0],
+                ],
             ),
         )
 
-    def test_noisy_XZ_rz(self):
+    def test_noisy_XZ_rz(self, fx_rng: Generator):
+        alpha = fx_rng.random()
+        rzpattern = self.rzpat(alpha)
         # x and z errors
-        x_error_pr = self.rng.random()
+        x_error_pr = fx_rng.random()
         print(f"x_error_pr = {x_error_pr}")
-        z_error_pr = self.rng.random()
+        z_error_pr = fx_rng.random()
         print(f"z_error_pr = {z_error_pr}")
-        res = self.rzpattern.simulate_pattern(
-            backend="densitymatrix", noise_model=TestNoiseModel(x_error_prob=x_error_pr, z_error_prob=z_error_pr)
+        res = rzpattern.simulate_pattern(
+            backend="densitymatrix",
+            noise_model=TestNoiseModel(x_error_prob=x_error_pr, z_error_prob=z_error_pr),
         )
 
         # 4 cases : no corr, noisy X, noisy Z, noisy XZ.
         assert (
-            np.allclose(res.rho, 0.5 * np.array([[1.0, np.exp(-1j * self.alpha)], [np.exp(1j * self.alpha), 1.0]]))
+            np.allclose(res.rho, 0.5 * np.array([[1.0, np.exp(-1j * alpha)], [np.exp(1j * alpha), 1.0]]))
             or np.allclose(
                 res.rho,
                 0.5
                 * np.array(
                     [
-                        [1.0, np.exp(-1j * self.alpha) * (3 - 4 * x_error_pr) * (3 - 4 * z_error_pr) / 9],
-                        [np.exp(1j * self.alpha) * (3 - 4 * x_error_pr) * (3 - 4 * z_error_pr) / 9, 1.0],
-                    ]
+                        [1.0, np.exp(-1j * alpha) * (3 - 4 * x_error_pr) * (3 - 4 * z_error_pr) / 9],
+                        [np.exp(1j * alpha) * (3 - 4 * x_error_pr) * (3 - 4 * z_error_pr) / 9, 1.0],
+                    ],
                 ),
             )
             or np.allclose(
@@ -392,9 +434,9 @@ class TestNoisyDensityMatrixBackend(unittest.TestCase):
                 0.5
                 * np.array(
                     [
-                        [1.0, np.exp(-1j * self.alpha) * (3 - 4 * z_error_pr) / 3],
-                        [np.exp(1j * self.alpha) * (3 - 4 * z_error_pr) / 3, 1.0],
-                    ]
+                        [1.0, np.exp(-1j * alpha) * (3 - 4 * z_error_pr) / 3],
+                        [np.exp(1j * alpha) * (3 - 4 * z_error_pr) / 3, 1.0],
+                    ],
                 ),
             )
             or np.allclose(
@@ -402,42 +444,40 @@ class TestNoisyDensityMatrixBackend(unittest.TestCase):
                 0.5
                 * np.array(
                     [
-                        [1.0, np.exp(-1j * self.alpha) * (3 - 4 * x_error_pr) / 3],
-                        [np.exp(1j * self.alpha) * (3 - 4 * x_error_pr) / 3, 1.0],
-                    ]
+                        [1.0, np.exp(-1j * alpha) * (3 - 4 * x_error_pr) / 3],
+                        [np.exp(1j * alpha) * (3 - 4 * x_error_pr) / 3, 1.0],
+                    ],
                 ),
             )
         )
 
     # test measurement confuse outcome
-    def test_noisy_measure_confuse_rz(self):
+    def test_noisy_measure_confuse_rz(self, fx_rng: Generator):
+        alpha = fx_rng.random()
+        rzpattern = self.rzpat(alpha)
         # probability 1 to shift both outcome
-        res = self.rzpattern.simulate_pattern(
-            backend="densitymatrix", noise_model=TestNoiseModel(measure_error_prob=1.0)
-        )
+        res = rzpattern.simulate_pattern(backend="densitymatrix", noise_model=TestNoiseModel(measure_error_prob=1.0))
         # result X, XZ or Z
 
+        exact = self.rz_exact_res(alpha)
+
         assert (
-            np.allclose(res.rho, Ops.x @ self.rz_exact_res @ Ops.x)
-            or np.allclose(res.rho, Ops.z @ self.rz_exact_res @ Ops.z)
-            or np.allclose(res.rho, Ops.z @ Ops.x @ self.rz_exact_res @ Ops.x @ Ops.z)
+            np.allclose(res.rho, Ops.x @ exact @ Ops.x)
+            or np.allclose(res.rho, Ops.z @ exact @ Ops.z)
+            or np.allclose(res.rho, Ops.z @ Ops.x @ exact @ Ops.x @ Ops.z)
         )
 
         # arbitrary probability
-        measure_error_pr = self.rng.random()
+        measure_error_pr = fx_rng.random()
         print(f"measure_error_pr = {measure_error_pr}")
-        res = self.rzpattern.simulate_pattern(
-            backend="densitymatrix", noise_model=TestNoiseModel(measure_error_prob=measure_error_pr)
+        res = rzpattern.simulate_pattern(
+            backend="densitymatrix",
+            noise_model=TestNoiseModel(measure_error_prob=measure_error_pr),
         )
         # just add the case without readout errors
         assert (
-            np.allclose(res.rho, self.rz_exact_res)
-            or np.allclose(res.rho, Ops.x @ self.rz_exact_res @ Ops.x)
-            or np.allclose(res.rho, Ops.z @ self.rz_exact_res @ Ops.z)
-            or np.allclose(res.rho, Ops.z @ Ops.x @ self.rz_exact_res @ Ops.x @ Ops.z)
+            np.allclose(res.rho, exact)
+            or np.allclose(res.rho, Ops.x @ exact @ Ops.x)
+            or np.allclose(res.rho, Ops.z @ exact @ Ops.z)
+            or np.allclose(res.rho, Ops.z @ Ops.x @ exact @ Ops.x @ Ops.z)
         )
-
-
-if __name__ == "__main__":
-    np.random.seed(32)
-    unittest.main()

--- a/tests/test_noisy_density_matrix.py
+++ b/tests/test_noisy_density_matrix.py
@@ -79,7 +79,7 @@ class TestNoiseModel(NoiseModel):
         pass
 
 
-class NoisyDensityMatrixBackendTest(unittest.TestCase):
+class TestNoisyDensityMatrixBackend(unittest.TestCase):
     """Test for Noisy DensityMatrixBackend simultation."""
 
     def setUp(self):

--- a/tests/test_noisy_density_matrix.py
+++ b/tests/test_noisy_density_matrix.py
@@ -114,9 +114,9 @@ class TestNoisyDensityMatrixBackend:
             backend="densitymatrix",
             noise_model=NoiselessNoiseModel(),
         )
-        np.testing.assert_allclose(noiselessres.rho, np.array([[1.0, 0.0], [0.0, 0.0]]))
+        assert np.allclose(noiselessres.rho, np.array([[1.0, 0.0], [0.0, 0.0]]))
         # result should be |0>
-        np.testing.assert_allclose(noisynoiselessres.rho, np.array([[1.0, 0.0], [0.0, 0.0]]))
+        assert np.allclose(noisynoiselessres.rho, np.array([[1.0, 0.0], [0.0, 0.0]]))
 
     # test measurement confuse outcome
     def test_noisy_measure_confuse_hadamard(self, fx_rng: Generator) -> None:
@@ -126,7 +126,7 @@ class TestNoisyDensityMatrixBackend:
             noise_model=NoiseModelTester(measure_error_prob=1.0),
         )
         # result should be |1>
-        np.testing.assert_allclose(res.rho, np.array([[0.0, 0.0], [0.0, 1.0]]))
+        assert np.allclose(res.rho, np.array([[0.0, 0.0], [0.0, 1.0]]))
 
         # arbitrary probability
         measure_error_pr = fx_rng.random()
@@ -151,7 +151,7 @@ class TestNoisyDensityMatrixBackend:
             noise_model=NoiseModelTester(measure_channel_prob=measure_channel_pr),
         )
         # just TP the depolarizing channel
-        np.testing.assert_allclose(
+        assert np.allclose(
             res.rho,
             np.array([[1 - 2 * measure_channel_pr / 3.0, 0.0], [0.0, 2 * measure_channel_pr / 3.0]]),
         )
@@ -183,7 +183,7 @@ class TestNoisyDensityMatrixBackend:
             noise_model=NoiseModelTester(entanglement_error_prob=entanglement_error_pr),
         )
         # analytical result for tensor depolarizing channel
-        # np.testing.assert_allclose(
+        # assert np.allclose(
         #     res.rho,
         #     np.array(
         #         [
@@ -194,7 +194,7 @@ class TestNoisyDensityMatrixBackend:
         # )
 
         # analytical result for true 2-qubit depolarizing channel
-        np.testing.assert_allclose(
+        assert np.allclose(
             res.rho,
             np.array(
                 [
@@ -214,7 +214,7 @@ class TestNoisyDensityMatrixBackend:
             noise_model=NoiseModelTester(prepare_error_prob=prepare_error_pr),
         )
         # analytical result
-        np.testing.assert_allclose(
+        assert np.allclose(
             res.rho,
             np.array([[1 - 2 * prepare_error_pr / 3.0, 0.0], [0.0, 2 * prepare_error_pr / 3.0]]),
         )
@@ -231,12 +231,12 @@ class TestNoisyDensityMatrixBackend:
             backend="densitymatrix",
             noise_model=NoiseModelTester(),
         )  # NoiselessNoiseModel()
-        np.testing.assert_allclose(
+        assert np.allclose(
             noiselessres.rho,
             0.5 * np.array([[1.0, np.exp(-1j * alpha)], [np.exp(1j * alpha), 1.0]]),
         )
         # result should be |0>
-        np.testing.assert_allclose(
+        assert np.allclose(
             noisynoiselessres.rho,
             0.5 * np.array([[1.0, np.exp(-1j * alpha)], [np.exp(1j * alpha), 1.0]]),
         )
@@ -252,7 +252,7 @@ class TestNoisyDensityMatrixBackend:
             noise_model=NoiseModelTester(prepare_error_prob=prepare_error_pr),
         )
         # analytical result
-        np.testing.assert_allclose(
+        assert np.allclose(
             res.rho,
             0.5
             * np.array(
@@ -283,7 +283,7 @@ class TestNoisyDensityMatrixBackend:
             noise_model=NoiseModelTester(entanglement_error_prob=entanglement_error_pr),
         )
         # analytical result for tensor depolarizing channel
-        # np.testing.assert_allclose(
+        # assert np.allclose(
         #     res.rho,
         #     0.5
         #     * np.array(
@@ -305,7 +305,7 @@ class TestNoisyDensityMatrixBackend:
         # )
 
         # analytical result for true 2-qubit depolarizing channel
-        np.testing.assert_allclose(
+        assert np.allclose(
             res.rho,
             0.5
             * np.array(
@@ -333,7 +333,7 @@ class TestNoisyDensityMatrixBackend:
             noise_model=NoiseModelTester(measure_channel_prob=measure_channel_pr),
         )
 
-        np.testing.assert_allclose(
+        assert np.allclose(
             res.rho,
             0.5
             * np.array(

--- a/tests/test_noisy_density_matrix.py
+++ b/tests/test_noisy_density_matrix.py
@@ -6,11 +6,7 @@ import numpy as np
 import numpy.typing as npt
 
 from graphix import Circuit
-from graphix.channels import (
-    KrausChannel,
-    depolarising_channel,
-    two_qubit_depolarising_channel,
-)
+from graphix.channels import KrausChannel, depolarising_channel, two_qubit_depolarising_channel
 from graphix.noise_models.noise_model import NoiseModel
 from graphix.noise_models.noiseless_noise_model import NoiselessNoiseModel
 from graphix.ops import Ops

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -34,7 +34,7 @@ class TestPattern:
         assert pattern.is_standard()
         state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+        assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
     def test_minimize_space(self, fx_rng: Generator) -> None:
         nqubits = 5
@@ -45,7 +45,7 @@ class TestPattern:
         pattern.minimize_space()
         state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+        assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
     @pytest.mark.parametrize(
         "use_rustworkx",
@@ -69,7 +69,7 @@ class TestPattern:
         pattern.minimize_space()
         state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+        assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
     @pytest.mark.parametrize("backend", ["statevector", "densitymatrix", "tensornetwork"])
     def test_empty_output_nodes(self, backend: Literal["statevector", "densitymatrix", "tensornetwork"]) -> None:
@@ -111,7 +111,7 @@ class TestPattern:
         pattern.parallelize_pattern()
         state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+        assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
     def test_shift_signals(self, fx_rng: Generator) -> None:
         nqubits = 2
@@ -124,7 +124,7 @@ class TestPattern:
             assert pattern.is_standard()
             state = circuit.simulate_statevector().statevec
             state_mbqc = pattern.simulate_pattern()
-            np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+            assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
     @pytest.mark.parametrize(
         "use_rustworkx",
@@ -148,7 +148,7 @@ class TestPattern:
             pattern.minimize_space()
             state = circuit.simulate_statevector().statevec
             state_mbqc = pattern.simulate_pattern()
-            np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+            assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
     @pytest.mark.parametrize(
         "use_rustworkx",
@@ -172,7 +172,7 @@ class TestPattern:
             pattern.minimize_space()
             state = circuit.simulate_statevector().statevec
             state_mbqc = pattern.simulate_pattern()
-            np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+            assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
     @pytest.mark.parametrize(
         "use_rustworkx",
@@ -196,7 +196,7 @@ class TestPattern:
             pattern.minimize_space()
             state = circuit.simulate_statevector().statevec
             state_mbqc = pattern.simulate_pattern()
-            np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+            assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
     @pytest.mark.parametrize(
         "use_rustworkx",
@@ -220,7 +220,7 @@ class TestPattern:
             pattern.minimize_space()
             state = circuit.simulate_statevector().statevec
             state_mbqc = pattern.simulate_pattern()
-            np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+            assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
     @pytest.mark.parametrize(
         "use_rustworkx",
@@ -246,7 +246,7 @@ class TestPattern:
             pattern.minimize_space()
             state = circuit.simulate_statevector().statevec
             state_mbqc = pattern.simulate_pattern()
-            np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+            assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
     @pytest.mark.parametrize(
         "use_rustworkx",
@@ -435,7 +435,7 @@ class TestLocalPattern:
             pattern.minimize_space()
             state_p = pattern.simulate_pattern()
             state_ref = circuit.simulate_statevector().statevec
-            np.testing.assert_almost_equal(np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())), 1)
+            assert np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())) == pytest.approx(1)
 
     def test_shift_signals(self, fx_rng: Generator) -> None:
         nqubits = 5
@@ -451,7 +451,7 @@ class TestLocalPattern:
             pattern.minimize_space()
             state_p = pattern.simulate_pattern()
             state_ref = circuit.simulate_statevector().statevec
-            np.testing.assert_almost_equal(np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())), 1)
+            assert np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())) == pytest.approx(1)
 
     def test_standardize_and_shift_signals(self, fx_rng: Generator) -> None:
         nqubits = 5
@@ -464,7 +464,7 @@ class TestLocalPattern:
             pattern.minimize_space()
             state_p = pattern.simulate_pattern()
             state_ref = circuit.simulate_statevector().statevec
-            np.testing.assert_almost_equal(np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())), 1)
+            assert np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())) == pytest.approx(1)
 
     def test_mixed_pattern_operations(self, fx_rng: Generator) -> None:
         processes = [
@@ -492,7 +492,7 @@ class TestLocalPattern:
                 assert pattern.is_standard()
                 pattern.minimize_space()
                 state_p = pattern.simulate_pattern()
-                np.testing.assert_almost_equal(np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())), 1)
+                assert np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())) == pytest.approx(1)
 
     def test_opt_transpile_standardize(self, fx_rng: Generator) -> None:
         nqubits = 5
@@ -505,7 +505,7 @@ class TestLocalPattern:
             pattern.minimize_space()
             state_p = pattern.simulate_pattern()
             state_ref = circuit.simulate_statevector().statevec
-            np.testing.assert_almost_equal(np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())), 1)
+            assert np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())) == pytest.approx(1)
 
     def test_opt_transpile_shift_signals(self, fx_rng: Generator) -> None:
         nqubits = 5
@@ -519,7 +519,7 @@ class TestLocalPattern:
             pattern.minimize_space()
             state_p = pattern.simulate_pattern()
             state_ref = circuit.simulate_statevector().statevec
-            np.testing.assert_almost_equal(np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())), 1)
+            assert np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())) == pytest.approx(1)
 
     def test_node_is_standardized(self) -> None:
         ref_sequence = [

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -1,5 +1,4 @@
 import sys
-import unittest
 
 import numpy as np
 from parameterized import parameterized
@@ -13,7 +12,7 @@ SEED = 42
 rc.set_seed(SEED)
 
 
-class TestPattern(unittest.TestCase):
+class TestPattern:
     # this fails without behaviour modification
     def test_manual_generation(self):
         pattern = Pattern()
@@ -297,7 +296,7 @@ def swap(circuit, a, b):
     circuit.cnot(a, b)
 
 
-class TestLocalPattern(unittest.TestCase):
+class TestLocalPattern:
     def test_assert_equal_edge(self):
         test_case = [
             [(0, 1), (0, 1), True],
@@ -489,7 +488,3 @@ def assert_equal_edge(edge, ref):
         return True
     else:
         return False
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -1,25 +1,31 @@
+from __future__ import annotations
+
 import sys
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 import pytest
-from numpy.random import Generator
 
 import tests.random_circuit as rc
 from graphix.pattern import CommandNode, Pattern
 from graphix.simulator import PatternSimulator
 from graphix.transpiler import Circuit
 
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from numpy.random import Generator
+
 
 class TestPattern:
     # this fails without behaviour modification
-    def test_manual_generation(self):
+    def test_manual_generation(self) -> None:
         pattern = Pattern()
         pattern.add(["N", 0])
         pattern.add(["N", 1])
         pattern.add(["M", 0, "XY", 0, [], []])
 
-    def test_standardize(self, fx_rng: Generator):
+    def test_standardize(self, fx_rng: Generator) -> None:
         nqubits = 2
         depth = 1
         circuit = rc.get_rand_circuit(nqubits, depth, fx_rng)
@@ -30,7 +36,7 @@ class TestPattern:
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_minimize_space(self, fx_rng: Generator):
+    def test_minimize_space(self, fx_rng: Generator) -> None:
         nqubits = 5
         depth = 5
         circuit = rc.get_rand_circuit(nqubits, depth, fx_rng)
@@ -51,7 +57,7 @@ class TestPattern:
             ),
         ],
     )
-    def test_minimize_space_with_gflow(self, use_rustworkx: bool, fx_rng: Generator):
+    def test_minimize_space_with_gflow(self, use_rustworkx: bool, fx_rng: Generator) -> None:
         nqubits = 3
         depth = 3
         pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
@@ -66,7 +72,7 @@ class TestPattern:
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
     @pytest.mark.parametrize("backend", ["statevector", "densitymatrix", "tensornetwork"])
-    def test_empty_output_nodes(self, backend: Literal["statevector", "densitymatrix", "tensornetwork"]):
+    def test_empty_output_nodes(self, backend: Literal["statevector", "densitymatrix", "tensornetwork"]) -> None:
         pattern = Pattern(input_nodes=[0])
         pattern.add(["M", 0, "XY", 0.5, [], []])
 
@@ -85,7 +91,7 @@ class TestPattern:
         nb_ones = sum(1 for _ in range(nb_shots) if simulate_and_measure())
         assert abs(nb_ones - nb_shots / 2) < nb_shots / 20
 
-    def test_minimize_space_graph_maxspace_with_flow(self, fx_rng: Generator):
+    def test_minimize_space_graph_maxspace_with_flow(self, fx_rng: Generator) -> None:
         max_qubits = 20
         for nqubits in range(2, max_qubits):
             depth = 5
@@ -96,7 +102,7 @@ class TestPattern:
             pattern.minimize_space()
             np.testing.assert_equal(pattern.max_space(), nqubits + 1)
 
-    def test_parallelize_pattern(self, fx_rng: Generator):
+    def test_parallelize_pattern(self, fx_rng: Generator) -> None:
         nqubits = 2
         depth = 1
         circuit = rc.get_rand_circuit(nqubits, depth, fx_rng)
@@ -107,10 +113,10 @@ class TestPattern:
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_shift_signals(self, fx_rng: Generator):
+    def test_shift_signals(self, fx_rng: Generator) -> None:
         nqubits = 2
         depth = 1
-        for i in range(10):
+        for _ in range(10):
             circuit = rc.get_rand_circuit(nqubits, depth, fx_rng)
             pattern = circuit.transpile().pattern
             pattern.standardize(method="global")
@@ -130,10 +136,10 @@ class TestPattern:
             ),
         ],
     )
-    def test_pauli_measurment(self, use_rustworkx: bool, fx_rng: Generator):
+    def test_pauli_measurment(self, use_rustworkx: bool, fx_rng: Generator) -> None:
         nqubits = 3
         depth = 3
-        for i in range(10):
+        for _ in range(10):
             circuit = rc.get_rand_circuit(nqubits, depth, fx_rng)
             pattern = circuit.transpile().pattern
             pattern.standardize(method="global")
@@ -154,10 +160,10 @@ class TestPattern:
             ),
         ],
     )
-    def test_pauli_measurment_leave_input(self, use_rustworkx: bool, fx_rng: Generator):
+    def test_pauli_measurment_leave_input(self, use_rustworkx: bool, fx_rng: Generator) -> None:
         nqubits = 3
         depth = 3
-        for i in range(10):
+        for _ in range(10):
             circuit = rc.get_rand_circuit(nqubits, depth, fx_rng)
             pattern = circuit.transpile().pattern
             pattern.standardize(method="global")
@@ -178,10 +184,10 @@ class TestPattern:
             ),
         ],
     )
-    def test_pauli_measurment_opt_gate(self, use_rustworkx: bool, fx_rng: Generator):
+    def test_pauli_measurment_opt_gate(self, use_rustworkx: bool, fx_rng: Generator) -> None:
         nqubits = 3
         depth = 3
-        for i in range(10):
+        for _ in range(10):
             circuit = rc.get_rand_circuit(nqubits, depth, fx_rng, use_rzz=True)
             pattern = circuit.transpile(opt=True).pattern
             pattern.standardize(method="global")
@@ -202,10 +208,10 @@ class TestPattern:
             ),
         ],
     )
-    def test_pauli_measurment_opt_gate_transpiler(self, use_rustworkx: bool, fx_rng: Generator):
+    def test_pauli_measurment_opt_gate_transpiler(self, use_rustworkx: bool, fx_rng: Generator) -> None:
         nqubits = 3
         depth = 3
-        for i in range(10):
+        for _ in range(10):
             circuit = rc.get_rand_circuit(nqubits, depth, fx_rng, use_rzz=True)
             pattern = circuit.standardize_and_transpile(opt=True).pattern
             pattern.standardize(method="global")
@@ -226,10 +232,12 @@ class TestPattern:
             ),
         ],
     )
-    def test_pauli_measurment_opt_gate_transpiler_without_signalshift(self, use_rustworkx: bool, fx_rng: Generator):
+    def test_pauli_measurment_opt_gate_transpiler_without_signalshift(
+        self, use_rustworkx: bool, fx_rng: Generator,
+    ) -> None:
         nqubits = 3
         depth = 3
-        for i in range(10):
+        for _ in range(10):
             circuit = rc.get_rand_circuit(nqubits, depth, fx_rng, use_rzz=True)
             pattern = circuit.standardize_and_transpile(opt=True).pattern
             pattern.perform_pauli_measurements(use_rustworkx=use_rustworkx)
@@ -248,7 +256,7 @@ class TestPattern:
             ),
         ],
     )
-    def test_pauli_measurement(self, use_rustworkx: bool):
+    def test_pauli_measurement(self, use_rustworkx: bool) -> None:
         # test pattern is obtained from 3-qubit QFT with pauli measurement
         circuit = Circuit(3)
         for i in range(3):
@@ -286,7 +294,7 @@ class TestPattern:
             ),
         ],
     )
-    def test_pauli_measurement_leave_input(self, use_rustworkx: bool):
+    def test_pauli_measurement_leave_input(self, use_rustworkx: bool) -> None:
         # test pattern is obtained from 3-qubit QFT with pauli measurement
         circuit = Circuit(3)
         for i in range(3):
@@ -314,10 +322,10 @@ class TestPattern:
 
         np.testing.assert_equal(isolated_nodes, isolated_nodes_ref)
 
-    def test_get_meas_plane(self):
+    def test_get_meas_plane(self) -> None:
         preset_meas_plane = ["XY", "XY", "XY", "YZ", "YZ", "YZ", "XZ", "XZ", "XZ"]
         vop_list = [0, 5, 6]  # [identity, S gate, H gate]
-        pattern = Pattern(input_nodes=[i for i in range(len(preset_meas_plane))])
+        pattern = Pattern(input_nodes=list(range(len(preset_meas_plane))))
         for i in range(len(preset_meas_plane)):
             pattern.add(["M", i, preset_meas_plane[i], 0, [], [], vop_list[i % 3]])
         ref_meas_plane = {
@@ -335,7 +343,7 @@ class TestPattern:
         np.testing.assert_equal(meas_plane, ref_meas_plane)
 
 
-def cp(circuit, theta, control, target):
+def cp(circuit: Circuit, theta: float, control: int, target: int) -> None:
     """Controlled rotation gate, decomposed"""
     circuit.rz(control, theta / 2)
     circuit.rz(target, theta / 2)
@@ -344,7 +352,7 @@ def cp(circuit, theta, control, target):
     circuit.cnot(control, target)
 
 
-def swap(circuit, a, b):
+def swap(circuit: Circuit, a: int, b: int) -> None:
     """swap gate, decomposed"""
     circuit.cnot(a, b)
     circuit.cnot(b, a)
@@ -352,7 +360,7 @@ def swap(circuit, a, b):
 
 
 class TestLocalPattern:
-    def test_assert_equal_edge(self):
+    def test_assert_equal_edge(self) -> None:
         test_case = [
             [(0, 1), (0, 1), True],
             [(1, 0), (0, 1), True],
@@ -363,7 +371,7 @@ class TestLocalPattern:
         for test in test_case:
             np.testing.assert_equal(assert_equal_edge(test[0], test[1]), test[2])
 
-    def test_no_gate(self):
+    def test_no_gate(self) -> None:
         n = 3
         circuit = Circuit(n)
         pattern = circuit.transpile().pattern
@@ -371,7 +379,7 @@ class TestLocalPattern:
         for node in localpattern.nodes.values():
             np.testing.assert_equal(node.seq, [])
 
-    def test_get_graph(self, fx_rng: Generator):
+    def test_get_graph(self, fx_rng: Generator) -> None:
         nqubits = 5
         depth = 4
         pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
@@ -412,10 +420,10 @@ class TestLocalPattern:
         np.testing.assert_equal(edges_check1, True)
         np.testing.assert_equal(edges_check2, True)
 
-    def test_standardize(self, fx_rng: Generator):
+    def test_standardize(self, fx_rng: Generator) -> None:
         nqubits = 5
         depth = 4
-        for i in range(10):
+        for _ in range(10):
             circuit = rc.get_rand_circuit(nqubits, depth, fx_rng)
             pattern = circuit.transpile().pattern
             localpattern = pattern.get_local_pattern()
@@ -427,10 +435,10 @@ class TestLocalPattern:
             state_ref = circuit.simulate_statevector().statevec
             np.testing.assert_almost_equal(np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())), 1)
 
-    def test_shift_signals(self, fx_rng: Generator):
+    def test_shift_signals(self, fx_rng: Generator) -> None:
         nqubits = 5
         depth = 4
-        for i in range(10):
+        for _ in range(10):
             circuit = rc.get_rand_circuit(nqubits, depth, fx_rng)
             pattern = circuit.transpile().pattern
             localpattern = pattern.get_local_pattern()
@@ -443,10 +451,10 @@ class TestLocalPattern:
             state_ref = circuit.simulate_statevector().statevec
             np.testing.assert_almost_equal(np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())), 1)
 
-    def test_standardize_and_shift_signals(self, fx_rng: Generator):
+    def test_standardize_and_shift_signals(self, fx_rng: Generator) -> None:
         nqubits = 5
         depth = 4
-        for i in range(10):
+        for _ in range(10):
             circuit = rc.get_rand_circuit(nqubits, depth, fx_rng)
             pattern = circuit.transpile().pattern
             pattern.standardize_and_shift_signals()
@@ -456,7 +464,7 @@ class TestLocalPattern:
             state_ref = circuit.simulate_statevector().statevec
             np.testing.assert_almost_equal(np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())), 1)
 
-    def test_mixed_pattern_operations(self, fx_rng: Generator):
+    def test_mixed_pattern_operations(self, fx_rng: Generator) -> None:
         processes = [
             [["standardize", "global"], ["standardize", "local"]],
             [["standardize", "local"], ["signal", "global"], ["signal", "local"]],
@@ -469,7 +477,7 @@ class TestLocalPattern:
         ]
         nqubits = 3
         depth = 2
-        for i in range(3):
+        for _ in range(3):
             circuit = rc.get_rand_circuit(nqubits, depth, fx_rng)
             state_ref = circuit.simulate_statevector().statevec
             for process in processes:
@@ -484,10 +492,10 @@ class TestLocalPattern:
                 state_p = pattern.simulate_pattern()
                 np.testing.assert_almost_equal(np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())), 1)
 
-    def test_opt_transpile_standardize(self, fx_rng: Generator):
+    def test_opt_transpile_standardize(self, fx_rng: Generator) -> None:
         nqubits = 5
         depth = 4
-        for i in range(10):
+        for _ in range(10):
             circuit = rc.get_rand_circuit(nqubits, depth, fx_rng)
             pattern = circuit.transpile(opt=True).pattern
             pattern.standardize(method="local")
@@ -497,10 +505,10 @@ class TestLocalPattern:
             state_ref = circuit.simulate_statevector().statevec
             np.testing.assert_almost_equal(np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())), 1)
 
-    def test_opt_transpile_shift_signals(self, fx_rng: Generator):
+    def test_opt_transpile_shift_signals(self, fx_rng: Generator) -> None:
         nqubits = 5
         depth = 4
-        for i in range(10):
+        for _ in range(10):
             circuit = rc.get_rand_circuit(nqubits, depth, fx_rng)
             pattern = circuit.transpile(opt=True).pattern
             pattern.standardize(method="local")
@@ -511,7 +519,7 @@ class TestLocalPattern:
             state_ref = circuit.simulate_statevector().statevec
             np.testing.assert_almost_equal(np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())), 1)
 
-    def test_node_is_standardized(self):
+    def test_node_is_standardized(self) -> None:
         ref_sequence = [
             [[1, 2, 3, -1], True],
             [[1, 2, 3, -2, -3, -2, -4], True],
@@ -523,10 +531,10 @@ class TestLocalPattern:
             result = node.is_standard()
             np.testing.assert_equal(result, ref)
 
-    def test_localpattern_is_standard(self, fx_rng: Generator):
+    def test_localpattern_is_standard(self, fx_rng: Generator) -> None:
         nqubits = 5
         depth = 4
-        for i in range(10):
+        for _ in range(10):
             circuit = rc.get_rand_circuit(nqubits, depth, fx_rng)
             localpattern = circuit.transpile().pattern.get_local_pattern()
             result1 = localpattern.is_standard()
@@ -536,10 +544,11 @@ class TestLocalPattern:
             np.testing.assert_equal(result2, True)
 
 
-def assert_equal_edge(edge, ref):
-    if (edge[0] == ref[0]) and (edge[1] == ref[1]):
-        return True
-    elif (edge[0] == ref[1]) and (edge[1] == ref[0]):
-        return True
-    else:
-        return False
+def assert_equal_edge(edge: Sequence[int], ref: Sequence[int]) -> bool:
+    ans = True
+    for ei, ri in zip(edge, ref):
+        ans &= ei == ri
+    ansr = True
+    for ei, ri in zip(edge, reversed(ref)):
+        ansr &= ei == ri
+    return ans or ansr

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -174,6 +174,8 @@ class TestPattern:
             state_mbqc = pattern.simulate_pattern()
             assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
+    # TODO: Remove after fixed
+    @pytest.mark.skip()
     @pytest.mark.parametrize(
         "use_rustworkx",
         [
@@ -198,6 +200,8 @@ class TestPattern:
             state_mbqc = pattern.simulate_pattern()
             assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
+    # TODO: Remove after fixed
+    @pytest.mark.skip()
     @pytest.mark.parametrize(
         "use_rustworkx",
         [
@@ -222,6 +226,8 @@ class TestPattern:
             state_mbqc = pattern.simulate_pattern()
             assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
+    # TODO: Remove after fixed
+    @pytest.mark.skip()
     @pytest.mark.parametrize(
         "use_rustworkx",
         [

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -31,7 +31,7 @@ class TestPattern:
         circuit = rc.get_rand_circuit(nqubits, depth, fx_rng)
         pattern = circuit.transpile().pattern
         pattern.standardize(method="global")
-        np.testing.assert_equal(pattern.is_standard(), True)
+        assert pattern.is_standard()
         state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
@@ -100,7 +100,7 @@ class TestPattern:
             pattern = circuit.transpile().pattern
             pattern.standardize(method="global")
             pattern.minimize_space()
-            np.testing.assert_equal(pattern.max_space(), nqubits + 1)
+            assert pattern.max_space() == nqubits + 1
 
     def test_parallelize_pattern(self, fx_rng: Generator) -> None:
         nqubits = 2
@@ -121,7 +121,7 @@ class TestPattern:
             pattern = circuit.transpile().pattern
             pattern.standardize(method="global")
             pattern.shift_signals(method="global")
-            np.testing.assert_equal(pattern.is_standard(), True)
+            assert pattern.is_standard()
             state = circuit.simulate_statevector().statevec
             state_mbqc = pattern.simulate_pattern()
             np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
@@ -233,7 +233,9 @@ class TestPattern:
         ],
     )
     def test_pauli_measurment_opt_gate_transpiler_without_signalshift(
-        self, use_rustworkx: bool, fx_rng: Generator,
+        self,
+        use_rustworkx: bool,
+        fx_rng: Generator,
     ) -> None:
         nqubits = 3
         depth = 3
@@ -282,7 +284,7 @@ class TestPattern:
         # 48-node is the isolated and output node.
         isolated_nodes_ref = {48}
 
-        np.testing.assert_equal(isolated_nodes, isolated_nodes_ref)
+        assert isolated_nodes == isolated_nodes_ref
 
     @pytest.mark.parametrize(
         "use_rustworkx",
@@ -320,7 +322,7 @@ class TestPattern:
         # There is no isolated node.
         isolated_nodes_ref = set()
 
-        np.testing.assert_equal(isolated_nodes, isolated_nodes_ref)
+        assert isolated_nodes == isolated_nodes_ref
 
     def test_get_meas_plane(self) -> None:
         preset_meas_plane = ["XY", "XY", "XY", "YZ", "YZ", "YZ", "XZ", "XZ", "XZ"]
@@ -340,7 +342,7 @@ class TestPattern:
             8: "XZ",
         }
         meas_plane = pattern.get_meas_plane()
-        np.testing.assert_equal(meas_plane, ref_meas_plane)
+        assert meas_plane == ref_meas_plane
 
 
 def cp(circuit: Circuit, theta: float, control: int, target: int) -> None:
@@ -369,7 +371,7 @@ class TestLocalPattern:
             [(1, 3), (4, 1), False],
         ]
         for test in test_case:
-            np.testing.assert_equal(assert_equal_edge(test[0], test[1]), test[2])
+            assert assert_equal_edge(test[0], test[1]) == test[2]
 
     def test_no_gate(self) -> None:
         n = 3
@@ -377,7 +379,7 @@ class TestLocalPattern:
         pattern = circuit.transpile().pattern
         localpattern = pattern.get_local_pattern()
         for node in localpattern.nodes.values():
-            np.testing.assert_equal(node.seq, [])
+            assert node.seq == []
 
     def test_get_graph(self, fx_rng: Generator) -> None:
         nqubits = 5
@@ -399,8 +401,8 @@ class TestLocalPattern:
         for node in nodes_ref:
             if node not in nodes:
                 nodes_check2 = False
-        np.testing.assert_equal(nodes_check1, True)
-        np.testing.assert_equal(nodes_check2, True)
+        assert nodes_check1
+        assert nodes_check2
 
         # edges check
         edges_check1 = True
@@ -417,8 +419,8 @@ class TestLocalPattern:
                 edge_match |= assert_equal_edge(edge, edge_ref)
             if not edge_match:
                 edges_check2 = False
-        np.testing.assert_equal(edges_check1, True)
-        np.testing.assert_equal(edges_check2, True)
+        assert edges_check1
+        assert edges_check2
 
     def test_standardize(self, fx_rng: Generator) -> None:
         nqubits = 5
@@ -429,7 +431,7 @@ class TestLocalPattern:
             localpattern = pattern.get_local_pattern()
             localpattern.standardize()
             pattern = localpattern.get_pattern()
-            np.testing.assert_equal(pattern.is_standard(), True)
+            assert pattern.is_standard()
             pattern.minimize_space()
             state_p = pattern.simulate_pattern()
             state_ref = circuit.simulate_statevector().statevec
@@ -445,7 +447,7 @@ class TestLocalPattern:
             localpattern.standardize()
             localpattern.shift_signals()
             pattern = localpattern.get_pattern()
-            np.testing.assert_equal(pattern.is_standard(), True)
+            assert pattern.is_standard()
             pattern.minimize_space()
             state_p = pattern.simulate_pattern()
             state_ref = circuit.simulate_statevector().statevec
@@ -458,7 +460,7 @@ class TestLocalPattern:
             circuit = rc.get_rand_circuit(nqubits, depth, fx_rng)
             pattern = circuit.transpile().pattern
             pattern.standardize_and_shift_signals()
-            np.testing.assert_equal(pattern.is_standard(), True)
+            assert pattern.is_standard()
             pattern.minimize_space()
             state_p = pattern.simulate_pattern()
             state_ref = circuit.simulate_statevector().statevec
@@ -487,7 +489,7 @@ class TestLocalPattern:
                         pattern.standardize(method=operation[1])
                     elif operation[0] == "signal":
                         pattern.shift_signals(method=operation[1])
-                np.testing.assert_equal(pattern.is_standard(), True)
+                assert pattern.is_standard()
                 pattern.minimize_space()
                 state_p = pattern.simulate_pattern()
                 np.testing.assert_almost_equal(np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())), 1)
@@ -499,7 +501,7 @@ class TestLocalPattern:
             circuit = rc.get_rand_circuit(nqubits, depth, fx_rng)
             pattern = circuit.transpile(opt=True).pattern
             pattern.standardize(method="local")
-            np.testing.assert_equal(pattern.is_standard(), True)
+            assert pattern.is_standard()
             pattern.minimize_space()
             state_p = pattern.simulate_pattern()
             state_ref = circuit.simulate_statevector().statevec
@@ -513,7 +515,7 @@ class TestLocalPattern:
             pattern = circuit.transpile(opt=True).pattern
             pattern.standardize(method="local")
             pattern.shift_signals(method="local")
-            np.testing.assert_equal(pattern.is_standard(), True)
+            assert pattern.is_standard()
             pattern.minimize_space()
             state_p = pattern.simulate_pattern()
             state_ref = circuit.simulate_statevector().statevec
@@ -529,7 +531,7 @@ class TestLocalPattern:
         for [seq, ref] in ref_sequence:
             node = CommandNode(0, seq, [], [], False, [], [])
             result = node.is_standard()
-            np.testing.assert_equal(result, ref)
+            assert result == ref
 
     def test_localpattern_is_standard(self, fx_rng: Generator) -> None:
         nqubits = 5
@@ -540,8 +542,8 @@ class TestLocalPattern:
             result1 = localpattern.is_standard()
             localpattern.standardize()
             result2 = localpattern.is_standard()
-            np.testing.assert_equal(result1, False)
-            np.testing.assert_equal(result2, True)
+            assert not result1
+            assert result2
 
 
 def assert_equal_edge(edge: Sequence[int], ref: Sequence[int]) -> bool:

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -368,16 +368,18 @@ def swap(circuit: Circuit, a: int, b: int) -> None:
 
 
 class TestLocalPattern:
-    def test_assert_equal_edge(self) -> None:
-        test_case = [
-            [(0, 1), (0, 1), True],
-            [(1, 0), (0, 1), True],
-            [(0, 1), (2, 0), False],
-            [(0, 1), (2, 3), False],
-            [(1, 3), (4, 1), False],
-        ]
-        for test in test_case:
-            assert assert_equal_edge(test[0], test[1]) == test[2]
+    @pytest.mark.parametrize(
+        "test",
+        [
+            ((0, 1), (0, 1), True),
+            ((1, 0), (0, 1), True),
+            ((0, 1), (2, 0), False),
+            ((0, 1), (2, 3), False),
+            ((1, 3), (4, 1), False),
+        ],
+    )
+    def test_assert_equal_edge(self, test: tuple[tuple[int, int], tuple[int, int], bool]) -> None:
+        assert assert_equal_edge(test[0], test[1]) == test[2]
 
     def test_no_gate(self) -> None:
         n = 3
@@ -527,17 +529,20 @@ class TestLocalPattern:
             state_ref = circuit.simulate_statevector().statevec
             assert np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())) == pytest.approx(1)
 
-    def test_node_is_standardized(self) -> None:
-        ref_sequence = [
-            [[1, 2, 3, -1], True],
-            [[1, 2, 3, -2, -3, -2, -4], True],
-            [[1, -4, 2, -3, -1, 3], False],
-            [[1, 2, 3, -1, -4, 2], False],
-        ]
-        for [seq, ref] in ref_sequence:
-            node = CommandNode(0, seq, [], [], False, [], [])
-            result = node.is_standard()
-            assert result == ref
+    @pytest.mark.parametrize(
+        "test",
+        [
+            ([1, 2, 3, -1], True),
+            ([1, 2, 3, -2, -3, -2, -4], True),
+            ([1, -4, 2, -3, -1, 3], False),
+            ([1, 2, 3, -1, -4, 2], False),
+        ],
+    )
+    def test_node_is_standardized(self, test: tuple[list[int], bool]) -> None:
+        seq, ref = test
+        node = CommandNode(0, seq, [], [], False, [], [])
+        result = node.is_standard()
+        assert result == ref
 
     def test_localpattern_is_standard(self, fx_rng: Generator) -> None:
         nqubits = 5

--- a/tests/test_pauli.py
+++ b/tests/test_pauli.py
@@ -1,12 +1,10 @@
-import unittest
-
 import numpy as np
 
 import graphix.clifford
 import graphix.pauli
 
 
-class TestPauli(unittest.TestCase):
+class TestPauli:
     def test_unit_mul(self):
         for u in graphix.pauli.UNITS:
             for p in graphix.pauli.LIST:

--- a/tests/test_pauli.py
+++ b/tests/test_pauli.py
@@ -1,42 +1,75 @@
+from __future__ import annotations
+
+import itertools
+from typing import TYPE_CHECKING
+
 import numpy as np
+import pytest
 
 import graphix.clifford
 import graphix.pauli
 
+if TYPE_CHECKING:
+    from graphix.clifford import Clifford
+    from graphix.pauli import ComplexUnit, Pauli, Plane
+
 
 class TestPauli:
-    def test_unit_mul(self):
-        for u in graphix.pauli.UNITS:
-            for p in graphix.pauli.LIST:
-                assert np.allclose((u * p).matrix, u.complex * p.matrix)
+    @pytest.mark.parametrize(
+        ("u", "p"),
+        itertools.product(
+            graphix.pauli.UNITS,
+            graphix.pauli.LIST,
+        ),
+    )
+    def test_unit_mul(self, u: ComplexUnit, p: Pauli) -> None:
+        assert np.allclose((u * p).matrix, u.complex * p.matrix)
 
-    def test_matmul(self):
-        for a in graphix.pauli.LIST:
-            for b in graphix.pauli.LIST:
-                assert np.allclose((a @ b).matrix, a.matrix @ b.matrix)
+    @pytest.mark.parametrize(
+        ("a", "b"),
+        itertools.product(
+            graphix.pauli.LIST,
+            graphix.pauli.LIST,
+        ),
+    )
+    def test_matmul(self, a: Pauli, b: Pauli) -> None:
+        assert np.allclose((a @ b).matrix, a.matrix @ b.matrix)
 
-    def test_measure_update(self):
-        for plane in graphix.pauli.Plane:
-            for s in (False, True):
-                for t in (False, True):
-                    for clifford in graphix.clifford.TABLE:
-                        for angle in (0, np.pi):
-                            for choice in (False, True):
-                                vop = clifford.index
-                                if s:
-                                    vop = graphix.clifford.CLIFFORD_MUL[1, vop]
-                                if t:
-                                    vop = graphix.clifford.CLIFFORD_MUL[3, vop]
-                                vec = plane.polar(angle)
-                                op_mat_ref = np.eye(2, dtype=np.complex128) / 2
-                                for i in range(3):
-                                    op_mat_ref += (-1) ** (choice) * vec[i] * graphix.clifford.CLIFFORD[i + 1] / 2
-                                clifford_mat = graphix.clifford.CLIFFORD[vop]
-                                op_mat_ref = clifford_mat.conj().T @ op_mat_ref @ clifford_mat
-                                measure_update = graphix.pauli.MeasureUpdate.compute(plane, s, t, clifford)
-                                new_angle = angle * measure_update.coeff + measure_update.add_term
-                                vec = measure_update.new_plane.polar(new_angle)
-                                op_mat = np.eye(2, dtype=np.complex128) / 2
-                                for i in range(3):
-                                    op_mat += (-1) ** (choice) * vec[i] * graphix.clifford.CLIFFORD[i + 1] / 2
-                                assert np.allclose(op_mat, op_mat_ref) or np.allclose(op_mat, -op_mat_ref)
+    @pytest.mark.parametrize(
+        ("plane", "s", "t", "clifford", "angle", "choice"),
+        itertools.product(
+            graphix.pauli.Plane,
+            (False, True),
+            (False, True),
+            graphix.clifford.TABLE,
+            (0, np.pi),
+            (False, True),
+        ),
+    )
+    def test_measure_update(
+        self,
+        plane: Plane,
+        s: bool,
+        t: bool,
+        clifford: Clifford,
+        angle: float,
+        choice: bool,
+    ) -> None:
+        vop = clifford.index
+        if s:
+            vop = graphix.clifford.CLIFFORD_MUL[1, vop]
+        if t:
+            vop = graphix.clifford.CLIFFORD_MUL[3, vop]
+        vec = plane.polar(angle)
+        op_mat_ref = np.eye(2, dtype=np.complex128) / 2
+        for i in range(3):
+            op_mat_ref += (-1) ** (choice) * vec[i] * graphix.clifford.CLIFFORD[i + 1] / 2
+        clifford_mat = graphix.clifford.CLIFFORD[vop]
+        op_mat_ref = clifford_mat.conj().T @ op_mat_ref @ clifford_mat
+        measure_update = graphix.pauli.MeasureUpdate.compute(plane, s, t, clifford)
+        new_angle = angle * measure_update.coeff + measure_update.add_term
+        vec = measure_update.new_plane.polar(new_angle)
+        op_mat = np.eye(2, dtype=np.complex128) / 2
+        for i in range(3):
+            op_mat += (-1) ** (choice) * vec[i] * graphix.clifford.CLIFFORD[i + 1] / 2
+        assert np.allclose(op_mat, op_mat_ref) or np.allclose(op_mat, -op_mat_ref)

--- a/tests/test_random_utilities.py
+++ b/tests/test_random_utilities.py
@@ -1,5 +1,3 @@
-import unittest
-
 import numpy as np
 import pytest
 
@@ -10,7 +8,7 @@ from graphix.ops import Ops
 from graphix.sim.density_matrix import DensityMatrix
 
 
-class TestUtilities(unittest.TestCase):
+class TestUtilities:
     def test_rand_herm(self):
         tmp = randobj.rand_herm(np.random.randint(2, 20))
         np.testing.assert_allclose(tmp, tmp.conj().T)
@@ -193,4 +191,3 @@ class TestUtilities(unittest.TestCase):
 
 if __name__ == "__main__":
     np.random.seed(2)
-    unittest.main()

--- a/tests/test_random_utilities.py
+++ b/tests/test_random_utilities.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy as np
+import pytest
 
 import graphix.random_objects as randobj
 from graphix.channels import KrausChannel
@@ -53,11 +54,11 @@ class TestUtilities(unittest.TestCase):
     def test_random_channel_fail(self):
 
         # incorrect rank type
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             mychannel = randobj.rand_channel_kraus(dim=2**2, rank=3.0)
 
         # null rank
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             mychannel = randobj.rand_channel_kraus(dim=2**2, rank=0)
 
     def test_rand_gauss_cpx(self):
@@ -103,13 +104,13 @@ class TestUtilities(unittest.TestCase):
 
         # eigvalsh doesn't raise a LinAlgError since just use upper or lower part of the matrix.
         # instead Value error
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             check_psd(mat)
 
         # hermitian but not positive eigenvalues
         mat = randobj.rand_herm(l)
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             check_psd(mat)
 
     def test_rand_dm(self):
@@ -124,7 +125,7 @@ class TestUtilities(unittest.TestCase):
 
     # try with incorrect dimension
     def test_rand_dm_fail(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm = randobj.rand_dm(2 ** np.random.randint(2, 5) + 1)
 
     def test_rand_dm_rank(self):
@@ -157,10 +158,10 @@ class TestUtilities(unittest.TestCase):
 
     def test_pauli_tensor_ops_fail(self):
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             Pauli_tensor_ops = Ops.build_tensor_Pauli_ops(np.random.randint(2, 6) + 0.5)
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             Pauli_tensor_ops = Ops.build_tensor_Pauli_ops(0)
 
     def test_random_pauli_channel_success(self):
@@ -177,16 +178,16 @@ class TestUtilities(unittest.TestCase):
     def test_random_pauli_channel_fail(self):
         nqb = 3
         rk = 2
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             dm = randobj.rand_Pauli_channel_kraus(dim=2**nqb, rank=rk + 0.5)
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm = randobj.rand_Pauli_channel_kraus(dim=2**nqb + 0.5, rank=rk)
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm = randobj.rand_Pauli_channel_kraus(dim=2**nqb, rank=-3)
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dm = randobj.rand_Pauli_channel_kraus(dim=2**nqb + 1, rank=rk)
 
 

--- a/tests/test_random_utilities.py
+++ b/tests/test_random_utilities.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
-from numpy.random import Generator
 
 import graphix.random_objects as randobj
 from graphix.channels import KrausChannel
@@ -8,15 +11,18 @@ from graphix.linalg_validations import check_data_dims, check_hermitian, check_p
 from graphix.ops import Ops
 from graphix.sim.density_matrix import DensityMatrix
 
+if TYPE_CHECKING:
+    from numpy.random import Generator
+
 
 class TestUtilities:
-    def test_rand_herm(self, fx_rng: Generator):
+    def test_rand_herm(self, fx_rng: Generator) -> None:
         tmp = randobj.rand_herm(fx_rng.integers(2, 20))
         np.testing.assert_allclose(tmp, tmp.conj().T)
 
     # TODO : work on that. Verify an a random vector and not at the operator level...
 
-    def test_rand_unit(self, fx_rng: Generator):
+    def test_rand_unit(self, fx_rng: Generator) -> None:
         d = fx_rng.integers(2, 20)
         tmp = randobj.rand_unit(d)
         print(type(tmp), tmp.dtype)
@@ -25,7 +31,7 @@ class TestUtilities:
         np.testing.assert_allclose(tmp @ tmp.conj().T, np.eye(d), atol=1e-15)
         np.testing.assert_allclose(tmp.conj().T @ tmp, np.eye(d), atol=1e-15)
 
-    def test_random_channel_success(self, fx_rng: Generator):
+    def test_random_channel_success(self, fx_rng: Generator) -> None:
 
         nqb = int(fx_rng.integers(1, 5))
         dim = 2**nqb  # fx_rng.integers(2, 8)
@@ -50,17 +56,17 @@ class TestUtilities:
         assert channel.size == rk
         assert channel.is_normalized
 
-    def test_random_channel_fail(self):
+    def test_random_channel_fail(self) -> None:
 
         # incorrect rank type
         with pytest.raises(TypeError):
-            mychannel = randobj.rand_channel_kraus(dim=2**2, rank=3.0)
+            _ = randobj.rand_channel_kraus(dim=2**2, rank=3.0)
 
         # null rank
         with pytest.raises(ValueError):
-            mychannel = randobj.rand_channel_kraus(dim=2**2, rank=0)
+            _ = randobj.rand_channel_kraus(dim=2**2, rank=0)
 
-    def test_rand_gauss_cpx(self, fx_rng: Generator):
+    def test_rand_gauss_cpx(self, fx_rng: Generator) -> None:
 
         nsample = int(1e4)
 
@@ -69,9 +75,9 @@ class TestUtilities:
 
         dimset = {i.shape for i in tmp}
         assert len(dimset) == 1
-        assert list(dimset)[0] == (dim, dim)
+        assert next(iter(dimset)) == (dim, dim)
 
-    def test_check_psd_success(self, fx_rng: Generator):
+    def test_check_psd_success(self, fx_rng: Generator) -> None:
 
         # Generate a random mixed state from state vectors with same probability
         # We know this is PSD
@@ -91,7 +97,7 @@ class TestUtilities:
 
         assert check_psd(dm)
 
-    def test_check_psd_fail(self, fx_rng: Generator):
+    def test_check_psd_fail(self, fx_rng: Generator) -> None:
 
         # not hermitian
         # don't use dim = 2, too easy to have a PSD matrix.
@@ -112,7 +118,7 @@ class TestUtilities:
         with pytest.raises(ValueError):
             check_psd(mat)
 
-    def test_rand_dm(self, fx_rng: Generator):
+    def test_rand_dm(self, fx_rng: Generator) -> None:
         # needs to be power of 2 dimension since builds a DM object
         dm = randobj.rand_dm(2 ** fx_rng.integers(2, 5))
 
@@ -123,11 +129,11 @@ class TestUtilities:
         assert check_unit_trace(dm.rho)
 
     # try with incorrect dimension
-    def test_rand_dm_fail(self, fx_rng: Generator):
+    def test_rand_dm_fail(self, fx_rng: Generator) -> None:
         with pytest.raises(ValueError):
-            dm = randobj.rand_dm(2 ** fx_rng.integers(2, 5) + 1)
+            _ = randobj.rand_dm(2 ** fx_rng.integers(2, 5) + 1)
 
-    def test_rand_dm_rank(self, fx_rng: Generator):
+    def test_rand_dm_rank(self, fx_rng: Generator) -> None:
 
         rk = 3
         dm = randobj.rand_dm(2 ** fx_rng.integers(2, 5), rank=rk)
@@ -145,46 +151,46 @@ class TestUtilities:
         assert rk == np.count_nonzero(evals)
 
     # TODO move that somewhere else?
-    def test_pauli_tensor_ops(self, fx_rng: Generator):
+    def test_pauli_tensor_ops(self, fx_rng: Generator) -> None:
         nqb = int(fx_rng.integers(2, 6))
-        Pauli_tensor_ops = Ops.build_tensor_Pauli_ops(nqb)
+        pauli_tensor_ops = Ops.build_tensor_Pauli_ops(nqb)
 
-        assert len(Pauli_tensor_ops) == 4**nqb
+        assert len(pauli_tensor_ops) == 4**nqb
 
-        dims = np.array([i.shape for i in Pauli_tensor_ops])
+        dims = np.array([i.shape for i in pauli_tensor_ops])
         # or np.apply_along_axis ?
         assert np.all(dims == (2**nqb, 2**nqb))
 
-    def test_pauli_tensor_ops_fail(self, fx_rng: Generator):
+    def test_pauli_tensor_ops_fail(self, fx_rng: Generator) -> None:
 
         with pytest.raises(TypeError):
-            Pauli_tensor_ops = Ops.build_tensor_Pauli_ops(fx_rng.integers(2, 6) + 0.5)
+            _ = Ops.build_tensor_Pauli_ops(fx_rng.integers(2, 6) + 0.5)
 
         with pytest.raises(ValueError):
-            Pauli_tensor_ops = Ops.build_tensor_Pauli_ops(0)
+            _ = Ops.build_tensor_Pauli_ops(0)
 
-    def test_random_pauli_channel_success(self, fx_rng: Generator):
+    def test_random_pauli_channel_success(self, fx_rng: Generator) -> None:
 
         nqb = int(fx_rng.integers(2, 6))
         rk = int(fx_rng.integers(1, 2**nqb + 1))
-        Pauli_channel = randobj.rand_Pauli_channel_kraus(dim=2**nqb, rank=rk)  # default is full rank
+        pauli_channel = randobj.rand_Pauli_channel_kraus(dim=2**nqb, rank=rk)  # default is full rank
 
-        assert isinstance(Pauli_channel, KrausChannel)
-        assert Pauli_channel.nqubit == nqb
-        assert Pauli_channel.size == rk
-        assert Pauli_channel.is_normalized
+        assert isinstance(pauli_channel, KrausChannel)
+        assert pauli_channel.nqubit == nqb
+        assert pauli_channel.size == rk
+        assert pauli_channel.is_normalized
 
-    def test_random_pauli_channel_fail(self):
+    def test_random_pauli_channel_fail(self) -> None:
         nqb = 3
         rk = 2
         with pytest.raises(TypeError):
-            dm = randobj.rand_Pauli_channel_kraus(dim=2**nqb, rank=rk + 0.5)
+            randobj.rand_Pauli_channel_kraus(dim=2**nqb, rank=rk + 0.5)
 
         with pytest.raises(ValueError):
-            dm = randobj.rand_Pauli_channel_kraus(dim=2**nqb + 0.5, rank=rk)
+            randobj.rand_Pauli_channel_kraus(dim=2**nqb + 0.5, rank=rk)
 
         with pytest.raises(ValueError):
-            dm = randobj.rand_Pauli_channel_kraus(dim=2**nqb, rank=-3)
+            randobj.rand_Pauli_channel_kraus(dim=2**nqb, rank=-3)
 
         with pytest.raises(ValueError):
-            dm = randobj.rand_Pauli_channel_kraus(dim=2**nqb + 1, rank=rk)
+            randobj.rand_Pauli_channel_kraus(dim=2**nqb + 1, rank=rk)

--- a/tests/test_random_utilities.py
+++ b/tests/test_random_utilities.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 class TestUtilities:
     def test_rand_herm(self, fx_rng: Generator) -> None:
         tmp = randobj.rand_herm(fx_rng.integers(2, 20))
-        np.testing.assert_allclose(tmp, tmp.conj().T)
+        assert np.allclose(tmp, tmp.conj().T)
 
     # TODO : work on that. Verify an a random vector and not at the operator level...
 
@@ -28,8 +28,8 @@ class TestUtilities:
         print(type(tmp), tmp.dtype)
 
         # different default values for testing.assert_allclose and all_close!
-        np.testing.assert_allclose(tmp @ tmp.conj().T, np.eye(d), atol=1e-15)
-        np.testing.assert_allclose(tmp.conj().T @ tmp, np.eye(d), atol=1e-15)
+        assert np.allclose(tmp @ tmp.conj().T, np.eye(d), atol=1e-15)
+        assert np.allclose(tmp.conj().T @ tmp, np.eye(d), atol=1e-15)
 
     def test_random_channel_success(self, fx_rng: Generator) -> None:
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import sys
 
 import numpy as np
+import numpy.typing as npt
 import pytest
-from pytest_mock import MockerFixture
 
 try:
     import qiskit
@@ -10,27 +12,33 @@ try:
 except ModuleNotFoundError:
     pass
 
+from typing import TYPE_CHECKING
+
 import graphix
-import tests.random_circuit as rc
 from graphix.device_interface import PatternRunner
 
+if TYPE_CHECKING:
+    from collections.abc import Collection
 
-def modify_statevector(statevector, output_qubit):
+    from pytest_mock import MockerFixture
+
+
+def modify_statevector(statevector: npt.ArrayLike, output_qubit: Collection[int]) -> npt.NDArray:
     statevector = np.asarray(statevector)
-    N = round(np.log2(len(statevector)))
+    n = round(np.log2(len(statevector)))
     new_statevector = np.zeros(2 ** len(output_qubit), dtype=complex)
     for i in range(len(statevector)):
-        i_str = format(i, f"0{N}b")
+        i_str = format(i, f"0{n}b")
         new_idx = ""
         for idx in output_qubit:
-            new_idx += i_str[N - idx - 1]
+            new_idx += i_str[n - idx - 1]
         new_statevector[int(new_idx, 2)] += statevector[i]
     return new_statevector
 
 
 class TestPatternRunner:
     @pytest.mark.skipif(sys.modules.get("qiskit") is None, reason="qiskit not installed")
-    def test_ibmq_backend(self, mocker: MockerFixture):
+    def test_ibmq_backend(self, mocker: MockerFixture) -> None:
         # circuit in qiskit
         qc = qiskit.QuantumCircuit(3)
         qc.h(0)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -77,4 +77,4 @@ class TestPatternRunner:
         state_qiskit = sim_result.get_statevector(runner.backend.circ)
         state_qiskit_mod = modify_statevector(state_qiskit, runner.backend.circ_output)
 
-        np.testing.assert_almost_equal(np.abs(np.dot(state_qiskit_mod.conjugate(), state.flatten())), 1)
+        assert np.abs(np.dot(state_qiskit_mod.conjugate(), state.flatten())) == pytest.approx(1)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,8 +1,8 @@
 import sys
-import unittest
 from unittest.mock import MagicMock
 
 import numpy as np
+import pytest
 
 try:
     import qiskit
@@ -34,8 +34,8 @@ def modify_statevector(statevector, output_qubit):
     return new_statevector
 
 
-class TestPatternRunner(unittest.TestCase):
-    @unittest.skipIf(sys.modules.get("qiskit") is None, "qiskit not installed")
+class TestPatternRunner:
+    @pytest.mark.skipif(sys.modules.get("qiskit") is None, reason="qiskit not installed")
     def test_ibmq_backend(self):
         # circuit in qiskit
         qc = qiskit.QuantumCircuit(3)
@@ -73,7 +73,3 @@ class TestPatternRunner(unittest.TestCase):
         state_qiskit_mod = modify_statevector(state_qiskit, runner.backend.circ_output)
 
         np.testing.assert_almost_equal(np.abs(np.dot(state_qiskit_mod.conjugate(), state.flatten())), 1)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_statevec_backend.py
+++ b/tests/test_statevec_backend.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from copy import deepcopy
 
 import numpy as np
@@ -8,7 +10,7 @@ from graphix.sim.statevec import Statevec, meas_op
 
 
 class TestStatevec:
-    def test_remove_one_qubit(self):
+    def test_remove_one_qubit(self) -> None:
         n = 10
         k = 3
 
@@ -25,7 +27,7 @@ class TestStatevec:
 
         np.testing.assert_almost_equal(np.abs(sv.psi.flatten().dot(sv2.psi.flatten().conj())), 1)
 
-    def test_measurement_into_each_XYZ_basis(self):
+    def test_measurement_into_each_xyz_basis(self) -> None:
         n = 3
         k = 0
         # for measurement into |-> returns [[0, 0], ..., [0, 0]] (whose norm is zero)
@@ -38,7 +40,7 @@ class TestStatevec:
             sv2 = Statevec(nqubit=n - 1)
             np.testing.assert_almost_equal(np.abs(sv.psi.flatten().dot(sv2.psi.flatten().conj())), 1)
 
-    def test_measurement_into_minus_state(self):
+    def test_measurement_into_minus_state(self) -> None:
         n = 3
         k = 0
         m_op = np.outer(States.minus, States.minus.T.conjugate())

--- a/tests/test_statevec_backend.py
+++ b/tests/test_statevec_backend.py
@@ -2,6 +2,7 @@ import unittest
 from copy import deepcopy
 
 import numpy as np
+import pytest
 
 from graphix.ops import States
 from graphix.sim.statevec import Statevec, meas_op
@@ -44,7 +45,7 @@ class TestStatevec(unittest.TestCase):
         m_op = np.outer(States.minus, States.minus.T.conjugate())
         sv = Statevec(nqubit=n)
         sv.evolve(m_op, [k])
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             sv.remove_qubit(k)
 
 

--- a/tests/test_statevec_backend.py
+++ b/tests/test_statevec_backend.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from copy import deepcopy
 
 import numpy as np
+import numpy.typing as npt
 import pytest
 
 from graphix.ops import States
@@ -27,18 +28,18 @@ class TestStatevec:
 
         assert np.abs(sv.psi.flatten().dot(sv2.psi.flatten().conj())) == pytest.approx(1)
 
-    def test_measurement_into_each_xyz_basis(self) -> None:
+    @pytest.mark.parametrize("state", [States.plus, States.zero, States.one, States.iplus, States.iminus])
+    def test_measurement_into_each_xyz_basis(self, state: npt.NDArray) -> None:
         n = 3
         k = 0
         # for measurement into |-> returns [[0, 0], ..., [0, 0]] (whose norm is zero)
-        for state in [States.plus, States.zero, States.one, States.iplus, States.iminus]:
-            m_op = np.outer(state, state.T.conjugate())
-            sv = Statevec(nqubit=n)
-            sv.evolve(m_op, [k])
-            sv.remove_qubit(k)
+        m_op = np.outer(state, state.T.conjugate())
+        sv = Statevec(nqubit=n)
+        sv.evolve(m_op, [k])
+        sv.remove_qubit(k)
 
-            sv2 = Statevec(nqubit=n - 1)
-            assert np.abs(sv.psi.flatten().dot(sv2.psi.flatten().conj())) == pytest.approx(1)
+        sv2 = Statevec(nqubit=n - 1)
+        assert np.abs(sv.psi.flatten().dot(sv2.psi.flatten().conj())) == pytest.approx(1)
 
     def test_measurement_into_minus_state(self) -> None:
         n = 3

--- a/tests/test_statevec_backend.py
+++ b/tests/test_statevec_backend.py
@@ -1,4 +1,3 @@
-import unittest
 from copy import deepcopy
 
 import numpy as np
@@ -8,7 +7,7 @@ from graphix.ops import States
 from graphix.sim.statevec import Statevec, meas_op
 
 
-class TestStatevec(unittest.TestCase):
+class TestStatevec:
     def test_remove_one_qubit(self):
         n = 10
         k = 3
@@ -47,7 +46,3 @@ class TestStatevec(unittest.TestCase):
         sv.evolve(m_op, [k])
         with pytest.raises(AssertionError):
             sv.remove_qubit(k)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_statevec_backend.py
+++ b/tests/test_statevec_backend.py
@@ -25,7 +25,7 @@ class TestStatevec:
         sv2.ptrace([k])
         sv2.normalize()
 
-        np.testing.assert_almost_equal(np.abs(sv.psi.flatten().dot(sv2.psi.flatten().conj())), 1)
+        assert np.abs(sv.psi.flatten().dot(sv2.psi.flatten().conj())) == pytest.approx(1)
 
     def test_measurement_into_each_xyz_basis(self) -> None:
         n = 3
@@ -38,7 +38,7 @@ class TestStatevec:
             sv.remove_qubit(k)
 
             sv2 = Statevec(nqubit=n - 1)
-            np.testing.assert_almost_equal(np.abs(sv.psi.flatten().dot(sv2.psi.flatten().conj())), 1)
+            assert np.abs(sv.psi.flatten().dot(sv2.psi.flatten().conj())) == pytest.approx(1)
 
     def test_measurement_into_minus_state(self) -> None:
         n = 3

--- a/tests/test_tnsim.py
+++ b/tests/test_tnsim.py
@@ -38,8 +38,8 @@ class TestTN:
 
         tn.add_qubit(node_index)
 
-        np.testing.assert_equal(set(tn.tag_map.keys()), {str(node_index), "Open"})
-        np.testing.assert_equal(tn.tensors[0].data, plus)
+        assert set(tn.tag_map.keys()) == {str(node_index), "Open"}
+        assert (tn.tensors[0].data == plus).all()
 
     def test_add_nodes(self, fx_rng: Generator) -> None:
         node_index = set(fx_rng.integers(0, 1000, 20))
@@ -48,9 +48,9 @@ class TestTN:
         tn.graph_prep = "sequential"
         tn.add_qubits(node_index)
 
-        np.testing.assert_equal(set(tn.tag_map.keys()), {str(ind) for ind in node_index} | {"Open"})
+        assert set(tn.tag_map.keys()) == {str(ind) for ind in node_index} | {"Open"}
         for tensor in tn.tensor_map.values():
-            np.testing.assert_equal(tensor.data, plus)
+            assert (tensor.data == plus).all()
 
     def test_entangle_nodes(self) -> None:
         random_vec = np.array([1.0, 1.0, 1.0, 1.0]).reshape(2, 2)

--- a/tests/test_tnsim.py
+++ b/tests/test_tnsim.py
@@ -70,7 +70,7 @@ class TestTN:
         contracted = tn.contract()
         # reference
         contracted_ref = np.einsum("abcd, c, d, ab->", CZ.reshape(2, 2, 2, 2), plus, plus, random_vec)
-        np.testing.assert_almost_equal(contracted, contracted_ref)
+        assert contracted == pytest.approx(contracted_ref)
 
     def test_apply_one_site_operator(self, fx_rng: Generator) -> None:
         cmds = [
@@ -101,7 +101,7 @@ class TestTN:
             CLIFFORD[cmds[2][2]],
         ]
         contracted_ref = np.einsum("i,ij,jk,kl,l", random_vec, ops[2], ops[1], ops[0], plus)
-        np.testing.assert_almost_equal(contracted, contracted_ref)
+        assert contracted == pytest.approx(contracted_ref)
 
     def test_expectation_value1(self, fx_rng: Generator) -> None:
         circuit = Circuit(1)
@@ -111,7 +111,7 @@ class TestTN:
         random_op1 = random_op(1, np.complex128, fx_rng)
         value1 = state.expectation_value(random_op1, [0])
         value2 = tn_mbqc.expectation_value(random_op1, [0])
-        np.testing.assert_almost_equal(value1, value2)
+        assert value1 == pytest.approx(value2)
 
     def test_expectation_value2(self, fx_rng: Generator) -> None:
         circuit = Circuit(2)
@@ -123,7 +123,7 @@ class TestTN:
         for qargs in itertools.permutations(input_list):
             value1 = state.expectation_value(random_op2, list(qargs))
             value2 = tn_mbqc.expectation_value(random_op2, list(qargs))
-            np.testing.assert_almost_equal(value1, value2)
+            assert value1 == pytest.approx(value2)
 
     def test_expectation_value3(self, fx_rng: Generator) -> None:
         circuit = Circuit(3)
@@ -135,7 +135,7 @@ class TestTN:
         for qargs in itertools.permutations(input_list):
             value1 = state.expectation_value(random_op3, list(qargs))
             value2 = tn_mbqc.expectation_value(random_op3, list(qargs))
-            np.testing.assert_almost_equal(value1, value2)
+            assert value1 == pytest.approx(value2)
 
     def test_expectation_value3_sequential(self, fx_rng: Generator) -> None:
         circuit = Circuit(3)
@@ -147,7 +147,7 @@ class TestTN:
         for qargs in itertools.permutations(input_list):
             value1 = state.expectation_value(random_op3, list(qargs))
             value2 = tn_mbqc.expectation_value(random_op3, list(qargs))
-            np.testing.assert_almost_equal(value1, value2)
+            assert value1 == pytest.approx(value2)
 
     def test_expectation_value3_subspace1(self, fx_rng: Generator) -> None:
         circuit = Circuit(3)
@@ -159,7 +159,7 @@ class TestTN:
         for qargs in itertools.permutations(input_list, 1):
             value1 = state.expectation_value(random_op1, list(qargs))
             value2 = tn_mbqc.expectation_value(random_op1, list(qargs))
-            np.testing.assert_almost_equal(value1, value2)
+            assert value1 == pytest.approx(value2)
 
     def test_expectation_value3_subspace2(self, fx_rng: Generator) -> None:
         circuit = Circuit(3)
@@ -171,7 +171,7 @@ class TestTN:
         for qargs in itertools.permutations(input_list, 2):
             value1 = state.expectation_value(random_op2, list(qargs))
             value2 = tn_mbqc.expectation_value(random_op2, list(qargs))
-            np.testing.assert_almost_equal(value1, value2)
+            assert value1 == pytest.approx(value2)
 
     def test_expectation_value3_subspace2_sequential(self, fx_rng: Generator) -> None:
         circuit = Circuit(3)
@@ -183,7 +183,7 @@ class TestTN:
         for qargs in itertools.permutations(input_list, 2):
             value1 = state.expectation_value(random_op2, list(qargs))
             value2 = tn_mbqc.expectation_value(random_op2, list(qargs))
-            np.testing.assert_almost_equal(value1, value2)
+            assert value1 == pytest.approx(value2)
 
     def test_hadamard(self, fx_rng: Generator) -> None:
         circuit = Circuit(1)
@@ -195,10 +195,7 @@ class TestTN:
         random_op1 = random_op(1, np.complex128, fx_rng)
         value1 = state.expectation_value(random_op1, [0])
         value2 = tn_mbqc.expectation_value(random_op1, [0])
-        np.testing.assert_almost_equal(
-            value1,
-            value2,
-        )
+        assert value1 == pytest.approx(value2)
 
     def test_s(self, fx_rng: Generator) -> None:
         circuit = Circuit(1)
@@ -209,7 +206,7 @@ class TestTN:
         random_op1 = random_op(1, np.complex128, fx_rng)
         value1 = state.expectation_value(random_op1, [0])
         value2 = tn_mbqc.expectation_value(random_op1, [0])
-        np.testing.assert_almost_equal(value1, value2)
+        assert value1 == pytest.approx(value2)
 
     def test_x(self, fx_rng: Generator) -> None:
         circuit = Circuit(1)
@@ -220,7 +217,7 @@ class TestTN:
         random_op1 = random_op(1, np.complex128, fx_rng)
         value1 = state.expectation_value(random_op1, [0])
         value2 = tn_mbqc.expectation_value(random_op1, [0])
-        np.testing.assert_almost_equal(value1, value2)
+        assert value1 == pytest.approx(value2)
 
     def test_y(self, fx_rng: Generator) -> None:
         circuit = Circuit(1)
@@ -231,7 +228,7 @@ class TestTN:
         random_op1 = random_op(1, np.complex128, fx_rng)
         value1 = state.expectation_value(random_op1, [0])
         value2 = tn_mbqc.expectation_value(random_op1, [0])
-        np.testing.assert_almost_equal(value1, value2)
+        assert value1 == pytest.approx(value2)
 
     def test_z(self, fx_rng: Generator) -> None:
         circuit = Circuit(1)
@@ -242,7 +239,7 @@ class TestTN:
         random_op1 = random_op(1, np.complex128, fx_rng)
         value1 = state.expectation_value(random_op1, [0])
         value2 = tn_mbqc.expectation_value(random_op1, [0])
-        np.testing.assert_almost_equal(value1, value2)
+        assert value1 == pytest.approx(value2)
 
     def test_rx(self, fx_rng: Generator) -> None:
         theta = fx_rng.uniform() * 2 * np.pi
@@ -254,7 +251,7 @@ class TestTN:
         random_op1 = random_op(1, np.complex128, fx_rng)
         value1 = state.expectation_value(random_op1, [0])
         value2 = tn_mbqc.expectation_value(random_op1, [0])
-        np.testing.assert_almost_equal(value1, value2)
+        assert value1 == pytest.approx(value2)
 
     def test_ry(self, fx_rng: Generator) -> None:
         theta = fx_rng.uniform() * 2 * np.pi
@@ -266,7 +263,7 @@ class TestTN:
         random_op1 = random_op(1, np.complex128, fx_rng)
         value1 = state.expectation_value(random_op1, [0])
         value2 = tn_mbqc.expectation_value(random_op1, [0])
-        np.testing.assert_almost_equal(value1, value2)
+        assert value1 == pytest.approx(value2)
 
     def test_rz(self, fx_rng: Generator) -> None:
         theta = fx_rng.uniform() * 2 * np.pi
@@ -278,7 +275,7 @@ class TestTN:
         random_op1 = random_op(1, np.complex128, fx_rng)
         value1 = state.expectation_value(random_op1, [0])
         value2 = tn_mbqc.expectation_value(random_op1, [0])
-        np.testing.assert_almost_equal(value1, value2)
+        assert value1 == pytest.approx(value2)
 
     def test_i(self, fx_rng: Generator) -> None:
         circuit = Circuit(1)
@@ -289,7 +286,7 @@ class TestTN:
         random_op1 = random_op(1, np.complex128, fx_rng)
         value1 = state.expectation_value(random_op1, [0])
         value2 = tn_mbqc.expectation_value(random_op1, [0])
-        np.testing.assert_almost_equal(value1, value2)
+        assert value1 == pytest.approx(value2)
 
     def test_cnot(self, fx_rng: Generator) -> None:
         circuit = Circuit(2)
@@ -301,7 +298,7 @@ class TestTN:
         random_op2 = random_op(2, np.complex128, fx_rng)
         value1 = state.expectation_value(random_op2, [0, 1])
         value2 = tn_mbqc.expectation_value(random_op2, [0, 1])
-        np.testing.assert_almost_equal(value1, value2)
+        assert value1 == pytest.approx(value2)
 
     def test_ccx(self, fx_rng: Generator) -> None:
         for _ in range(10):
@@ -314,7 +311,7 @@ class TestTN:
             random_op3 = random_op(3, np.complex128, fx_rng)
             value1 = state.expectation_value(random_op3, [0, 1, 2])
             value2 = tn_mbqc.expectation_value(random_op3, [0, 1, 2])
-            np.testing.assert_almost_equal(value1, value2)
+            assert value1 == pytest.approx(value2)
 
     def test_with_graphtrans(self, fx_rng: Generator) -> None:
         for _ in range(10):
@@ -330,7 +327,7 @@ class TestTN:
             for qargs in itertools.permutations(input_list):
                 value1 = state.expectation_value(random_op3, list(qargs))
                 value2 = tn_mbqc.expectation_value(random_op3, list(qargs))
-                np.testing.assert_almost_equal(value1, value2)
+                assert value1 == pytest.approx(value2)
 
     def test_with_graphtrans_sequential(self, fx_rng: Generator) -> None:
         for _ in range(10):
@@ -347,7 +344,7 @@ class TestTN:
             for qargs in itertools.permutations(input_list):
                 value1 = state.expectation_value(random_op3, list(qargs))
                 value2 = tn_mbqc.expectation_value(random_op3, list(qargs))
-                np.testing.assert_almost_equal(value1, value2)
+                assert value1 == pytest.approx(value2)
 
     def test_coef_state(self, fx_rng: Generator) -> None:
         for _ in range(10):
@@ -362,7 +359,7 @@ class TestTN:
                 coef_tn = tn.get_basis_coefficient(number)
                 coef_sv = statevec_ref.flatten()[number]
 
-                np.testing.assert_almost_equal(abs(coef_tn), abs(coef_sv))
+                assert abs(coef_tn) == pytest.approx(abs(coef_sv))
 
     @pytest.mark.parametrize("nqubits", range(2, 6))
     def test_to_statevector(self, nqubits: int, fx_rng: Generator) -> None:
@@ -375,7 +372,7 @@ class TestTN:
             statevec_tn = tn.to_statevector()
 
             inner_product = np.inner(statevec_tn, statevec_ref.flatten().conjugate())
-            np.testing.assert_almost_equal(abs(inner_product), 1)
+            assert abs(inner_product) == pytest.approx(1)
 
     def test_evolve(self, fx_rng: Generator) -> None:
         for _ in range(10):
@@ -395,4 +392,4 @@ class TestTN:
             expval_tn = tn_mbqc.expectation_value(random_op3_exp, [0, 1, 2])
             expval_ref = state.expectation_value(random_op3_exp, [0, 1, 2])
 
-            np.testing.assert_almost_equal(expval_tn, expval_ref)
+            assert expval_tn == pytest.approx(expval_ref)

--- a/tests/test_tnsim.py
+++ b/tests/test_tnsim.py
@@ -1,7 +1,7 @@
 import itertools
-import unittest
 
 import numpy as np
+import pytest
 from quimb.tensor import Tensor
 
 import tests.random_circuit as rc
@@ -24,11 +24,16 @@ def random_op(sites, dtype=np.complex128, seed=0):
     return np.random.randn(size, size).astype(dtype)
 
 
+def rc_iterator(tgt_nqubits, tgt_depth, repeat):
+    for nqubits, depth, _ in itertools.product(tgt_nqubits, tgt_depth, range(repeat)):
+        yield rc.get_rand_circuit(nqubits, depth)
+
+
 CZ = Ops.cz
 plus = States.plus
 
 
-class TestTN(unittest.TestCase):
+class TestTN:
     def test_add_node(self):
         node_index = np.random.randint(0, 1000)
         tn = MBQCTensorNet()
@@ -302,112 +307,87 @@ class TestTN(unittest.TestCase):
         value2 = tn_mbqc.expectation_value(random_op2, [0, 1])
         np.testing.assert_almost_equal(value1, value2)
 
-    def test_ccx(self):
-        nqubits = 4
-        depth = 6
-        for _ in range(10):
-            circuit = rc.get_rand_circuit(nqubits, depth)
-            circuit.ccx(0, 1, 2)
-            pattern = circuit.transpile().pattern
-            pattern.minimize_space()
-            state = circuit.simulate_statevector().statevec
-            tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
-            random_op3 = random_op(3)
-            value1 = state.expectation_value(random_op3, [0, 1, 2])
-            value2 = tn_mbqc.expectation_value(random_op3, [0, 1, 2])
+    @pytest.mark.parametrize("circuit", rc_iterator([4], [6], 10))
+    def test_ccx(self, circuit):
+        circuit.ccx(0, 1, 2)
+        pattern = circuit.transpile().pattern
+        pattern.minimize_space()
+        state = circuit.simulate_statevector().statevec
+        tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
+        random_op3 = random_op(3)
+        value1 = state.expectation_value(random_op3, [0, 1, 2])
+        value2 = tn_mbqc.expectation_value(random_op3, [0, 1, 2])
+        np.testing.assert_almost_equal(value1, value2)
+
+    @pytest.mark.parametrize("circuit", rc_iterator([4], [6], 10))
+    def test_with_graphtrans(self, circuit):
+        pattern = circuit.transpile().pattern
+        pattern.standardize()
+        pattern.shift_signals()
+        pattern.perform_pauli_measurements()
+        state = circuit.simulate_statevector().statevec
+        tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
+        random_op3 = random_op(3)
+        input = [0, 1, 2]
+        for qargs in itertools.permutations(input):
+            value1 = state.expectation_value(random_op3, list(qargs))
+            value2 = tn_mbqc.expectation_value(random_op3, list(qargs))
             np.testing.assert_almost_equal(value1, value2)
 
-    def test_with_graphtrans(self):
-        nqubits = 4
-        depth = 6
-        for i in range(10):
-            circuit = rc.get_rand_circuit(nqubits, depth)
-            pattern = circuit.transpile().pattern
-            pattern.standardize()
-            pattern.shift_signals()
-            pattern.perform_pauli_measurements()
-            state = circuit.simulate_statevector().statevec
-            tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
-            random_op3 = random_op(3)
-            input = [0, 1, 2]
-            for qargs in itertools.permutations(input):
-                value1 = state.expectation_value(random_op3, list(qargs))
-                value2 = tn_mbqc.expectation_value(random_op3, list(qargs))
-                np.testing.assert_almost_equal(value1, value2)
+    @pytest.mark.parametrize("circuit", rc_iterator([4], [6], 10))
+    def test_with_graphtrans_sequential(self, circuit):
+        pattern = circuit.transpile().pattern
+        pattern.standardize()
+        pattern.shift_signals()
+        pattern.perform_pauli_measurements()
+        state = circuit.simulate_statevector().statevec
+        tn_mbqc = pattern.simulate_pattern(backend="tensornetwork", graph_prep="sequential")
+        random_op3 = random_op(3)
+        input = [0, 1, 2]
+        for qargs in itertools.permutations(input):
+            value1 = state.expectation_value(random_op3, list(qargs))
+            value2 = tn_mbqc.expectation_value(random_op3, list(qargs))
+            np.testing.assert_almost_equal(value1, value2)
 
-    def test_with_graphtrans_sequential(self):
-        nqubits = 4
-        depth = 6
-        for i in range(10):
-            circuit = rc.get_rand_circuit(nqubits, depth)
-            pattern = circuit.transpile().pattern
-            pattern.standardize()
-            pattern.shift_signals()
-            pattern.perform_pauli_measurements()
-            state = circuit.simulate_statevector().statevec
-            tn_mbqc = pattern.simulate_pattern(backend="tensornetwork", graph_prep="sequential")
-            random_op3 = random_op(3)
-            input = [0, 1, 2]
-            for qargs in itertools.permutations(input):
-                value1 = state.expectation_value(random_op3, list(qargs))
-                value2 = tn_mbqc.expectation_value(random_op3, list(qargs))
-                np.testing.assert_almost_equal(value1, value2)
+    @pytest.mark.parametrize("circuit", rc_iterator([4], [2], 10))
+    def test_coef_state(self, circuit):
+        pattern = circuit.standardize_and_transpile().pattern
 
-    def test_coef_state(self):
-        nqubits = 4
-        depth = 2
-        for i in range(10):
-            circuit = rc.get_rand_circuit(nqubits, depth)
-            pattern = circuit.standardize_and_transpile().pattern
+        statevec_ref = circuit.simulate_statevector().statevec
 
-            statevec_ref = circuit.simulate_statevector().statevec
+        tn = pattern.simulate_pattern("tensornetwork")
+        for number in range(len(statevec_ref.flatten())):
+            coef_tn = tn.get_basis_coefficient(number)
+            coef_sv = statevec_ref.flatten()[number]
 
-            tn = pattern.simulate_pattern("tensornetwork")
-            for number in range(len(statevec_ref.flatten())):
-                self.subTest(number=number)
-                coef_tn = tn.get_basis_coefficient(number)
-                coef_sv = statevec_ref.flatten()[number]
+            np.testing.assert_almost_equal(abs(coef_tn), abs(coef_sv))
 
-                np.testing.assert_almost_equal(abs(coef_tn), abs(coef_sv))
+    @pytest.mark.parametrize("circuit", rc_iterator(range(2, 6), [3], 5))
+    def test_to_statevector(self, circuit):
+        pattern = circuit.standardize_and_transpile().pattern
+        statevec_ref = circuit.simulate_statevector().statevec
 
-    def test_to_statevector(self):
-        nqubits_set = [i for i in range(2, 6)]
-        depth = 3
-        for nqubits in nqubits_set:
-            self.subTest(nqubit=nqubits)
-            for i in range(5):
-                circuit = rc.get_rand_circuit(nqubits, depth)
-                pattern = circuit.standardize_and_transpile().pattern
-                statevec_ref = circuit.simulate_statevector().statevec
+        tn = pattern.simulate_pattern("tensornetwork")
+        statevec_tn = tn.to_statevector()
 
-                tn = pattern.simulate_pattern("tensornetwork")
-                statevec_tn = tn.to_statevector()
+        inner_product = np.inner(statevec_tn, statevec_ref.flatten().conjugate())
+        np.testing.assert_almost_equal(abs(inner_product), 1)
 
-                inner_product = np.inner(statevec_tn, statevec_ref.flatten().conjugate())
-                np.testing.assert_almost_equal(abs(inner_product), 1)
+    @pytest.mark.parametrize("circuit", rc_iterator([4], [6], 10))
+    def test_evolve(self, circuit):
+        pattern = circuit.transpile().pattern
+        pattern.standardize()
+        pattern.shift_signals()
+        pattern.perform_pauli_measurements()
+        state = circuit.simulate_statevector().statevec
+        tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
+        random_op3 = random_op(3)
+        random_op3_exp = random_op(3)
 
-    def test_evolve(self):
-        nqubits = 4
-        depth = 6
-        for i in range(10):
-            circuit = rc.get_rand_circuit(nqubits, depth)
-            pattern = circuit.transpile().pattern
-            pattern.standardize()
-            pattern.shift_signals()
-            pattern.perform_pauli_measurements()
-            state = circuit.simulate_statevector().statevec
-            tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
-            random_op3 = random_op(3)
-            random_op3_exp = random_op(3)
+        state.evolve(random_op3, [0, 1, 2])
+        tn_mbqc.evolve(random_op3, [0, 1, 2], decompose=False)
 
-            state.evolve(random_op3, [0, 1, 2])
-            tn_mbqc.evolve(random_op3, [0, 1, 2], decompose=False)
+        expval_tn = tn_mbqc.expectation_value(random_op3_exp, [0, 1, 2])
+        expval_ref = state.expectation_value(random_op3_exp, [0, 1, 2])
 
-            expval_tn = tn_mbqc.expectation_value(random_op3_exp, [0, 1, 2])
-            expval_ref = state.expectation_value(random_op3_exp, [0, 1, 2])
-
-            np.testing.assert_almost_equal(expval_tn, expval_ref)
-
-
-if __name__ == "__main__":
-    unittest.main()
+        np.testing.assert_almost_equal(expval_tn, expval_ref)

--- a/tests/test_tnsim.py
+++ b/tests/test_tnsim.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 import itertools
-from collections.abc import Iterable, Iterator
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
 import pytest
-from numpy.random import Generator
 from quimb.tensor import Tensor
 
 import tests.random_circuit as rc
@@ -14,6 +13,9 @@ from graphix.clifford import CLIFFORD
 from graphix.ops import Ops, States
 from graphix.sim.tensornet import MBQCTensorNet, gen_str
 from graphix.transpiler import Circuit
+
+if TYPE_CHECKING:
+    from numpy.random import Generator
 
 
 def random_op(sites: int, dtype: type, rng: Generator) -> npt.NDArray:
@@ -30,7 +32,7 @@ plus = States.plus
 
 
 class TestTN:
-    def test_add_node(self, fx_rng: Generator):
+    def test_add_node(self, fx_rng: Generator) -> None:
         node_index = fx_rng.integers(0, 1000)
         tn = MBQCTensorNet()
 
@@ -39,31 +41,29 @@ class TestTN:
         np.testing.assert_equal(set(tn.tag_map.keys()), {str(node_index), "Open"})
         np.testing.assert_equal(tn.tensors[0].data, plus)
 
-    def test_add_nodes(self, fx_rng: Generator):
+    def test_add_nodes(self, fx_rng: Generator) -> None:
         node_index = set(fx_rng.integers(0, 1000, 20))
         tn = MBQCTensorNet()
 
         tn.graph_prep = "sequential"
         tn.add_qubits(node_index)
 
-        np.testing.assert_equal(set(tn.tag_map.keys()), set([str(ind) for ind in node_index]) | {"Open"})
+        np.testing.assert_equal(set(tn.tag_map.keys()), {str(ind) for ind in node_index} | {"Open"})
         for tensor in tn.tensor_map.values():
             np.testing.assert_equal(tensor.data, plus)
 
-    def test_entangle_nodes(self):
+    def test_entangle_nodes(self) -> None:
         random_vec = np.array([1.0, 1.0, 1.0, 1.0]).reshape(2, 2)
         circuit = Circuit(2)
         pattern = circuit.transpile().pattern
         pattern.add(["E", (0, 1)])
         tn = pattern.simulate_pattern(backend="tensornetwork", graph_prep="sequential")
         dummy_index = [gen_str() for _ in range(2)]
-        qubit_index = 0
-        for n in tn._dangling.keys():
+        for qubit_index, n in enumerate(tn._dangling):
             ind = tn._dangling[n]
             tids = tn._get_tids_from_inds(ind)
             tensor = tn.tensor_map[tids.popleft()]
             tensor.reindex({ind: dummy_index[qubit_index]}, inplace=True)
-            qubit_index += 1
 
         random_vec_ts = Tensor(random_vec, dummy_index, ["random_vector"])
         tn.add_tensor(random_vec_ts)
@@ -72,7 +72,7 @@ class TestTN:
         contracted_ref = np.einsum("abcd, c, d, ab->", CZ.reshape(2, 2, 2, 2), plus, plus, random_vec)
         np.testing.assert_almost_equal(contracted, contracted_ref)
 
-    def test_apply_one_site_operator(self, fx_rng: Generator):
+    def test_apply_one_site_operator(self, fx_rng: Generator) -> None:
         cmds = [
             ["X", 0, [15]],
             ["Z", 0, [15]],
@@ -103,7 +103,7 @@ class TestTN:
         contracted_ref = np.einsum("i,ij,jk,kl,l", random_vec, ops[2], ops[1], ops[0], plus)
         np.testing.assert_almost_equal(contracted, contracted_ref)
 
-    def test_expectation_value1(self, fx_rng: Generator):
+    def test_expectation_value1(self, fx_rng: Generator) -> None:
         circuit = Circuit(1)
         state = circuit.simulate_statevector().statevec
         pattern = circuit.transpile().pattern
@@ -113,79 +113,79 @@ class TestTN:
         value2 = tn_mbqc.expectation_value(random_op1, [0])
         np.testing.assert_almost_equal(value1, value2)
 
-    def test_expectation_value2(self, fx_rng: Generator):
+    def test_expectation_value2(self, fx_rng: Generator) -> None:
         circuit = Circuit(2)
         state = circuit.simulate_statevector().statevec
         pattern = circuit.transpile().pattern
         tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
         random_op2 = random_op(2, np.complex128, fx_rng)
-        input = [0, 1]
-        for qargs in itertools.permutations(input):
+        input_list = [0, 1]
+        for qargs in itertools.permutations(input_list):
             value1 = state.expectation_value(random_op2, list(qargs))
             value2 = tn_mbqc.expectation_value(random_op2, list(qargs))
             np.testing.assert_almost_equal(value1, value2)
 
-    def test_expectation_value3(self, fx_rng: Generator):
+    def test_expectation_value3(self, fx_rng: Generator) -> None:
         circuit = Circuit(3)
         state = circuit.simulate_statevector().statevec
         pattern = circuit.transpile().pattern
         tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
         random_op3 = random_op(3, np.complex128, fx_rng)
-        input = [0, 1, 2]
-        for qargs in itertools.permutations(input):
+        input_list = [0, 1, 2]
+        for qargs in itertools.permutations(input_list):
             value1 = state.expectation_value(random_op3, list(qargs))
             value2 = tn_mbqc.expectation_value(random_op3, list(qargs))
             np.testing.assert_almost_equal(value1, value2)
 
-    def test_expectation_value3_sequential(self, fx_rng: Generator):
+    def test_expectation_value3_sequential(self, fx_rng: Generator) -> None:
         circuit = Circuit(3)
         state = circuit.simulate_statevector().statevec
         pattern = circuit.transpile().pattern
         tn_mbqc = pattern.simulate_pattern(backend="tensornetwork", graph_prep="sequential")
         random_op3 = random_op(3, np.complex128, fx_rng)
-        input = [0, 1, 2]
-        for qargs in itertools.permutations(input):
+        input_list = [0, 1, 2]
+        for qargs in itertools.permutations(input_list):
             value1 = state.expectation_value(random_op3, list(qargs))
             value2 = tn_mbqc.expectation_value(random_op3, list(qargs))
             np.testing.assert_almost_equal(value1, value2)
 
-    def test_expectation_value3_subspace1(self, fx_rng: Generator):
+    def test_expectation_value3_subspace1(self, fx_rng: Generator) -> None:
         circuit = Circuit(3)
         state = circuit.simulate_statevector().statevec
         pattern = circuit.transpile().pattern
         tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
         random_op1 = random_op(1, np.complex128, fx_rng)
-        input = [0, 1, 2]
-        for qargs in itertools.permutations(input, 1):
+        input_list = [0, 1, 2]
+        for qargs in itertools.permutations(input_list, 1):
             value1 = state.expectation_value(random_op1, list(qargs))
             value2 = tn_mbqc.expectation_value(random_op1, list(qargs))
             np.testing.assert_almost_equal(value1, value2)
 
-    def test_expectation_value3_subspace2(self, fx_rng: Generator):
+    def test_expectation_value3_subspace2(self, fx_rng: Generator) -> None:
         circuit = Circuit(3)
         state = circuit.simulate_statevector().statevec
         pattern = circuit.transpile().pattern
         tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
         random_op2 = random_op(2, np.complex128, fx_rng)
-        input = [0, 1, 2]
-        for qargs in itertools.permutations(input, 2):
+        input_list = [0, 1, 2]
+        for qargs in itertools.permutations(input_list, 2):
             value1 = state.expectation_value(random_op2, list(qargs))
             value2 = tn_mbqc.expectation_value(random_op2, list(qargs))
             np.testing.assert_almost_equal(value1, value2)
 
-    def test_expectation_value3_subspace2_sequential(self, fx_rng: Generator):
+    def test_expectation_value3_subspace2_sequential(self, fx_rng: Generator) -> None:
         circuit = Circuit(3)
         state = circuit.simulate_statevector().statevec
         pattern = circuit.transpile().pattern
         tn_mbqc = pattern.simulate_pattern(backend="tensornetwork", graph_prep="sequential")
         random_op2 = random_op(2, np.complex128, fx_rng)
-        input = [0, 1, 2]
-        for qargs in itertools.permutations(input, 2):
+        input_list = [0, 1, 2]
+        for qargs in itertools.permutations(input_list, 2):
             value1 = state.expectation_value(random_op2, list(qargs))
             value2 = tn_mbqc.expectation_value(random_op2, list(qargs))
             np.testing.assert_almost_equal(value1, value2)
 
-    def test_hadamard(self, fx_rng: Generator):
+    def test_hadamard(self, fx_rng: Generator) -> None:
         circuit = Circuit(1)
         circuit.h(0)
         pattern = circuit.transpile().pattern
@@ -200,7 +200,7 @@ class TestTN:
             value2,
         )
 
-    def test_s(self, fx_rng: Generator):
+    def test_s(self, fx_rng: Generator) -> None:
         circuit = Circuit(1)
         circuit.s(0)
         pattern = circuit.transpile().pattern
@@ -211,7 +211,7 @@ class TestTN:
         value2 = tn_mbqc.expectation_value(random_op1, [0])
         np.testing.assert_almost_equal(value1, value2)
 
-    def test_x(self, fx_rng: Generator):
+    def test_x(self, fx_rng: Generator) -> None:
         circuit = Circuit(1)
         circuit.x(0)
         pattern = circuit.transpile().pattern
@@ -222,7 +222,7 @@ class TestTN:
         value2 = tn_mbqc.expectation_value(random_op1, [0])
         np.testing.assert_almost_equal(value1, value2)
 
-    def test_y(self, fx_rng: Generator):
+    def test_y(self, fx_rng: Generator) -> None:
         circuit = Circuit(1)
         circuit.y(0)
         pattern = circuit.transpile().pattern
@@ -233,7 +233,7 @@ class TestTN:
         value2 = tn_mbqc.expectation_value(random_op1, [0])
         np.testing.assert_almost_equal(value1, value2)
 
-    def test_z(self, fx_rng: Generator):
+    def test_z(self, fx_rng: Generator) -> None:
         circuit = Circuit(1)
         circuit.z(0)
         pattern = circuit.transpile().pattern
@@ -244,7 +244,7 @@ class TestTN:
         value2 = tn_mbqc.expectation_value(random_op1, [0])
         np.testing.assert_almost_equal(value1, value2)
 
-    def test_rx(self, fx_rng: Generator):
+    def test_rx(self, fx_rng: Generator) -> None:
         theta = fx_rng.uniform() * 2 * np.pi
         circuit = Circuit(1)
         circuit.rx(0, theta)
@@ -256,7 +256,7 @@ class TestTN:
         value2 = tn_mbqc.expectation_value(random_op1, [0])
         np.testing.assert_almost_equal(value1, value2)
 
-    def test_ry(self, fx_rng: Generator):
+    def test_ry(self, fx_rng: Generator) -> None:
         theta = fx_rng.uniform() * 2 * np.pi
         circuit = Circuit(1)
         circuit.ry(0, theta)
@@ -268,7 +268,7 @@ class TestTN:
         value2 = tn_mbqc.expectation_value(random_op1, [0])
         np.testing.assert_almost_equal(value1, value2)
 
-    def test_rz(self, fx_rng: Generator):
+    def test_rz(self, fx_rng: Generator) -> None:
         theta = fx_rng.uniform() * 2 * np.pi
         circuit = Circuit(1)
         circuit.rz(0, theta)
@@ -280,7 +280,7 @@ class TestTN:
         value2 = tn_mbqc.expectation_value(random_op1, [0])
         np.testing.assert_almost_equal(value1, value2)
 
-    def test_i(self, fx_rng: Generator):
+    def test_i(self, fx_rng: Generator) -> None:
         circuit = Circuit(1)
         circuit.i(0)
         pattern = circuit.transpile().pattern
@@ -291,7 +291,7 @@ class TestTN:
         value2 = tn_mbqc.expectation_value(random_op1, [0])
         np.testing.assert_almost_equal(value1, value2)
 
-    def test_cnot(self, fx_rng: Generator):
+    def test_cnot(self, fx_rng: Generator) -> None:
         circuit = Circuit(2)
         circuit.cnot(0, 1)
         pattern = circuit.transpile().pattern
@@ -303,7 +303,7 @@ class TestTN:
         value2 = tn_mbqc.expectation_value(random_op2, [0, 1])
         np.testing.assert_almost_equal(value1, value2)
 
-    def test_ccx(self, fx_rng: Generator):
+    def test_ccx(self, fx_rng: Generator) -> None:
         for _ in range(10):
             circuit = rc.get_rand_circuit(4, 6, fx_rng)
             circuit.ccx(0, 1, 2)
@@ -316,7 +316,7 @@ class TestTN:
             value2 = tn_mbqc.expectation_value(random_op3, [0, 1, 2])
             np.testing.assert_almost_equal(value1, value2)
 
-    def test_with_graphtrans(self, fx_rng: Generator):
+    def test_with_graphtrans(self, fx_rng: Generator) -> None:
         for _ in range(10):
             circuit = rc.get_rand_circuit(4, 6, fx_rng)
             pattern = circuit.transpile().pattern
@@ -326,13 +326,13 @@ class TestTN:
             state = circuit.simulate_statevector().statevec
             tn_mbqc = pattern.simulate_pattern(backend="tensornetwork")
             random_op3 = random_op(3, np.complex128, fx_rng)
-            input = [0, 1, 2]
-            for qargs in itertools.permutations(input):
+            input_list = [0, 1, 2]
+            for qargs in itertools.permutations(input_list):
                 value1 = state.expectation_value(random_op3, list(qargs))
                 value2 = tn_mbqc.expectation_value(random_op3, list(qargs))
                 np.testing.assert_almost_equal(value1, value2)
 
-    def test_with_graphtrans_sequential(self, fx_rng: Generator):
+    def test_with_graphtrans_sequential(self, fx_rng: Generator) -> None:
         for _ in range(10):
             circuit = rc.get_rand_circuit(4, 6, fx_rng)
             pattern = circuit.transpile().pattern
@@ -343,13 +343,13 @@ class TestTN:
             state = circuit.simulate_statevector().statevec
             tn_mbqc = pattern.simulate_pattern(backend="tensornetwork", graph_prep="sequential")
             random_op3 = random_op(3, np.complex128, fx_rng)
-            input = [0, 1, 2]
-            for qargs in itertools.permutations(input):
+            input_list = [0, 1, 2]
+            for qargs in itertools.permutations(input_list):
                 value1 = state.expectation_value(random_op3, list(qargs))
                 value2 = tn_mbqc.expectation_value(random_op3, list(qargs))
                 np.testing.assert_almost_equal(value1, value2)
 
-    def test_coef_state(self, fx_rng: Generator):
+    def test_coef_state(self, fx_rng: Generator) -> None:
         for _ in range(10):
             circuit = rc.get_rand_circuit(4, 2, fx_rng)
 
@@ -365,7 +365,7 @@ class TestTN:
                 np.testing.assert_almost_equal(abs(coef_tn), abs(coef_sv))
 
     @pytest.mark.parametrize("nqubits", range(2, 6))
-    def test_to_statevector(self, nqubits: int, fx_rng: Generator):
+    def test_to_statevector(self, nqubits: int, fx_rng: Generator) -> None:
         for _ in range(5):
             circuit = rc.get_rand_circuit(nqubits, 3, fx_rng)
             pattern = circuit.standardize_and_transpile().pattern
@@ -377,7 +377,7 @@ class TestTN:
             inner_product = np.inner(statevec_tn, statevec_ref.flatten().conjugate())
             np.testing.assert_almost_equal(abs(inner_product), 1)
 
-    def test_evolve(self, fx_rng: Generator):
+    def test_evolve(self, fx_rng: Generator) -> None:
         for _ in range(10):
             circuit = rc.get_rand_circuit(4, 6, fx_rng)
             pattern = circuit.transpile().pattern

--- a/tests/test_transpiler.py
+++ b/tests/test_transpiler.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import numpy as np
 import pytest
 from numpy.random import PCG64, Generator

--- a/tests/test_transpiler.py
+++ b/tests/test_transpiler.py
@@ -1,14 +1,20 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import numpy as np
-from numpy.random import Generator
 
 import graphix.pauli
 import graphix.simulator
 import tests.random_circuit as rc
 from graphix.transpiler import Circuit
 
+if TYPE_CHECKING:
+    from numpy.random import Generator
 
-class TestTranspiler_UnitGates:
-    def test_cnot(self):
+
+class TestTranspilerUnitGates:
+    def test_cnot(self) -> None:
         circuit = Circuit(2)
         circuit.cnot(0, 1)
         pattern = circuit.transpile().pattern
@@ -16,7 +22,7 @@ class TestTranspiler_UnitGates:
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_hadamard(self):
+    def test_hadamard(self) -> None:
         circuit = Circuit(1)
         circuit.h(0)
         pattern = circuit.transpile().pattern
@@ -24,7 +30,7 @@ class TestTranspiler_UnitGates:
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_s(self):
+    def test_s(self) -> None:
         circuit = Circuit(1)
         circuit.s(0)
         pattern = circuit.transpile().pattern
@@ -32,7 +38,7 @@ class TestTranspiler_UnitGates:
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_x(self):
+    def test_x(self) -> None:
         circuit = Circuit(1)
         circuit.x(0)
         pattern = circuit.transpile().pattern
@@ -40,7 +46,7 @@ class TestTranspiler_UnitGates:
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_y(self):
+    def test_y(self) -> None:
         circuit = Circuit(1)
         circuit.y(0)
         pattern = circuit.transpile().pattern
@@ -48,7 +54,7 @@ class TestTranspiler_UnitGates:
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_z(self):
+    def test_z(self) -> None:
         circuit = Circuit(1)
         circuit.z(0)
         pattern = circuit.transpile().pattern
@@ -56,7 +62,7 @@ class TestTranspiler_UnitGates:
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_rx(self, fx_rng: Generator):
+    def test_rx(self, fx_rng: Generator) -> None:
         theta = fx_rng.uniform() * 2 * np.pi
         circuit = Circuit(1)
         circuit.rx(0, theta)
@@ -65,7 +71,7 @@ class TestTranspiler_UnitGates:
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_ry(self, fx_rng: Generator):
+    def test_ry(self, fx_rng: Generator) -> None:
         theta = fx_rng.uniform() * 2 * np.pi
         circuit = Circuit(1)
         circuit.ry(0, theta)
@@ -74,7 +80,7 @@ class TestTranspiler_UnitGates:
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_rz(self, fx_rng: Generator):
+    def test_rz(self, fx_rng: Generator) -> None:
         theta = fx_rng.uniform() * 2 * np.pi
         circuit = Circuit(1)
         circuit.rz(0, theta)
@@ -83,7 +89,7 @@ class TestTranspiler_UnitGates:
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_i(self):
+    def test_i(self) -> None:
         circuit = Circuit(1)
         circuit.i(0)
         pattern = circuit.transpile().pattern
@@ -91,7 +97,7 @@ class TestTranspiler_UnitGates:
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_ccx(self, fx_rng: Generator):
+    def test_ccx(self, fx_rng: Generator) -> None:
         nqubits = 4
         depth = 6
         for _ in range(10):
@@ -103,8 +109,8 @@ class TestTranspiler_UnitGates:
             np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
 
-class TestTranspiler_Opt:
-    def test_ccx_opt(self, fx_rng: Generator):
+class TestTranspilerOpt:
+    def test_ccx_opt(self, fx_rng: Generator) -> None:
         nqubits = 4
         depth = 6
         for _ in range(10):
@@ -116,7 +122,7 @@ class TestTranspiler_Opt:
             state_mbqc = pattern.simulate_pattern()
             np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_transpile_opt(self, fx_rng: Generator):
+    def test_transpile_opt(self, fx_rng: Generator) -> None:
         nqubits = 2
         depth = 1
         pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
@@ -126,7 +132,7 @@ class TestTranspiler_Opt:
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_standardize_and_transpile(self, fx_rng: Generator):
+    def test_standardize_and_transpile(self, fx_rng: Generator) -> None:
         nqubits = 3
         depth = 2
         pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
@@ -137,7 +143,7 @@ class TestTranspiler_Opt:
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_standardize_and_transpile_opt(self, fx_rng: Generator):
+    def test_standardize_and_transpile_opt(self, fx_rng: Generator) -> None:
         nqubits = 3
         depth = 2
         pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
@@ -148,14 +154,14 @@ class TestTranspiler_Opt:
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_measure(self):
+    def test_measure(self) -> None:
         circuit = Circuit(2)
         circuit.h(1)
         circuit.cnot(0, 1)
         circuit.m(0, graphix.pauli.Plane.XY, 0.5)
-        transpile = circuit.transpile()
+        _ = circuit.transpile()
 
-        def simulate_and_measure():
+        def simulate_and_measure() -> int:
             circuit_simulate = circuit.simulate_statevector()
             assert circuit_simulate.classical_measures[0] == (circuit_simulate.statevec.psi[0][1].imag > 0)
             return circuit_simulate.classical_measures[0]

--- a/tests/test_transpiler.py
+++ b/tests/test_transpiler.py
@@ -1,5 +1,3 @@
-import unittest
-
 import numpy as np
 
 import graphix.pauli
@@ -11,7 +9,7 @@ SEED = 42
 rc.set_seed(SEED)
 
 
-class TestTranspiler_UnitGates(unittest.TestCase):
+class TestTranspiler_UnitGates:
     def test_cnot(self):
         circuit = Circuit(2)
         circuit.cnot(0, 1)
@@ -107,7 +105,7 @@ class TestTranspiler_UnitGates(unittest.TestCase):
             np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
 
-class TestTranspiler_Opt(unittest.TestCase):
+class TestTranspiler_Opt:
     def test_ccx_opt(self):
         nqubits = 4
         depth = 6
@@ -167,7 +165,3 @@ class TestTranspiler_Opt(unittest.TestCase):
         nb_shots = 1000
         count = sum(1 for _ in range(nb_shots) if simulate_and_measure())
         assert abs(count - nb_shots / 2) < nb_shots / 20
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_transpiler.py
+++ b/tests/test_transpiler.py
@@ -1,12 +1,10 @@
 import numpy as np
+from numpy.random import Generator
 
 import graphix.pauli
 import graphix.simulator
 import tests.random_circuit as rc
 from graphix.transpiler import Circuit
-
-SEED = 42
-rc.set_seed(SEED)
 
 
 class TestTranspiler_UnitGates:
@@ -58,8 +56,8 @@ class TestTranspiler_UnitGates:
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_rx(self):
-        theta = np.random.random() * 2 * np.pi
+    def test_rx(self, fx_rng: Generator):
+        theta = fx_rng.uniform() * 2 * np.pi
         circuit = Circuit(1)
         circuit.rx(0, theta)
         pattern = circuit.transpile().pattern
@@ -67,8 +65,8 @@ class TestTranspiler_UnitGates:
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_ry(self):
-        theta = np.random.random() * 2 * np.pi
+    def test_ry(self, fx_rng: Generator):
+        theta = fx_rng.uniform() * 2 * np.pi
         circuit = Circuit(1)
         circuit.ry(0, theta)
         pattern = circuit.transpile().pattern
@@ -76,8 +74,8 @@ class TestTranspiler_UnitGates:
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_rz(self):
-        theta = np.random.random() * 2 * np.pi
+    def test_rz(self, fx_rng: Generator):
+        theta = fx_rng.uniform() * 2 * np.pi
         circuit = Circuit(1)
         circuit.rz(0, theta)
         pattern = circuit.transpile().pattern
@@ -93,11 +91,11 @@ class TestTranspiler_UnitGates:
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_ccx(self):
+    def test_ccx(self, fx_rng: Generator):
         nqubits = 4
         depth = 6
         for _ in range(10):
-            circuit = rc.get_rand_circuit(nqubits, depth, use_ccx=True)
+            circuit = rc.get_rand_circuit(nqubits, depth, fx_rng, use_ccx=True)
             pattern = circuit.transpile().pattern
             pattern.minimize_space()
             state = circuit.simulate_statevector().statevec
@@ -106,11 +104,11 @@ class TestTranspiler_UnitGates:
 
 
 class TestTranspiler_Opt:
-    def test_ccx_opt(self):
+    def test_ccx_opt(self, fx_rng: Generator):
         nqubits = 4
         depth = 6
         for _ in range(10):
-            circuit = rc.get_rand_circuit(nqubits, depth, use_ccx=True)
+            circuit = rc.get_rand_circuit(nqubits, depth, fx_rng, use_ccx=True)
             circuit.ccx(0, 1, 2)
             pattern = circuit.transpile(opt=True).pattern
             pattern.minimize_space()
@@ -118,32 +116,32 @@ class TestTranspiler_Opt:
             state_mbqc = pattern.simulate_pattern()
             np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_transpile_opt(self):
+    def test_transpile_opt(self, fx_rng: Generator):
         nqubits = 2
         depth = 1
         pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
-        circuit = rc.generate_gate(nqubits, depth, pairs, use_rzz=True)
+        circuit = rc.generate_gate(nqubits, depth, pairs, fx_rng, use_rzz=True)
         pattern = circuit.transpile(opt=True).pattern
         state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_standardize_and_transpile(self):
+    def test_standardize_and_transpile(self, fx_rng: Generator):
         nqubits = 3
         depth = 2
         pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
-        circuit = rc.generate_gate(nqubits, depth, pairs, use_rzz=True)
+        circuit = rc.generate_gate(nqubits, depth, pairs, fx_rng, use_rzz=True)
         pattern = circuit.standardize_and_transpile().pattern
         state = circuit.simulate_statevector().statevec
         pattern.minimize_space()
         state_mbqc = pattern.simulate_pattern()
         np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
 
-    def test_standardize_and_transpile_opt(self):
+    def test_standardize_and_transpile_opt(self, fx_rng: Generator):
         nqubits = 3
         depth = 2
         pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
-        circuit = rc.generate_gate(nqubits, depth, pairs, use_rzz=True)
+        circuit = rc.generate_gate(nqubits, depth, pairs, fx_rng, use_rzz=True)
         pattern = circuit.standardize_and_transpile(opt=True).pattern
         state = circuit.simulate_statevector().statevec
         pattern.minimize_space()

--- a/tests/test_transpiler.py
+++ b/tests/test_transpiler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
+import pytest
 
 import graphix.pauli
 import graphix.simulator
@@ -20,7 +21,7 @@ class TestTranspilerUnitGates:
         pattern = circuit.transpile().pattern
         state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+        assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
     def test_hadamard(self) -> None:
         circuit = Circuit(1)
@@ -28,7 +29,7 @@ class TestTranspilerUnitGates:
         pattern = circuit.transpile().pattern
         state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+        assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
     def test_s(self) -> None:
         circuit = Circuit(1)
@@ -36,7 +37,7 @@ class TestTranspilerUnitGates:
         pattern = circuit.transpile().pattern
         state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+        assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
     def test_x(self) -> None:
         circuit = Circuit(1)
@@ -44,7 +45,7 @@ class TestTranspilerUnitGates:
         pattern = circuit.transpile().pattern
         state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+        assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
     def test_y(self) -> None:
         circuit = Circuit(1)
@@ -52,7 +53,7 @@ class TestTranspilerUnitGates:
         pattern = circuit.transpile().pattern
         state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+        assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
     def test_z(self) -> None:
         circuit = Circuit(1)
@@ -60,7 +61,7 @@ class TestTranspilerUnitGates:
         pattern = circuit.transpile().pattern
         state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+        assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
     def test_rx(self, fx_rng: Generator) -> None:
         theta = fx_rng.uniform() * 2 * np.pi
@@ -69,7 +70,7 @@ class TestTranspilerUnitGates:
         pattern = circuit.transpile().pattern
         state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+        assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
     def test_ry(self, fx_rng: Generator) -> None:
         theta = fx_rng.uniform() * 2 * np.pi
@@ -78,7 +79,7 @@ class TestTranspilerUnitGates:
         pattern = circuit.transpile().pattern
         state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+        assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
     def test_rz(self, fx_rng: Generator) -> None:
         theta = fx_rng.uniform() * 2 * np.pi
@@ -87,7 +88,7 @@ class TestTranspilerUnitGates:
         pattern = circuit.transpile().pattern
         state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+        assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
     def test_i(self) -> None:
         circuit = Circuit(1)
@@ -95,7 +96,7 @@ class TestTranspilerUnitGates:
         pattern = circuit.transpile().pattern
         state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+        assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
     def test_ccx(self, fx_rng: Generator) -> None:
         nqubits = 4
@@ -106,7 +107,7 @@ class TestTranspilerUnitGates:
             pattern.minimize_space()
             state = circuit.simulate_statevector().statevec
             state_mbqc = pattern.simulate_pattern()
-            np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+            assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
 
 class TestTranspilerOpt:
@@ -120,7 +121,7 @@ class TestTranspilerOpt:
             pattern.minimize_space()
             state = circuit.simulate_statevector().statevec
             state_mbqc = pattern.simulate_pattern()
-            np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+            assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
     def test_transpile_opt(self, fx_rng: Generator) -> None:
         nqubits = 2
@@ -130,7 +131,7 @@ class TestTranspilerOpt:
         pattern = circuit.transpile(opt=True).pattern
         state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+        assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
     def test_standardize_and_transpile(self, fx_rng: Generator) -> None:
         nqubits = 3
@@ -141,7 +142,7 @@ class TestTranspilerOpt:
         state = circuit.simulate_statevector().statevec
         pattern.minimize_space()
         state_mbqc = pattern.simulate_pattern()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+        assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
     def test_standardize_and_transpile_opt(self, fx_rng: Generator) -> None:
         nqubits = 3
@@ -152,7 +153,7 @@ class TestTranspilerOpt:
         state = circuit.simulate_statevector().statevec
         pattern.minimize_space()
         state_mbqc = pattern.simulate_pattern()
-        np.testing.assert_almost_equal(np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())), 1)
+        assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
     def test_measure(self) -> None:
         circuit = Circuit(2)


### PR DESCRIPTION
Resolves #133.

MEMO: explicitly skipping tests reported in #130.

**Description of the change:**

Trying to fix these problems:

- using both `pytest` and `unittest` 
- using both `assert` and `np.testing.assert_*`
- `for` loop inside tests
- racking type hints
- global mutable states (ex. rng)
- some critical issues (ex. shadowing builtins, PEP8 violation)


