### PR TITLE
Fix #181 and #188: Better pauli nodes recognition

### DIFF
--- a/graphix/command.py
+++ b/graphix/command.py
@@ -61,7 +61,7 @@ class M(Command):
 
     def is_pauli(self, precision: float = 1e-6) -> tuple[Axis, Sign] | None:
         angle_double = 2 * self.angle
-        angle_double_int = int(angle_double)
+        angle_double_int = round(angle_double)
         if abs(angle_double - angle_double_int) > precision:
             return None
         angle_double_mod_4 = angle_double_int % 4

--- a/graphix/command.py
+++ b/graphix/command.py
@@ -10,7 +10,8 @@ import numpy as np
 from pydantic import BaseModel
 
 import graphix.clifford
-from graphix.pauli import Plane
+from graphix.clifford import Clifford
+from graphix.pauli import Axis, Plane, Sign
 
 if TYPE_CHECKING:
     from graphix.clifford import Clifford
@@ -57,6 +58,19 @@ class M(Command):
     angle: float = 0.0
     s_domain: set[Node] = set()
     t_domain: set[Node] = set()
+
+    def is_pauli(self, precision: float = 1e-6) -> tuple[Axis, Sign] | None:
+        angle_double = 2 * self.angle
+        angle_double_int = int(angle_double)
+        if abs(angle_double - angle_double_int) > precision:
+            return None
+        angle_double_mod_4 = angle_double_int % 4
+        if angle_double_mod_4 % 2 == 0:
+            axis = self.plane.cos
+        else:
+            axis = self.plane.sin
+        sign = Sign.minus_if(angle_double_mod_4 >= 2)
+        return (axis, sign)
 
     def clifford(self, clifford: Clifford) -> M:
         s_domain = self.s_domain

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -2021,11 +2021,10 @@ def is_pauli_measurement(cmd: command.Command):
         if the measurement is not in Pauli basis, returns None.
     """
     assert cmd.kind == command.CommandKind.M
-    pauli = cmd.is_pauli()
+    pauli = cmd.is_close_to_pauli()
     if pauli is None:
         return None
-    axis, sign = pauli
-    return f"{sign}{axis.name}"
+    return f"{pauli.sign}{pauli.axis.name}"
 
 
 def cmd_to_qasm3(cmd):

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -14,10 +14,11 @@ import graphix.clifford
 import graphix.pauli
 from graphix import command
 from graphix.clifford import CLIFFORD_CONJ, CLIFFORD_TO_QASM3
+from graphix.command import Pauli
 from graphix.device_interface import PatternRunner
 from graphix.gflow import find_flow, find_gflow, get_layers
 from graphix.graphsim.graphstate import GraphState
-from graphix.pauli import Plane
+from graphix.pauli import Axis, Plane, Sign
 from graphix.simulator import PatternSimulator
 from graphix.visualization import GraphVisualizer
 
@@ -1878,25 +1879,19 @@ def measure_pauli(pattern, leave_input, copy=False, use_rustworkx=False):
         new_inputs = pattern.input_nodes
     for cmd in to_measure:
         pattern_cmd: command.Command = cmd[0]
-        measurement_basis: str = cmd[1]
+        measurement_basis: Pauli = cmd[1]
         # extract signals for adaptive angle.
         s_signal = 0
         t_signal = 0
-        if measurement_basis in [
-            "+X",
-            "-X",
-        ]:  # X meaurement is not affected by s_signal
+        if measurement_basis.axis == Axis.X:  # X measurement is not affected by s_signal
             t_signal = sum([results[j] for j in pattern_cmd.t_domain])
-        elif measurement_basis in ["+Y", "-Y"]:
+        elif measurement_basis.axis == Axis.Y:
             s_signal = sum([results[j] for j in pattern_cmd.s_domain])
             t_signal = sum([results[j] for j in pattern_cmd.t_domain])
-        elif measurement_basis in [
-            "+Z",
-            "-Z",
-        ]:  # Z meaurement is not affected by t_signal
+        elif measurement_basis.axis == Axis.Z:  # Z measurement is not affected by t_signal
             s_signal = sum([results[j] for j in pattern_cmd.s_domain])
         else:
-            raise ValueError("unknown Pauli measurement basis", measurement_basis)
+            typing_extensions.assert_never(measurement_basis.axis)
 
         if int(s_signal % 2) == 1:  # equivalent to X byproduct
             graph_state.h(pattern_cmd.node)
@@ -1905,20 +1900,18 @@ def measure_pauli(pattern, leave_input, copy=False, use_rustworkx=False):
         if int(t_signal % 2) == 1:  # equivalent to Z byproduct
             graph_state.z(pattern_cmd.node)
         basis = measurement_basis
-        if basis == "+X":
-            results[pattern_cmd.node] = graph_state.measure_x(pattern_cmd.node, choice=0)
-        elif basis == "-X":
-            results[pattern_cmd.node] = 1 - graph_state.measure_x(pattern_cmd.node, choice=1)
-        elif basis == "+Y":
-            results[pattern_cmd.node] = graph_state.measure_y(pattern_cmd.node, choice=0)
-        elif basis == "-Y":
-            results[pattern_cmd.node] = 1 - graph_state.measure_y(pattern_cmd.node, choice=1)
-        elif basis == "+Z":
-            results[pattern_cmd.node] = graph_state.measure_z(pattern_cmd.node, choice=0)
-        elif basis == "-Z":
-            results[pattern_cmd.node] = 1 - graph_state.measure_z(pattern_cmd.node, choice=1)
+        if basis.axis == Axis.X:
+            measure = graph_state.measure_x
+        elif basis.axis == Axis.Y:
+            measure = graph_state.measure_y
+        elif basis.axis == Axis.Z:
+            measure = graph_state.measure_z
         else:
-            raise ValueError("unknown Pauli measurement basis", measurement_basis)
+            typing_extensions.assert_never(basis.axis)
+        if basis.sign == Sign.Plus:
+            results[pattern_cmd.node] = measure(pattern_cmd.node, choice=0)
+        else:
+            results[pattern_cmd.node] = 1 - measure(pattern_cmd.node, choice=1)
 
     # measure (remove) isolated nodes. if they aren't Pauli measurements,
     # measuring one of the results with probability of 1 should not occur as was possible above for Pauli measurements,
@@ -1956,7 +1949,7 @@ def measure_pauli(pattern, leave_input, copy=False, use_rustworkx=False):
     return pat
 
 
-def pauli_nodes(pattern: Pattern, leave_input: bool):
+def pauli_nodes(pattern: Pattern, leave_input: bool) -> list[tuple[command.M, Pauli]] :
     """returns the list of measurement commands that are in Pauli bases
     and that are not dependent on any non-Pauli measurements
 
@@ -1973,24 +1966,24 @@ def pauli_nodes(pattern: Pattern, leave_input: bool):
     if not pattern.is_standard():
         pattern.standardize()
     m_commands = pattern.get_measurement_commands()
-    pauli_node: list[tuple[command.M, str]] = []
+    pauli_node: list[tuple[command.M, Pauli]] = []
     # Nodes that are non-Pauli measured, or pauli measured but depends on pauli measurement
     non_pauli_node: set[int] = set()
     for cmd in m_commands:
         pm = is_pauli_measurement(cmd)
         if pm is not None and (cmd.node not in pattern.input_nodes or not leave_input):
             # Pauli measurement to be removed
-            if pm in ["+X", "-X"]:
+            if pm.axis == Axis.X:
                 if cmd.t_domain & non_pauli_node:  # cmd depend on non-Pauli measurement
                     non_pauli_node.add(cmd.node)
                 else:
                     pauli_node.append((cmd, pm))
-            elif pm in ["+Y", "-Y"]:
+            elif pm.axis == Axis.Y:
                 if (cmd.s_domain | cmd.t_domain) & non_pauli_node:  # cmd depend on non-Pauli measurement
                     non_pauli_node.add(cmd.node)
                 else:
                     pauli_node.append((cmd, pm))
-            elif pm in ["+Z", "-Z"]:
+            elif pm.axis == Axis.Z:
                 if cmd.s_domain & non_pauli_node:  # cmd depend on non-Pauli measurement
                     non_pauli_node.add(cmd.node)
                 else:
@@ -2002,7 +1995,7 @@ def pauli_nodes(pattern: Pattern, leave_input: bool):
     return pauli_node, non_pauli_node
 
 
-def is_pauli_measurement(cmd: command.Command):
+def is_pauli_measurement(cmd: command.Command) -> Pauli | None:
     """Determines whether or not the measurement command is a Pauli measurement,
     and if so returns the measurement basis.
 
@@ -2024,7 +2017,7 @@ def is_pauli_measurement(cmd: command.Command):
     pauli = cmd.is_close_to_pauli()
     if pauli is None:
         return None
-    return f"{pauli.sign}{pauli.axis.name}"
+    return pauli
 
 
 def cmd_to_qasm3(cmd):

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import networkx as nx
 import typing_extensions
@@ -14,13 +15,15 @@ import graphix.clifford
 import graphix.pauli
 from graphix import command
 from graphix.clifford import CLIFFORD_CONJ, CLIFFORD_TO_QASM3
-from graphix.command import Pauli
 from graphix.device_interface import PatternRunner
 from graphix.gflow import find_flow, find_gflow, get_layers
 from graphix.graphsim.graphstate import GraphState
 from graphix.pauli import Axis, Plane, Sign
 from graphix.simulator import PatternSimulator
 from graphix.visualization import GraphVisualizer
+
+if TYPE_CHECKING:
+    from graphix.command import Pauli
 
 
 class NodeAlreadyPrepared(Exception):

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -1977,7 +1977,7 @@ def pauli_nodes(pattern: Pattern, leave_input: bool):
     # Nodes that are non-Pauli measured, or pauli measured but depends on pauli measurement
     non_pauli_node: set[int] = set()
     for cmd in m_commands:
-        pm = is_pauli_measurement(cmd, ignore_vop=True)
+        pm = is_pauli_measurement(cmd)
         if pm is not None and (cmd.node not in pattern.input_nodes or not leave_input):
             # Pauli measurement to be removed
             if pm in ["+X", "-X"]:
@@ -2002,7 +2002,7 @@ def pauli_nodes(pattern: Pattern, leave_input: bool):
     return pauli_node, non_pauli_node
 
 
-def is_pauli_measurement(cmd: command.Command, ignore_vop=True):
+def is_pauli_measurement(cmd: command.Command):
     """Determines whether or not the measurement command is a Pauli measurement,
     and if so returns the measurement basis.
 
@@ -2014,8 +2014,6 @@ def is_pauli_measurement(cmd: command.Command, ignore_vop=True):
 
         e.g. `['M', 2, 'XY', 0.25, [], [], 6]`
         for measurement of node 2, in 4/pi angle in XY plane, with local Clifford index 6 (Hadamard).
-    ignore_vop : bool
-        whether or not to ignore local Clifford to detemrine the measurement basis.
 
     Returns
     -------

--- a/graphix/pauli.py
+++ b/graphix/pauli.py
@@ -145,13 +145,13 @@ class ComplexUnit:
         return COMPLEX_UNITS[self.__sign == Sign.Plus][self.__is_imag]
 
 
-COMPLEX_UNITS = [[ComplexUnit(sign, is_imag) for is_imag in (False, True)] for sign in (Sign.Plus, Sign.Minus)]
+COMPLEX_UNITS = tuple(tuple(ComplexUnit(sign, is_imag) for is_imag in (False, True)) for sign in (Sign.Plus, Sign.Minus))
 
 
 UNIT = COMPLEX_UNITS[False][False]
 
 
-UNITS = [UNIT, -UNIT, 1j * UNIT, -1j * UNIT]
+UNITS = (UNIT, -UNIT, 1j * UNIT, -1j * UNIT)
 
 
 class Axis(enum.Enum):
@@ -308,13 +308,13 @@ class Pauli:
         return get(self.__symbol, -self.__unit)
 
 
-TABLE = [
-    [[Pauli(symbol, COMPLEX_UNITS[sign][is_imag]) for is_imag in (False, True)] for sign in (False, True)]
+TABLE = tuple(
+    tuple(tuple(Pauli(symbol, COMPLEX_UNITS[sign][is_imag]) for is_imag in (False, True)) for sign in (False, True))
     for symbol in (IXYZ.I, IXYZ.X, IXYZ.Y, IXYZ.Z)
-]
+)
 
 
-LIST = [pauli for sign_im_list in TABLE for im_list in sign_im_list for pauli in im_list]
+LIST = tuple(pauli for sign_im_list in TABLE for im_list in sign_im_list for pauli in im_list)
 
 
 def get(symbol: IXYZ, unit: ComplexUnit) -> Pauli:

--- a/graphix/pauli.py
+++ b/graphix/pauli.py
@@ -81,29 +81,29 @@ class ComplexUnit:
     with Python constants 1, -1, 1j, -1j, and can be negated.
     """
 
-    def __init__(self, sign: Sign, im: bool):
+    def __init__(self, sign: Sign, is_imag: bool):
         self.__sign = sign
-        self.__im = im
+        self.__is_imag = is_imag
 
     @property
     def sign(self):
         return self.__sign
 
     @property
-    def im(self) -> bool:
-        return self.__im
+    def is_imag(self) -> bool:
+        return self.__is_imag
 
     def __complex__(self) -> complex:
         """
         Return the unit as complex number
         """
         result: complex = complex(self.__sign)
-        if self.__im:
+        if self.__is_imag:
             result *= 1j
         return result
 
     def __str__(self) -> str:
-        if self.__im:
+        if self.__is_imag:
             result = "1j"
         else:
             result = "1"
@@ -116,7 +116,7 @@ class ComplexUnit:
         Prefix the given string by the complex unit as coefficient,
         1 leaving the string unchanged.
         """
-        if self.__im:
+        if self.__is_imag:
             result = "1j*" + s
         else:
             result = s
@@ -126,26 +126,26 @@ class ComplexUnit:
 
     def __mul__(self, other):
         if isinstance(other, ComplexUnit):
-            im = self.__im != other.__im
-            sign = self.__sign * other.__sign * Sign.minus_if(self.__im and other.__im)
-            return COMPLEX_UNITS[sign == Sign.Minus][im]
+            is_imag = self.__is_imag != other.__is_imag
+            sign = self.__sign * other.__sign * Sign.minus_if(self.__is_imag and other.__is_imag)
+            return COMPLEX_UNITS[sign == Sign.Minus][is_imag]
         return NotImplemented
 
     def __rmul__(self, other):
         if other == 1:
             return self
         elif other == -1:
-            return COMPLEX_UNITS[self.__sign == Sign.Plus][self.__im]
+            return COMPLEX_UNITS[self.__sign == Sign.Plus][self.__is_imag]
         elif other == 1j:
-            return COMPLEX_UNITS[self.__sign == Sign.plus_if(self.__im)][not self.__im]
+            return COMPLEX_UNITS[self.__sign == Sign.plus_if(self.__is_imag)][not self.__is_imag]
         elif other == -1j:
-            return COMPLEX_UNITS[self.__sign == Sign.minus_if(self.__im)][not self.__im]
+            return COMPLEX_UNITS[self.__sign == Sign.minus_if(self.__is_imag)][not self.__is_imag]
 
     def __neg__(self):
-        return COMPLEX_UNITS[self.__sign == Sign.Plus][self.__im]
+        return COMPLEX_UNITS[self.__sign == Sign.Plus][self.__is_imag]
 
 
-COMPLEX_UNITS = [[ComplexUnit(sign, im) for im in (False, True)] for sign in (Sign.Plus, Sign.Minus)]
+COMPLEX_UNITS = [[ComplexUnit(sign, is_imag) for is_imag in (False, True)] for sign in (Sign.Plus, Sign.Minus)]
 
 
 UNIT = COMPLEX_UNITS[False][False]
@@ -309,7 +309,7 @@ class Pauli:
 
 
 TABLE = [
-    [[Pauli(symbol, COMPLEX_UNITS[sign][im]) for im in (False, True)] for sign in (False, True)]
+    [[Pauli(symbol, COMPLEX_UNITS[sign][is_imag]) for is_imag in (False, True)] for sign in (False, True)]
     for symbol in (IXYZ.I, IXYZ.X, IXYZ.Y, IXYZ.Z)
 ]
 
@@ -319,7 +319,7 @@ LIST = [pauli for sign_im_list in TABLE for im_list in sign_im_list for pauli in
 
 def get(symbol: IXYZ, unit: ComplexUnit) -> Pauli:
     """Return the Pauli gate with given symbol and unit."""
-    return TABLE[symbol.value + 1][unit.sign == Sign.Minus][unit.im]
+    return TABLE[symbol.value + 1][unit.sign == Sign.Minus][unit.is_imag]
 
 
 I = get(IXYZ.I, UNIT)

--- a/graphix/pauli.py
+++ b/graphix/pauli.py
@@ -20,6 +20,7 @@ class IXYZ(enum.Enum):
     Y = 1
     Z = 2
 
+
 class Sign(enum.Enum):
     Plus = 1
     Minus = -1
@@ -45,12 +46,10 @@ class Sign(enum.Enum):
         return Sign.minus_if(self == Sign.Plus)
 
     @typing.overload
-    def __mul__(self, other: Sign) -> Sign:
-        ...
+    def __mul__(self, other: Sign) -> Sign: ...
 
     @typing.overload
-    def __mul__(self, other: Number) -> Number:
-        ...
+    def __mul__(self, other: Number) -> Number: ...
 
     def __mul__(self, other):
         if isinstance(other, Sign):

--- a/graphix/pauli.py
+++ b/graphix/pauli.py
@@ -58,7 +58,7 @@ class Sign(enum.Enum):
             return self.value * other
         return NotImplemented
 
-    def __rmul__(self, other) -> Number | type(NotImplemented):
+    def __rmul__(self, other) -> Number:
         if isinstance(other, Number):
             return self.value * other
         return NotImplemented

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -171,6 +171,18 @@ class TestPattern:
         state_mbqc = pattern.simulate_pattern(backend)
         assert compare_backend_result_with_statevec(backend, state_mbqc, state) == pytest.approx(1)
 
+    @pytest.mark.parametrize("plane", Plane)
+    @pytest.mark.parametrize("angle", [0., 0.5, 1., 1.5])
+    def test_pauli_measurement_single(self, plane: Plane, angle: float, use_rustworkx: bool = True) -> None:
+        pattern = Pattern(input_nodes=[0, 1])
+        pattern.add(E(nodes=[0, 1]))
+        pattern.add(M(node=0, plane=plane, angle=angle))
+        pattern_ref = pattern.copy()
+        pattern.perform_pauli_measurements(use_rustworkx=use_rustworkx)
+        state = pattern.simulate_pattern()
+        state_ref = pattern_ref.simulate_pattern(pr_calc=False, rng=IterGenerator([0]))
+        assert np.abs(np.dot(state.flatten().conjugate(), state_ref.flatten())) == pytest.approx(1)
+
     @pytest.mark.parametrize("jumps", range(1, 11))
     def test_pauli_measurement_leave_input_random_circuit(
         self, fx_bg: PCG64, jumps: int, use_rustworkx: bool = True

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -172,7 +172,7 @@ class TestPattern:
         assert compare_backend_result_with_statevec(backend, state_mbqc, state) == pytest.approx(1)
 
     @pytest.mark.parametrize("plane", Plane)
-    @pytest.mark.parametrize("angle", [0., 0.5, 1., 1.5])
+    @pytest.mark.parametrize("angle", [0.0, 0.5, 1.0, 1.5])
     def test_pauli_measurement_single(self, plane: Plane, angle: float, use_rustworkx: bool = True) -> None:
         pattern = Pattern(input_nodes=[0, 1])
         pattern.add(E(nodes=[0, 1]))

--- a/tests/test_pauli.py
+++ b/tests/test_pauli.py
@@ -23,7 +23,7 @@ class TestPauli:
         ),
     )
     def test_unit_mul(self, u: ComplexUnit, p: Pauli) -> None:
-        assert np.allclose((u * p).matrix, u.complex * p.matrix)
+        assert np.allclose((u * p).matrix, complex(u) * p.matrix)
 
     @pytest.mark.parametrize(
         ("a", "b"),


### PR DESCRIPTION
This commit introduces a new method `is_pauli` on `M` commands, which returns a pair `(axis, sign)` if the measure is Pauli, and `None` otherwise.

This method takes an optional parameter `precision` ($\rho$, default: `1e-6`): a measure is considered to be Pauli if the angle is in an interval $[- \rho + k \cdot \frac \pi 2; \rho + k \cdot \frac \pi 2]$, addressing the precision problem raised in #181.

`axis` is computed by using the `cos` and `sin` definitions of `pauli.py`, solving the inconsistency bug reported in #188.

This commit introduces a new `Sign` class to make code manipulating `Plus` and `Minus` to be more readable than when using `bool`.