### PR TITLE
Remove `T.node` and `T.domain` introduced in a07197a

### DIFF
--- a/graphix/command.py
+++ b/graphix/command.py
@@ -125,7 +125,6 @@ class S(_KindChecker):
 class T(_KindChecker):
     """T command."""
 
-    node: Node
     kind: ClassVar[Literal[CommandKind.T]] = dataclasses.field(default=CommandKind.T, init=False)
 
 

--- a/graphix/command.py
+++ b/graphix/command.py
@@ -126,7 +126,6 @@ class T(_KindChecker):
     """T command."""
 
     node: Node
-    domain: set[Node] = dataclasses.field(default_factory=set)
     kind: ClassVar[Literal[CommandKind.T]] = dataclasses.field(default=CommandKind.T, init=False)
 
 


### PR DESCRIPTION
The fields `T.node` and `T.domain` have no meaningful semantics: their values are never set to anything other than their default and are never used throughout the code. In particular, the simulator does not take them into account (see https://github.com/TeamGraphix/graphix/blob/0728e439b00603e5292331f38df5c8aa98b66846/graphix/simulator.py#L209 )

```python
                elif cmd.kind == CommandKind.T:
                    # T command is a flag for one clock cycle in simulated experiment,
                    # to be added via hardware-agnostic pattern modifier
                    self.noise_model.tick_clock()
```
