### PR TITLE
Fix #188: Fix Pauli measurement conventions

### DIFF
--- a/graphix/command.py
+++ b/graphix/command.py
@@ -10,6 +10,7 @@ import numpy as np
 from pydantic import BaseModel
 
 import graphix.clifford
+from graphix.clifford import Clifford
 from graphix.pauli import Plane
 
 if TYPE_CHECKING:

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -17,7 +17,7 @@ from graphix.clifford import CLIFFORD_CONJ, CLIFFORD_TO_QASM3
 from graphix.device_interface import PatternRunner
 from graphix.gflow import find_flow, find_gflow, get_layers
 from graphix.graphsim.graphstate import GraphState
-from graphix.pauli import Axis, PauliMeasure, Plane, Sign
+from graphix.pauli import Axis, PauliMeasurement, Plane, Sign
 from graphix.simulator import PatternSimulator
 from graphix.visualization import GraphVisualizer
 
@@ -1878,7 +1878,7 @@ def measure_pauli(pattern, leave_input, copy=False, use_rustworkx=False):
         new_inputs = pattern.input_nodes
     for cmd in to_measure:
         pattern_cmd: command.Command = cmd[0]
-        measurement_basis: PauliMeasure = cmd[1]
+        measurement_basis: PauliMeasurement = cmd[1]
         # extract signals for adaptive angle.
         s_signal = 0
         t_signal = 0
@@ -1948,7 +1948,7 @@ def measure_pauli(pattern, leave_input, copy=False, use_rustworkx=False):
     return pat
 
 
-def pauli_nodes(pattern: Pattern, leave_input: bool) -> list[tuple[command.M, PauliMeasure]]:
+def pauli_nodes(pattern: Pattern, leave_input: bool) -> list[tuple[command.M, PauliMeasurement]]:
     """returns the list of measurement commands that are in Pauli bases
     and that are not dependent on any non-Pauli measurements
 
@@ -1965,11 +1965,11 @@ def pauli_nodes(pattern: Pattern, leave_input: bool) -> list[tuple[command.M, Pa
     if not pattern.is_standard():
         pattern.standardize()
     m_commands = pattern.get_measurement_commands()
-    pauli_node: list[tuple[command.M, PauliMeasure]] = []
+    pauli_node: list[tuple[command.M, PauliMeasurement]] = []
     # Nodes that are non-Pauli measured, or pauli measured but depends on pauli measurement
     non_pauli_node: set[int] = set()
     for cmd in m_commands:
-        pm = PauliMeasure.try_from(cmd.plane, cmd.angle)  # None returned if the measurement is not in Pauli basis
+        pm = PauliMeasurement.try_from(cmd.plane, cmd.angle)  # None returned if the measurement is not in Pauli basis
         if pm is not None and (cmd.node not in pattern.input_nodes or not leave_input):
             # Pauli measurement to be removed
             if pm.axis == Axis.X:

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -1969,7 +1969,7 @@ def pauli_nodes(pattern: Pattern, leave_input: bool) -> list[tuple[command.M, Pa
     # Nodes that are non-Pauli measured, or pauli measured but depends on pauli measurement
     non_pauli_node: set[int] = set()
     for cmd in m_commands:
-        pm = PauliMeasure.try_from(cmd.plane, cmd.angle)
+        pm = PauliMeasure.try_from(cmd.plane, cmd.angle)  # None returned if the measurement is not in Pauli basis
         if pm is not None and (cmd.node not in pattern.input_nodes or not leave_input):
             # Pauli measurement to be removed
             if pm.axis == Axis.X:

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -8,17 +8,16 @@ from copy import deepcopy
 from dataclasses import dataclass
 
 import networkx as nx
-import numpy as np
 import typing_extensions
 
 import graphix.clifford
 import graphix.pauli
 from graphix import command
-from graphix.clifford import CLIFFORD_CONJ, CLIFFORD_MEASURE, CLIFFORD_TO_QASM3
+from graphix.clifford import CLIFFORD_CONJ, CLIFFORD_TO_QASM3
 from graphix.device_interface import PatternRunner
 from graphix.gflow import find_flow, find_gflow, get_layers
 from graphix.graphsim.graphstate import GraphState
-from graphix.pauli import Plane
+from graphix.pauli import Axis, Plane, Sign
 from graphix.simulator import PatternSimulator
 from graphix.visualization import GraphVisualizer
 
@@ -1879,25 +1878,19 @@ def measure_pauli(pattern, leave_input, copy=False, use_rustworkx=False):
         new_inputs = pattern.input_nodes
     for cmd in to_measure:
         pattern_cmd: command.Command = cmd[0]
-        measurement_basis: str = cmd[1]
+        measurement_basis: graphix.pauli.Measure = cmd[1]
         # extract signals for adaptive angle.
         s_signal = 0
         t_signal = 0
-        if measurement_basis in [
-            "+X",
-            "-X",
-        ]:  # X meaurement is not affected by s_signal
+        if measurement_basis.axis == Axis.X:  # X measurement is not affected by s_signal
             t_signal = sum([results[j] for j in pattern_cmd.t_domain])
-        elif measurement_basis in ["+Y", "-Y"]:
+        elif measurement_basis.axis == Axis.Y:
             s_signal = sum([results[j] for j in pattern_cmd.s_domain])
             t_signal = sum([results[j] for j in pattern_cmd.t_domain])
-        elif measurement_basis in [
-            "+Z",
-            "-Z",
-        ]:  # Z meaurement is not affected by t_signal
+        elif measurement_basis.axis == Axis.Z:  # Z measurement is not affected by t_signal
             s_signal = sum([results[j] for j in pattern_cmd.s_domain])
         else:
-            raise ValueError("unknown Pauli measurement basis", measurement_basis)
+            typing_extensions.assert_never(measurement_basis.axis)
 
         if int(s_signal % 2) == 1:  # equivalent to X byproduct
             graph_state.h(pattern_cmd.node)
@@ -1906,20 +1899,18 @@ def measure_pauli(pattern, leave_input, copy=False, use_rustworkx=False):
         if int(t_signal % 2) == 1:  # equivalent to Z byproduct
             graph_state.z(pattern_cmd.node)
         basis = measurement_basis
-        if basis == "+X":
-            results[pattern_cmd.node] = graph_state.measure_x(pattern_cmd.node, choice=0)
-        elif basis == "-X":
-            results[pattern_cmd.node] = 1 - graph_state.measure_x(pattern_cmd.node, choice=1)
-        elif basis == "+Y":
-            results[pattern_cmd.node] = graph_state.measure_y(pattern_cmd.node, choice=0)
-        elif basis == "-Y":
-            results[pattern_cmd.node] = 1 - graph_state.measure_y(pattern_cmd.node, choice=1)
-        elif basis == "+Z":
-            results[pattern_cmd.node] = graph_state.measure_z(pattern_cmd.node, choice=0)
-        elif basis == "-Z":
-            results[pattern_cmd.node] = 1 - graph_state.measure_z(pattern_cmd.node, choice=1)
+        if basis.axis == Axis.X:
+            measure = graph_state.measure_x
+        elif basis.axis == Axis.Y:
+            measure = graph_state.measure_y
+        elif basis.axis == Axis.Z:
+            measure = graph_state.measure_z
         else:
-            raise ValueError("unknown Pauli measurement basis", measurement_basis)
+            typing_extensions.assert_never(basis.axis)
+        if basis.sign == Sign.Plus:
+            results[pattern_cmd.node] = measure(pattern_cmd.node, choice=0)
+        else:
+            results[pattern_cmd.node] = 1 - measure(pattern_cmd.node, choice=1)
 
     # measure (remove) isolated nodes. if they aren't Pauli measurements,
     # measuring one of the results with probability of 1 should not occur as was possible above for Pauli measurements,
@@ -1957,7 +1948,7 @@ def measure_pauli(pattern, leave_input, copy=False, use_rustworkx=False):
     return pat
 
 
-def pauli_nodes(pattern: Pattern, leave_input: bool):
+def pauli_nodes(pattern: Pattern, leave_input: bool) -> list[tuple[command.M, graphix.pauli.Measure]]:
     """returns the list of measurement commands that are in Pauli bases
     and that are not dependent on any non-Pauli measurements
 
@@ -1974,24 +1965,24 @@ def pauli_nodes(pattern: Pattern, leave_input: bool):
     if not pattern.is_standard():
         pattern.standardize()
     m_commands = pattern.get_measurement_commands()
-    pauli_node: list[tuple[command.M, str]] = []
+    pauli_node: list[tuple[command.M, graphix.pauli.Measure]] = []
     # Nodes that are non-Pauli measured, or pauli measured but depends on pauli measurement
     non_pauli_node: set[int] = set()
     for cmd in m_commands:
-        pm = is_pauli_measurement(cmd, ignore_vop=True)
+        pm = graphix.pauli.Measure.try_from(cmd.plane, cmd.angle)
         if pm is not None and (cmd.node not in pattern.input_nodes or not leave_input):
             # Pauli measurement to be removed
-            if pm in ["+X", "-X"]:
+            if pm.axis == Axis.X:
                 if cmd.t_domain & non_pauli_node:  # cmd depend on non-Pauli measurement
                     non_pauli_node.add(cmd.node)
                 else:
                     pauli_node.append((cmd, pm))
-            elif pm in ["+Y", "-Y"]:
+            elif pm.axis == Axis.Y:
                 if (cmd.s_domain | cmd.t_domain) & non_pauli_node:  # cmd depend on non-Pauli measurement
                     non_pauli_node.add(cmd.node)
                 else:
                     pauli_node.append((cmd, pm))
-            elif pm in ["+Z", "-Z"]:
+            elif pm.axis == Axis.Z:
                 if cmd.s_domain & non_pauli_node:  # cmd depend on non-Pauli measurement
                     non_pauli_node.add(cmd.node)
                 else:
@@ -2001,77 +1992,6 @@ def pauli_nodes(pattern: Pattern, leave_input: bool):
         else:
             non_pauli_node.add(cmd.node)
     return pauli_node, non_pauli_node
-
-
-def is_pauli_measurement(cmd: command.Command, ignore_vop=True):
-    """Determines whether or not the measurement command is a Pauli measurement,
-    and if so returns the measurement basis.
-
-    Parameters
-    ----------
-    cmd : list
-        measurement command. list containing the information of the measurement,
-        "M", node index, measurement plane, angle (in unit of pi), s-signal, t-signal, clifford index.
-
-        e.g. `['M', 2, 'XY', 0.25, [], [], 6]`
-        for measurement of node 2, in 4/pi angle in XY plane, with local Clifford index 6 (Hadamard).
-    ignore_vop : bool
-        whether or not to ignore local Clifford to detemrine the measurement basis.
-
-    Returns
-    -------
-        str, one of '+X', '-X', '+Y', '-Y', '+Z', '-Z'
-        if the measurement is not in Pauli basis, returns None.
-    """
-    assert cmd.kind == command.CommandKind.M
-    basis_str = [("+X", "-X"), ("+Y", "-Y"), ("+Z", "-Z")]
-    # first item: 0, 1 or 2. correspond to choice of X, Y and Z
-    # second item: 0 or 1. correspond to sign (+, -)
-    basis_index = (0, 0)
-    if np.mod(cmd.angle, 2) == 0:
-        if cmd.plane == graphix.pauli.Plane.XY:
-            basis_index = (0, 0)
-        elif cmd.plane == graphix.pauli.Plane.YZ:
-            basis_index = (1, 0)
-        elif cmd.plane == graphix.pauli.Plane.XZ:
-            basis_index = (0, 0)
-        else:
-            raise ValueError("Unknown measurement plane")
-    elif np.mod(cmd.angle, 2) == 1:
-        if cmd.plane == graphix.pauli.Plane.XY:
-            basis_index = (0, 1)
-        elif cmd.plane == graphix.pauli.Plane.YZ:
-            basis_index = (1, 1)
-        elif cmd.plane == graphix.pauli.Plane.XZ:
-            basis_index = (0, 1)
-        else:
-            raise ValueError("Unknown measurement plane")
-    elif np.mod(cmd.angle, 2) == 0.5:
-        if cmd.plane == graphix.pauli.Plane.XY:
-            basis_index = (1, 0)
-        elif cmd.plane == graphix.pauli.Plane.YZ:
-            basis_index = (2, 0)
-        elif cmd.plane == graphix.pauli.Plane.XZ:
-            basis_index = (2, 0)
-        else:
-            raise ValueError("Unknown measurement plane")
-    elif np.mod(cmd.angle, 2) == 1.5:
-        if cmd.plane == graphix.pauli.Plane.XY:
-            basis_index = (1, 1)
-        elif cmd.plane == graphix.pauli.Plane.YZ:
-            basis_index = (2, 1)
-        elif cmd.plane == graphix.pauli.Plane.XZ:
-            basis_index = (2, 1)
-        else:
-            raise ValueError("Unknown measurement plane")
-    else:
-        return None
-    if not ignore_vop:
-        basis_index = (
-            CLIFFORD_MEASURE[cmd.vop][basis_index[0]][0],
-            int(np.abs(basis_index[1] - CLIFFORD_MEASURE[cmd.vop][basis_index[0]][1])),
-        )
-    return basis_str[basis_index[0]][basis_index[1]]
 
 
 def cmd_to_qasm3(cmd):

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -17,7 +17,7 @@ from graphix.clifford import CLIFFORD_CONJ, CLIFFORD_TO_QASM3
 from graphix.device_interface import PatternRunner
 from graphix.gflow import find_flow, find_gflow, get_layers
 from graphix.graphsim.graphstate import GraphState
-from graphix.pauli import Axis, Plane, Sign
+from graphix.pauli import Axis, PauliMeasure, Plane, Sign
 from graphix.simulator import PatternSimulator
 from graphix.visualization import GraphVisualizer
 
@@ -1878,7 +1878,7 @@ def measure_pauli(pattern, leave_input, copy=False, use_rustworkx=False):
         new_inputs = pattern.input_nodes
     for cmd in to_measure:
         pattern_cmd: command.Command = cmd[0]
-        measurement_basis: graphix.pauli.Measure = cmd[1]
+        measurement_basis: PauliMeasure = cmd[1]
         # extract signals for adaptive angle.
         s_signal = 0
         t_signal = 0
@@ -1948,7 +1948,7 @@ def measure_pauli(pattern, leave_input, copy=False, use_rustworkx=False):
     return pat
 
 
-def pauli_nodes(pattern: Pattern, leave_input: bool) -> list[tuple[command.M, graphix.pauli.Measure]]:
+def pauli_nodes(pattern: Pattern, leave_input: bool) -> list[tuple[command.M, PauliMeasure]]:
     """returns the list of measurement commands that are in Pauli bases
     and that are not dependent on any non-Pauli measurements
 
@@ -1965,11 +1965,11 @@ def pauli_nodes(pattern: Pattern, leave_input: bool) -> list[tuple[command.M, gr
     if not pattern.is_standard():
         pattern.standardize()
     m_commands = pattern.get_measurement_commands()
-    pauli_node: list[tuple[command.M, graphix.pauli.Measure]] = []
+    pauli_node: list[tuple[command.M, PauliMeasure]] = []
     # Nodes that are non-Pauli measured, or pauli measured but depends on pauli measurement
     non_pauli_node: set[int] = set()
     for cmd in m_commands:
-        pm = graphix.pauli.Measure.try_from(cmd.plane, cmd.angle)
+        pm = PauliMeasure.try_from(cmd.plane, cmd.angle)
         if pm is not None and (cmd.node not in pattern.input_nodes or not leave_input):
             # Pauli measurement to be removed
             if pm.axis == Axis.X:

--- a/graphix/pauli.py
+++ b/graphix/pauli.py
@@ -342,7 +342,7 @@ def is_int(value: Number) -> bool:
     return value == int(value)
 
 
-class Measure(typing.NamedTuple):
+class PauliMeasure(typing.NamedTuple):
     """
     Pauli measurement.
     """
@@ -351,7 +351,7 @@ class Measure(typing.NamedTuple):
     sign: Sign
 
     @staticmethod
-    def try_from(plane: Plane, angle: float) -> Measure | None:
+    def try_from(plane: Plane, angle: float) -> PauliMeasure | None:
         angle_double = 2 * angle
         if not is_int(angle_double):
             return None
@@ -361,7 +361,7 @@ class Measure(typing.NamedTuple):
         else:
             axis = plane.sin
         sign = Sign.minus_if(angle_double_mod_4 >= 2)
-        return Measure(axis, sign)
+        return PauliMeasure(axis, sign)
 
 
 class MeasureUpdate(pydantic.BaseModel):

--- a/graphix/pauli.py
+++ b/graphix/pauli.py
@@ -5,6 +5,7 @@ Pauli gates ± {1,j} × {I, X, Y, Z}
 from __future__ import annotations
 
 import enum
+import sys
 import typing
 from numbers import Number
 
@@ -68,9 +69,9 @@ class Sign(enum.Enum):
 
 
 if sys.version_info >= (3, 10):
-    SignOrNumber = typing.TypeVar("SignOrNumber", bound = Sign | Number)
+    SignOrNumber = typing.TypeVar("SignOrNumber", bound=Sign | Number)
 else:
-    SignOrNumber = typing.TypeVar("SignOrNumber", bound = typing.Union[Sign, Number])
+    SignOrNumber = typing.TypeVar("SignOrNumber", bound=typing.Union[Sign, Number])
 
 
 class ComplexUnit:

--- a/graphix/pauli.py
+++ b/graphix/pauli.py
@@ -342,7 +342,7 @@ def is_int(value: Number) -> bool:
     return value == int(value)
 
 
-class PauliMeasure(typing.NamedTuple):
+class PauliMeasurement(typing.NamedTuple):
     """
     Pauli measurement.
     """
@@ -351,7 +351,7 @@ class PauliMeasure(typing.NamedTuple):
     sign: Sign
 
     @staticmethod
-    def try_from(plane: Plane, angle: float) -> PauliMeasure | None:
+    def try_from(plane: Plane, angle: float) -> PauliMeasurement | None:
         angle_double = 2 * angle
         if not is_int(angle_double):
             return None
@@ -361,7 +361,7 @@ class PauliMeasure(typing.NamedTuple):
         else:
             axis = plane.sin
         sign = Sign.minus_if(angle_double_mod_4 >= 2)
-        return PauliMeasure(axis, sign)
+        return PauliMeasurement(axis, sign)
 
 
 class MeasureUpdate(pydantic.BaseModel):

--- a/graphix/pauli.py
+++ b/graphix/pauli.py
@@ -67,7 +67,10 @@ class Sign(enum.Enum):
         return complex(self.value)
 
 
-SignOrNumber = typing.TypeVar("SignOrNumber", bound = Sign | Number)
+if sys.version_info >= (3, 10):
+    SignOrNumber = typing.TypeVar("SignOrNumber", bound = Sign | Number)
+else:
+    SignOrNumber = typing.TypeVar("SignOrNumber", bound = typing.Union[Sign, Number])
 
 
 class ComplexUnit:

--- a/graphix/pauli.py
+++ b/graphix/pauli.py
@@ -45,13 +45,7 @@ class Sign(enum.Enum):
     def __neg__(self) -> Sign:
         return Sign.minus_if(self == Sign.Plus)
 
-    @typing.overload
-    def __mul__(self, other: Sign) -> Sign: ...
-
-    @typing.overload
-    def __mul__(self, other: Number) -> Number: ...
-
-    def __mul__(self, other):
+    def __mul__(self, other: SignOrNumber) -> SignOrNumber:
         if isinstance(other, Sign):
             return Sign.plus_if(self == other)
         if isinstance(other, Number):
@@ -71,6 +65,9 @@ class Sign(enum.Enum):
 
     def __complex__(self) -> complex:
         return complex(self.value)
+
+
+SignOrNumber = typing.TypeVar("SignOrNumber", bound = Sign | Number)
 
 
 class ComplexUnit:

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -171,6 +171,18 @@ class TestPattern:
         state_mbqc = pattern.simulate_pattern(backend)
         assert compare_backend_result_with_statevec(backend, state_mbqc, state) == pytest.approx(1)
 
+    @pytest.mark.parametrize("plane", Plane)
+    @pytest.mark.parametrize("angle", [0.0, 0.5, 1.0, 1.5])
+    def test_pauli_measurement_single(self, plane: Plane, angle: float, use_rustworkx: bool = True) -> None:
+        pattern = Pattern(input_nodes=[0, 1])
+        pattern.add(E(nodes=[0, 1]))
+        pattern.add(M(node=0, plane=plane, angle=angle))
+        pattern_ref = pattern.copy()
+        pattern.perform_pauli_measurements(use_rustworkx=use_rustworkx)
+        state = pattern.simulate_pattern()
+        state_ref = pattern_ref.simulate_pattern(pr_calc=False, rng=IterGenerator([0]))
+        assert np.abs(np.dot(state.flatten().conjugate(), state_ref.flatten())) == pytest.approx(1)
+
     @pytest.mark.parametrize("jumps", range(1, 11))
     def test_pauli_measurement_leave_input_random_circuit(
         self, fx_bg: PCG64, jumps: int, use_rustworkx: bool = True

--- a/tests/test_pauli.py
+++ b/tests/test_pauli.py
@@ -23,7 +23,7 @@ class TestPauli:
         ),
     )
     def test_unit_mul(self, u: ComplexUnit, p: Pauli) -> None:
-        assert np.allclose((u * p).matrix, u.complex * p.matrix)
+        assert np.allclose((u * p).matrix, complex(u) * p.matrix)
 
     @pytest.mark.parametrize(
         ("a", "b"),


### PR DESCRIPTION
This commit introduces a new named tuple, `graphix.pauli.Measure`, which contains a pair `(axis, sign)`. It includes a static method, `try_from`, that returns an instance of `Measure` if the given plane and angle represent a valid Pauli measure, or `None` otherwise.

The axis is computed using the `cos` and `sin` definitions from `pauli.py`, addressing the inconsistency bug reported in #188.

Additionally, this commit introduces a new `Sign` class, which enhances the readability of code that manipulates `Plus` and `Minus` values, as opposed to using `bool`.

Note: This PR follows up on #189, focusing on fixing #188 while preserving the equality test for recognizing Pauli measures.