### PR TITLE
Fix examples in opengraph/pyzx and check doctests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,32 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-### Fixed
-
-### Changed
-
-## [0.3.0] - 2025-02-04
-
-### Changed
-
-- Now variables, functions, and classes are named based on PEP8.
-- `KrausChannel` class now uses `KrausData` class (originally `dict`) to store Kraus operators.
-- Deprecated support for Python 3.8.
-- Major refactoring of the codebase, especially in the `pattern` and `transpiler` modules. 
-  - Removed `opt` option for `Circuit.transpile` method.
-  - Removed `pattern.LocalPattern` class and associted `local` options in `Pattern.standardize` and `Pattern.shift_signals` methods.
-  
-
-## [0.2.16] - 2024-08-26
-
-This version introduces several important interface changes, aimed at secure expression and improved code maintainability.
-
-### Added
-
-- Added classes for a standardized definition of pattern commands and circuit instructions (`graphix.commands`, `graphix.instructions`). This is for data validation, readability and maintainability purposes. Preiously, the commands and instructions were represented as raw data inside lists, which are prone to errors and not readable.
-- The following changes were made (#155):
-  - Added `class Command` and all its child classes that represent all the pattern commands.
-  - Added `class Instruction` for the gate network expression in quantum circuit model. Every instruction can be instanciated using this class by passing its name as defined in the Enum `InstructionName`.
 - Parameterized circuits and patterns: angles in instructions and
   measures can be expressions with parameters created with
   `parameter.Placeholder` class.  Parameterized circuits can be
@@ -50,8 +24,36 @@ This version introduces several important interface changes, aimed at secure exp
   computed symbolically, so `pr_calc=False` should be passed to
   simulators for symbolic computation, and an arbitrary path will be
   computed).
+
+### Fixed
+
+- #254: Fix examples in `opengraph` and `pyzx` modules
+
+### Changed
+
+## [0.3.0] - 2025-02-04
+
+### Changed
+
+- Now variables, functions, and classes are named based on PEP8.
+- `KrausChannel` class now uses `KrausData` class (originally `dict`) to store Kraus operators.
+- Deprecated support for Python 3.8.
+- Major refactoring of the codebase, especially in the `pattern` and `transpiler` modules. 
+  - Removed `opt` option for `Circuit.transpile` method.
+  - Removed `pattern.LocalPattern` class and associted `local` options in `Pattern.standardize` and `Pattern.shift_signals` methods.
 - Simulator back-ends have an additional optional argument `rng`,
   to specify the random generator to use during the simulation.
+
+## [0.2.16] - 2024-08-26
+
+This version introduces several important interface changes, aimed at secure expression and improved code maintainability.
+
+### Added
+
+- Added classes for a standardized definition of pattern commands and circuit instructions (`graphix.commands`, `graphix.instructions`). This is for data validation, readability and maintainability purposes. Preiously, the commands and instructions were represented as raw data inside lists, which are prone to errors and not readable.
+- The following changes were made (#155):
+  - Added `class Command` and all its child classes that represent all the pattern commands.
+  - Added `class Instruction` for the gate network expression in quantum circuit model. Every instruction can be instanciated using this class by passing its name as defined in the Enum `InstructionName`.
 - `class graphix.OpenGraph` to transpile between graphix patterns and pyzx graphs.
 - `class graphix.pauli.PauliMeasurement` as a new Pauli measurement checks (used in `pattern.perform_pauli_measurements`).
 

--- a/graphix/opengraph.py
+++ b/graphix/opengraph.py
@@ -29,6 +29,7 @@ class OpenGraph:
     Example
     -------
     >>> import networkx as nx
+    >>> from graphix.fundamentals import Plane
     >>> from graphix.opengraph import OpenGraph, Measurement
     >>>
     >>> inside_graph = nx.Graph([(0, 1), (1, 2), (2, 0)])

--- a/graphix/pyzx.py
+++ b/graphix/pyzx.py
@@ -29,12 +29,13 @@ def to_pyzx_graph(og: OpenGraph) -> BaseGraph[int, tuple[int, int]]:
     Example
     -------
     >>> import networkx as nx
+    >>> from graphix.pyzx import to_pyzx_graph
     >>> g = nx.Graph([(0, 1), (1, 2)])
     >>> inputs = [0]
     >>> outputs = [2]
     >>> measurements = {0: Measurement(0, Plane.XY), 1: Measurement(1, Plane.YZ)}
     >>> og = OpenGraph(g, measurements, inputs, outputs)
-    >>> reconstructed_pyzx_graph = og.to_pyzx_graph()
+    >>> reconstructed_pyzx_graph = to_pyzx_graph(og)
     """
     # check pyzx availability and version
     try:
@@ -123,10 +124,10 @@ def from_pyzx_graph(g: BaseGraph[int, tuple[int, int]]) -> OpenGraph:
     Example
     -------
     >>> import pyzx as zx
-    >>> from graphix.opengraph import OpenGraph
+    >>> from graphix.pyzx import from_pyzx_graph
     >>> circ = zx.qasm("qreg q[2]; h q[1]; cx q[0], q[1]; h q[1];")
     >>> g = circ.to_graph()
-    >>> og = OpenGraph.from_pyzx_graph(g)
+    >>> og = from_pyzx_graph(g)
     """
     zx.simplify.to_graph_like(g)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -18,7 +18,7 @@ def tests_minimal(session: Session) -> None:
 def tests(session: Session) -> None:
     """Run the test suite with full dependencies."""
     session.install("-e", ".[dev]")
-    session.run("pytest")
+    session.run("pytest --doctest-modules")
 
 
 @nox.session(python=["3.8", "3.9", "3.10", "3.11", "3.12"])

--- a/noxfile.py
+++ b/noxfile.py
@@ -18,7 +18,7 @@ def tests_minimal(session: Session) -> None:
 def tests(session: Session) -> None:
     """Run the test suite with full dependencies."""
     session.install("-e", ".[dev]")
-    session.run("pytest --doctest-modules")
+    session.run("pytest", "--doctest-modules")
 
 
 @nox.session(python=["3.8", "3.9", "3.10", "3.11", "3.12"])

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --ignore=examples --ignore=docs --ignore=benchmarks


### PR DESCRIPTION
Code review in #245 revealed that the examples in the doc-comments of the `opengraph` and `pyzx` modules were broken (see the discussion [[here](https://github.com/TeamGraphix/graphix/pull/245#discussion_r1970672058)](https://github.com/TeamGraphix/graphix/pull/245#discussion_r1970672058)).

This PR proposes two commits:
- 11fa6a9 fixes the examples.
- b5e3389 configures `nox` to run `pytest --doctest-modules`, which includes the examples in the doc-comments in the test suite. This is executed only during a full test (using `requirements-dev.txt`), as it requires optional dependencies such as `pyzx`.