### PR TITLE
Fix type warnings

### DIFF
--- a/graphix/ops.py
+++ b/graphix/ops.py
@@ -208,5 +208,7 @@ class Ops:
         else:
             raise TypeError(f"The number of qubits must be an integer and not {n_qubits}.")
 
-        # TODO: Refactor this
-        return np.array([reduce(np.kron, i) for i in product((Ops.I, Ops.X, Ops.Y, Ops.Z), repeat=n_qubits)])
+        def _reducer(lhs: npt.NDArray[np.complex128], rhs: npt.NDArray[np.complex128]) -> npt.NDArray[np.complex128]:
+            return np.kron(lhs, rhs).astype(np.complex128, copy=False)
+
+        return np.array([reduce(_reducer, i) for i in product((Ops.I, Ops.X, Ops.Y, Ops.Z), repeat=n_qubits)])

--- a/graphix/states.py
+++ b/graphix/states.py
@@ -31,7 +31,7 @@ class State(ABC):
     def get_densitymatrix(self) -> npt.NDArray[np.complex128]:
         """Return the density matrix."""
         # return DM in 2**n x 2**n dim (2x2 here)
-        return np.outer(self.get_statevector(), self.get_statevector().conj())
+        return np.outer(self.get_statevector(), self.get_statevector().conj()).astype(np.complex128, copy=False)
 
 
 @pydantic.dataclasses.dataclass


### PR DESCRIPTION
**Description of the change:**

This PR fixes two `mypy` errors suddenly appeared recently.

```sh
graphix/ops.py:212: error: Argument 1 to "reduce" has incompatible type overloaded function; expected "Callable[[ndarray[tuple[int, ...], dtype[complex128]], ndarray[tuple[int, ...], dtype[complex128]]], ndarray[tuple[int, ...], dtype[complex128]]]"  [arg-type]
graphix/states.py:34: error: Incompatible return value type (got "ndarray[tuple[int, ...], dtype[complexfloating[Any, Any]]]", expected "ndarray[tuple[int, ...], dtype[complex128]]")  [return-value]
```