### PR TITLE
Enforce `from __future__ import annotations`

### DIFF
--- a/benchmarks/graphsim.py
+++ b/benchmarks/graphsim.py
@@ -12,6 +12,7 @@ While networkx is a pure Python package, rustworkx is a Rust package with Python
 
 # %%
 # Firstly, let us import relevant modules:
+from __future__ import annotations
 
 from copy import copy
 from time import perf_counter

--- a/benchmarks/statevec.py
+++ b/benchmarks/statevec.py
@@ -13,6 +13,7 @@ The methods and modules we use are the followings:
 
 # %%
 # Firstly, let us import relevant modules:
+from __future__ import annotations
 
 from time import perf_counter
 

--- a/examples/deutsch_jozsa.py
+++ b/examples/deutsch_jozsa.py
@@ -12,6 +12,8 @@ First, let us import relevant modules:
 """
 
 # %%
+from __future__ import annotations
+
 import numpy as np
 
 from graphix import Circuit

--- a/examples/fusion_extraction.py
+++ b/examples/fusion_extraction.py
@@ -14,6 +14,8 @@ The decomposition algorithm is based on [1].
 """
 
 # %%
+from __future__ import annotations
+
 import itertools
 
 import graphix

--- a/examples/ghz_with_tn.py
+++ b/examples/ghz_with_tn.py
@@ -9,6 +9,7 @@ Firstly, let us import relevant modules:
 """
 
 # %%
+from __future__ import annotations
 
 import matplotlib.pyplot as plt
 import networkx as nx

--- a/examples/mbqc_vqe.py
+++ b/examples/mbqc_vqe.py
@@ -19,10 +19,12 @@ We will build a parameterized quantum circuit and optimize its parameters to min
 the expectation value of the Hamiltonian, effectively finding the ground state energy.
 """
 
+from __future__ import annotations
+
 import itertools
 import sys
-from collections.abc import Iterable
 from timeit import timeit
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
@@ -30,9 +32,13 @@ from scipy.optimize import minimize
 
 from graphix import Circuit
 from graphix.parameter import Placeholder
-from graphix.pattern import Pattern
 from graphix.simulator import PatternSimulator
-from graphix.transpiler import Angle
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from graphix.pattern import Pattern
+    from graphix.transpiler import Angle
 
 Z = np.array([[1, 0], [0, -1]])
 X = np.array([[0, 1], [1, 0]])

--- a/examples/qaoa.py
+++ b/examples/qaoa.py
@@ -7,6 +7,8 @@ Here we generate and optimize pattern for QAOA circuit.
 """
 
 # %%
+from __future__ import annotations
+
 import networkx as nx
 import numpy as np
 

--- a/examples/qft_with_tn.py
+++ b/examples/qft_with_tn.py
@@ -8,6 +8,8 @@ Firstly, let us import relevant modules and define the circuit:
 """
 
 # %%
+from __future__ import annotations
+
 import numpy as np
 
 from graphix import Circuit

--- a/examples/qnn.py
+++ b/examples/qnn.py
@@ -10,6 +10,7 @@ Firstly, let us import relevant modules:
 """
 
 # %%
+from __future__ import annotations
 
 from functools import reduce
 from time import time

--- a/examples/rotation.py
+++ b/examples/rotation.py
@@ -14,6 +14,8 @@ First, let us import relevant modules:
 """
 
 # %%
+from __future__ import annotations
+
 import numpy as np
 
 from graphix import Circuit, Statevec

--- a/examples/tn_simulation.py
+++ b/examples/tn_simulation.py
@@ -8,6 +8,7 @@ Firstly, let's import the relevant modules:
 """
 
 # %%
+from __future__ import annotations
 
 from functools import reduce
 

--- a/examples/visualization.py
+++ b/examples/visualization.py
@@ -19,6 +19,8 @@ with the pattern, graph or the (generalized-)flow.
 # - Nodes with blue color is the nodes that are measured in *Pauli basis*, one of *X*, *Y* or *Z* computational bases.
 # - Nodes in white are the ones measured in *non-Pauli basis*.
 #
+from __future__ import annotations
+
 import numpy as np
 
 from graphix import Circuit

--- a/graphix/__init__.py
+++ b/graphix/__init__.py
@@ -1,5 +1,7 @@
 """Optimize and simulate measurement-based quantum computation."""
 
+from __future__ import annotations
+
 from graphix.generator import generate_from_graph
 from graphix.graphsim.graphstate import GraphState
 from graphix.pattern import Pattern

--- a/graphix/graphsim/__init__.py
+++ b/graphix/graphsim/__init__.py
@@ -1,5 +1,7 @@
 """Graph simulator."""
 
+from __future__ import annotations
+
 from graphix.graphsim.basegraphstate import BaseGraphState
 from graphix.graphsim.graphstate import GraphState
 from graphix.graphsim.nxgraphstate import NXGraphState

--- a/graphix/noise_models/__init__.py
+++ b/graphix/noise_models/__init__.py
@@ -1,5 +1,7 @@
 """Noise models."""
 
+from __future__ import annotations
+
 from graphix.noise_models.noise_model import NoiseModel
 from graphix.noise_models.noiseless_noise_model import NoiselessNoiseModel
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,9 @@ convention = "numpy"
 [tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"
 
+[tool.ruff.lint.isort]
+required-imports = ["from __future__ import annotations"]
+
 [tool.pytest.ini_options]
 # Silence cotengra warning
 filterwarnings = ["ignore:Couldn't import `kahypar`"]

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 """Blank setup.py for backward compatibility."""
 
+from __future__ import annotations
+
 from setuptools import setup
 
 setup()

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 import importlib.util
 from typing import TYPE_CHECKING
 
 import matplotlib as mpl
 import numpy as np
 import pytest
-from numpy.random import Generator
 
 import graphix
 import graphix.command
@@ -16,6 +17,8 @@ from graphix.sim.density_matrix import DensityMatrix
 from graphix.sim.statevec import Statevec
 
 if TYPE_CHECKING:
+    from numpy.random import Generator
+
     from graphix.parameter import Parameter
 
 

--- a/tests/test_rng.py
+++ b/tests/test_rng.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from concurrent.futures import ThreadPoolExecutor
 from threading import Thread
 

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import networkx as nx
 
 from graphix import gflow, transpiler, visualization


### PR DESCRIPTION
**Description of the change:**

Enable ruff `I002` to ensure that all files have `from __future__ import annotations`, which is required for lazy evaluation of type annotations.