### PR TITLE
Fix #153: check for `IndexError` in `get_measurement_commands`

### DIFF
--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -954,8 +954,14 @@ class Pattern:
         ind = self._find_op_to_be_moved("M")
         if ind == "end":
             return []
-        while self.__seq[ind][0] == "M":
-            meas_cmds.append(self.__seq[ind])
+        while True:
+            try:
+                cmd = self.__seq[ind]
+            except IndexError:
+                break
+            if cmd[0] != "M":
+                break
+            meas_cmds.append(cmd)
             ind += 1
         return meas_cmds
 

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -507,6 +507,13 @@ class TestLocalPattern:
         assert not result1
         assert result2
 
+    def test_pauli_measurement_end_with_measure(self) -> None:
+        # https://github.com/TeamGraphix/graphix/issues/153
+        p = Pattern(input_nodes=[0])
+        p.add(["N", 1])
+        p.add(["M", 1, "XY", 0, [], []])
+        p.perform_pauli_measurements()
+
 
 def assert_equal_edge(edge: Sequence[int], ref: Sequence[int]) -> bool:
     ans = True


### PR DESCRIPTION
This commit fixes #153 by catching `IndexError` in `get_measurement_commands`. A test is added to catch this bug to prevent regression.