### PR TITLE
Fix `NodeIndex.remove` bug which misinterprets non-runnable patterns

### DIFF
--- a/graphix/sim/base_backend.py
+++ b/graphix/sim/base_backend.py
@@ -77,6 +77,7 @@ class NodeIndex:
         """Remove the specified node label from the list and dictionary, and re-attributes qubit indices for the remaining nodes."""
         index = self.__dict[node]
         del self.__list[index]
+        del self.__dict[node]
         for new_index, node in enumerate(self.__list[index:], start=index):
             self.__dict[node] = new_index
 

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -710,6 +710,13 @@ class TestLocalPattern:
                 backend="tensornetwork", graph_prep="sequential", input_state=states, rng=fx_rng
             )
 
+    def test_remove_qubit(self) -> None:
+        p = Pattern(input_nodes=[0, 1])
+        p.add(M(node=0))
+        p.add(C(node=0, clifford=clifford.X))
+        with pytest.raises(KeyError):
+            p.simulate_pattern()
+
 
 def assert_equal_edge(edge: Sequence[int], ref: Sequence[int]) -> bool:
     return any(all(ei == ri for ei, ri in zip(edge, other)) for other in (ref, reversed(ref)))


### PR DESCRIPTION
Nodes were not removed from `NodeIndex` dictionary which allow non-runnable patterns to use wrong nodes by mistake.

Related to #193 (runnability issues).
