### PR TITLE
abstract class for device interface

### DIFF
--- a/graphix/device_backend.py
+++ b/graphix/device_backend.py
@@ -1,0 +1,18 @@
+from typing import Optional
+from graphix.device_interface import DeviceBackend
+from graphix.pattern import Pattern
+
+
+def get_backend(name: str, pattern: Optional[Pattern] = None, **kwargs) -> DeviceBackend:
+    if name == "ibmq":
+        try:
+            from graphix_ibmq.backend import IBMQBackend
+        except ImportError:
+            raise ImportError("Please install graphix-ibmq via `pip install graphix-ibmq`.")
+
+        backend = IBMQBackend(**kwargs)
+        if pattern is not None:
+            backend.set_pattern(pattern)
+        return backend
+    else:
+        raise ValueError(f"Unknown backend: {name}")

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -18,7 +18,7 @@ import typing_extensions
 from graphix import command, parameter
 from graphix.clifford import Clifford
 from graphix.command import Command, CommandKind
-from graphix.device_interface import PatternRunner
+# from graphix.device_interface import PatternRunner
 from graphix.fundamentals import Axis, Plane, Sign
 from graphix.gflow import find_flow, find_gflow, get_layers
 from graphix.graphsim.graphstate import GraphState
@@ -1282,26 +1282,6 @@ class Pattern:
         sim = PatternSimulator(self, backend=backend, **kwargs)
         sim.run(input_state)
         return sim.backend.state
-
-    def run_pattern(self, backend, **kwargs):
-        """Run the pattern on cloud-based quantum devices and their simulators.
-
-        Available backend: ['ibmq']
-
-        Parameters
-        ----------
-        backend : str
-            parameter to select executor backend.
-        kwargs: keyword args for specified backend.
-
-        Returns
-        -------
-        result :
-            the measurement result,
-            in the representation depending on the backend used.
-        """
-        exe = PatternRunner(self, backend=backend, **kwargs)
-        return exe.run()
 
     def perform_pauli_measurements(
         self, leave_input: bool = False, use_rustworkx: bool = False, ignore_pauli_with_deps: bool = False


### PR DESCRIPTION
Before submitting, please check the following:

- Make sure you have tests for the new code and that test passes (run `nox`)
- If applicable, add a line to the [unreleased] part of CHANGELOG.md, following [keep-a-changelog](https://keepachangelog.com/en/1.0.0/).
- Format added code by `ruff`
  - See `CONTRIBUTING.md` for more details
- Make sure the checks (github actions) pass.

Then, please fill in below:

**Context (if applicable):**
Refactoring and modularization of the device backend interface is required.

**Description of the change:**
- Refactored the `device_interface` API structure into a formal abstract class system.
- Defined abstract classes in `graphix.device_interface`:
  - `DeviceBackend`: an interface for executing MBQC patterns on a backend (real or simulated).
  - `JobHandler`: an interface for managing job lifecycle (status, cancellation, result retrieval).
- These abstract interfaces are now the only contracts `graphix` defines for device execution.
- All device-specific implementations (e.g. for IBMQ) are completely delegated to external packages such as `graphix-ibmq`, which implement and register concrete subclasses.
- Introduced `graphix.backend_factory.get_backend(name: str)`:
  - Supports lazy import of external device backends (e.g., `name="ibmq"`).
  - This allows preserving one-way dependency flow from external backend libraries to `graphix`, while still enabling centralized backend access for users.

**Related issue:**
