### PR TITLE
fixed ruff error using dict.fromkeys method + update CI

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -12,16 +12,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint-format:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
+      - name: Cache pip dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-dev.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: Install dependencies
-        run: python -m pip install ruff -c requirements-dev.txt 
+        run: python -m pip install --upgrade pip && python -m pip install ruff -c requirements-dev.txt
 
       - name: Run Ruff Linter
         run: ruff check --output-format=github
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-dev.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: python -m pip install --upgrade pip && python -m pip install ruff -c requirements-dev.txt
 
       - name: Run Ruff Formatter Check
         run: ruff format --check

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -21,7 +21,7 @@ jobs:
         run: python -m pip install -c ruff requirements-dev.txt 
 
       - name: Run Ruff Linter
-      - run: ruff check --output-format=github
+        run: ruff check --output-format=github
 
       - name: Run Ruff Formatter Check
-      - run: ruff format --check
+        run: ruff format --check

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install dependencies
-        run: python -m pip install -c ruff requirements-dev.txt 
+        run: python -m pip install ruff -c requirements-dev.txt 
 
       - name: Run Ruff Linter
         run: ruff check --output-format=github

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -16,14 +16,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1
+      - uses: astral-sh/ruff-action@v3
         with:
+          version: "latest"
           args: "check --output-format=github"
 
   format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1
+      - uses: astral-sh/ruff-action@v3
         with:
+          version: "latest"
           args: "format --check"

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -12,20 +12,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
+  lint-format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v3
-        with:
-          version: "latest"
-          args: "check --output-format=github"
 
-  format:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v3
-        with:
-          version: "latest"
-          args: "format --check"
+      - name: Install dependencies
+        run: python -m pip install -c ruff requirements-dev.txt 
+
+      - name: Run Ruff Linter
+      - run: ruff check --output-format=github
+
+      - name: Run Ruff Formatter Check
+      - run: ruff format --check

--- a/graphix/generator.py
+++ b/graphix/generator.py
@@ -54,7 +54,7 @@ def generate_from_graph(graph, angles, inputs, outputs, meas_planes=None):
     measuring_nodes = list(set(graph.nodes) - set(outputs) - set(inputs))
 
     if meas_planes is None:
-        meas_planes = {i: Plane.XY for i in measuring_nodes}
+        meas_planes = dict.fromkeys(measuring_nodes, Plane.XY)
 
     # search for flow first
     f, l_k = find_flow(graph, set(inputs), set(outputs), meas_planes=meas_planes)

--- a/graphix/gflow.py
+++ b/graphix/gflow.py
@@ -267,13 +267,13 @@ def find_flow(
     edges = set(graph.edges)
 
     if meas_planes is None:
-        meas_planes = {i: Plane.XY for i in (nodes - oset)}
+        meas_planes = dict.fromkeys(nodes - oset, Plane.XY)
 
     for plane in meas_planes.values():
         if plane != Plane.XY:
             return None, None
 
-    l_k = {i: 0 for i in nodes}
+    l_k = dict.fromkeys(nodes, 0)
     f = {}
     k = 1
     v_c = oset - iset

--- a/graphix/visualization.py
+++ b/graphix/visualization.py
@@ -70,7 +70,7 @@ class GraphVisualizer:
         self.v_in = v_in
         self.v_out = v_out
         if meas_plane is None:
-            self.meas_planes = {i: Plane.XY for i in iter(g.nodes)}
+            self.meas_planes = dict.fromkeys(iter(g.nodes), Plane.XY)
         else:
             self.meas_planes = meas_plane
         self.meas_angles = meas_angles
@@ -1047,7 +1047,7 @@ class GraphVisualizer:
 
         for component in connected_components:
             subgraph = self.graph.subgraph(component)
-            initial_pos = {node: (0, 0) for node in component}
+            initial_pos = dict.fromkeys(component, (0, 0))
 
             if len(set(self.v_out) & set(component)) == 0 and len(set(self.v_in) & set(component)) == 0:
                 pos = nx.spring_layout(subgraph)

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -22,7 +22,7 @@ class TestGenerator:
         angles = fx_rng.normal(size=6)
         results = []
         repeats = 3  # for testing the determinism of a pattern
-        meas_planes = {i: Plane.XY for i in range(6)}
+        meas_planes = dict.fromkeys(range(6), Plane.XY)
         for _ in range(repeats):
             pattern = generate_from_graph(graph, angles, list(inputs), list(outputs), meas_planes=meas_planes)
             pattern.standardize()
@@ -39,7 +39,7 @@ class TestGenerator:
         inputs = {1, 3, 5}
         outputs = {2, 4, 6}
         angles = fx_rng.normal(size=6)
-        meas_planes = {i: Plane.XY for i in range(1, 6)}
+        meas_planes = dict.fromkeys(range(1, 6), Plane.XY)
         results = []
         repeats = 3  # for testing the determinism of a pattern
         for _ in range(repeats):


### PR DESCRIPTION
Before submitting, please check the following:

- Make sure you have tests for the new code and that test passes (run `nox`)
- If applicable, add a line to the [unreleased] part of CHANGELOG.md, following [keep-a-changelog](https://keepachangelog.com/en/1.0.0/).
- Format added code by `ruff`
  - See `CONTRIBUTING.md` for more details
- Make sure the checks (github actions) pass.

Then, please fill in below:

**Context (if applicable):**

**Description of the change:**
Use of `dict.fromkeys` method and update ruff CI for using the ruff version specified in `requirements-dev.txt`.
Additionally use a cache dependencies to avoid downloading twice the same dependency within the CI process.

**Related issue:**
#258 