### PR TITLE
Fix #252: pyzx 0.9.0, move to extra, comment graphix-{ibmq,perceval}

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,3 @@ updates:
       python-packages:
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "pyzx"

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -24,7 +24,7 @@ jobs:
 
       - run: |
           python -m pip install --upgrade pip
-          pip install -e .[dev]
+          pip install -e .[dev,extra]
 
       - run: mypy
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Methods for pretty-printing `Pattern`: `to_ascii`, `to_unicode`,
-  `to_latex`.
+- #277: Methods for pretty-printing `Pattern`: `to_ascii`,
+  `to_unicode`, `to_latex`.
 
 ### Fixed
 
-- The result of `repr()` for `Pattern`, `Circuit`, `Command`,
+- #277: The result of `repr()` for `Pattern`, `Circuit`, `Command`,
   `Instruction`, `Plane`, `Axis` and `Sign` is now a valid Python
   expression and is more readable.
 
+- #235, #252, #273: The open graph representation is now compatible
+  with pyzx 0.9, and conventions have been fixed to ensure that the
+  semantics is preserved between circuits, ZX graphs, open graphs and
+  patterns.
+
 ### Changed
 
-- The method `Pattern.print_pattern` is now deprecated.
+- #277: The method `Pattern.print_pattern` is now deprecated.
 
 ## [0.3.1] - 2025-04-21
 

--- a/graphix/generator.py
+++ b/graphix/generator.py
@@ -78,7 +78,6 @@ def generate_from_graph(
         # flow found
         depth, layers = get_layers(l_k)
         pattern = Pattern(input_nodes=inputs)
-        # pattern.extend([["N", i] for i in inputs])
         for i in set(graph.nodes) - set(inputs):
             pattern.add(N(node=i))
         for e in graph.edges:
@@ -102,7 +101,6 @@ def generate_from_graph(
             # gflow found
             depth, layers = get_layers(l_k)
             pattern = Pattern(input_nodes=inputs)
-            # pattern.extend([["N", i] for i in inputs])
             for i in set(graph.nodes) - set(inputs):
                 pattern.add(N(node=i))
             for e in graph.edges:
@@ -118,4 +116,5 @@ def generate_from_graph(
         else:
             raise ValueError("no flow or gflow found")
 
+    pattern.reorder_output_nodes(outputs)
     return pattern

--- a/graphix/pyzx.py
+++ b/graphix/pyzx.py
@@ -51,7 +51,7 @@ def to_pyzx_graph(og: OpenGraph) -> BaseGraph[int, tuple[int, int]]:
     g = Graph()
 
     # Add vertices into the graph and set their type
-    def add_vertices(n: int, ty: VertexType.Type) -> list[VertexType]:
+    def add_vertices(n: int, ty: VertexType) -> list[VertexType]:
         verts = g.add_vertices(n)
         for vert in verts:
             g.set_type(vert, ty)

--- a/graphix/pyzx.py
+++ b/graphix/pyzx.py
@@ -95,12 +95,12 @@ def to_pyzx_graph(og: OpenGraph) -> BaseGraph[int, tuple[int, int]]:
     for og_index, meas in og.measurements.items():
         # If it's an X measured node, then we handle it in the next loop
         if meas.plane == Plane.XY:
-            g.set_phase(map_to_pyzx[og_index], Fraction(meas.angle))
+            g.set_phase(map_to_pyzx[og_index], Fraction(-meas.angle))
 
     # Connect the X measured vertices
     for og_index, pyzx_index in zip(x_meas, x_meas_verts):
         g.add_edge((map_to_pyzx[og_index], pyzx_index), EdgeType.HADAMARD)
-        g.set_phase(pyzx_index, Fraction(og.measurements[og_index].angle))
+        g.set_phase(pyzx_index, Fraction(-og.measurements[og_index].angle))
 
     return g
 
@@ -165,7 +165,7 @@ def from_pyzx_graph(g: BaseGraph[int, tuple[int, int]]) -> OpenGraph:
 
         nbrs = list(g.neighbors(v))
         if len(nbrs) == 1:
-            measurements[nbrs[0]] = Measurement(_checked_float(g.phase(v)), Plane.YZ)
+            measurements[nbrs[0]] = Measurement(-_checked_float(g.phase(v)), Plane.YZ)
             g_nx.remove_node(v)
 
     next_id = max(g_nx.nodes) + 1
@@ -189,6 +189,6 @@ def from_pyzx_graph(g: BaseGraph[int, tuple[int, int]]) -> OpenGraph:
 
         # g.phase() may be a fractions.Fraction object, but Measurement
         # expects a float
-        measurements[v] = Measurement(_checked_float(g.phase(v)), Plane.XY)
+        measurements[v] = Measurement(-_checked_float(g.phase(v)), Plane.XY)
 
     return OpenGraph(g_nx, measurements, inputs, outputs)

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,7 +17,7 @@ def tests_minimal(session: Session) -> None:
 @nox.session(python=["3.9", "3.10", "3.11", "3.12"])
 def tests(session: Session) -> None:
     """Run the test suite with full dependencies."""
-    session.install("-e", ".[dev]")
+    session.install("-e", ".[dev,extra]")
     session.run("pytest", "--doctest-modules")
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,6 +20,3 @@ pytest-mock
 # Optional dependencies
 qiskit>=1.0
 qiskit-aer
-
-# Optional dependency. Pinned due to version changes often being incompatible
-pyzx==0.8.0

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -1,2 +1,3 @@
-graphix-ibmq
-graphix-perceval
+#graphix-ibmq
+#graphix-perceval
+pyzx==0.9.0

--- a/tests/test_pyzx.py
+++ b/tests/test_pyzx.py
@@ -107,7 +107,7 @@ def test_rz() -> None:
     circuit = Circuit(1)
     circuit.rz(0, np.pi / 4)
     pattern = circuit.transpile().pattern
-    circ = zx.qasm("qreg q[1]; rz(pi/4) q[0];")
+    circ = zx.qasm("qreg q[1]; rz(pi/4) q[0];")  # type: ignore[attr-defined]
     g = circ.to_graph()
     og = from_pyzx_graph(g)
     pattern_zx = og.to_pattern()

--- a/tests/test_pyzx.py
+++ b/tests/test_pyzx.py
@@ -104,10 +104,10 @@ def test_rz() -> None:
 
     from graphix.pyzx import from_pyzx_graph
 
-    circuit = Circuit(1)
+    circuit = Circuit(2)
     circuit.rz(0, np.pi / 4)
     pattern = circuit.transpile().pattern
-    circ = zx.qasm("qreg q[1]; rz(pi/4) q[0];")  # type: ignore[attr-defined]
+    circ = zx.qasm("qreg q[2]; rz(pi / 4) q[0];")  # type: ignore[attr-defined]
     g = circ.to_graph()
     og = from_pyzx_graph(g)
     pattern_zx = og.to_pattern()

--- a/tests/test_pyzx.py
+++ b/tests/test_pyzx.py
@@ -5,8 +5,8 @@ import random
 from copy import deepcopy
 from typing import TYPE_CHECKING
 
-import pytest
 import numpy as np
+import pytest
 from numpy.random import PCG64, Generator
 
 from graphix.opengraph import OpenGraph
@@ -78,6 +78,7 @@ def test_random_clifford_t() -> None:
 @pytest.mark.parametrize("jumps", range(1, 11))
 def test_random_circuit(fx_bg: PCG64, jumps: int) -> None:
     from graphix.pyzx import from_pyzx_graph, to_pyzx_graph
+
     rng = Generator(fx_bg.jumped(jumps))
     nqubits = 5
     depth = 5

--- a/tests/test_pyzx.py
+++ b/tests/test_pyzx.py
@@ -98,6 +98,7 @@ def test_random_circuit(fx_bg: PCG64, jumps: int) -> None:
     assert np.abs(np.dot(state.flatten().conjugate(), state2.flatten())) == pytest.approx(1)
 
 
+@pytest.mark.skipif(_pyzx_notfound(), reason="pyzx not installed")
 def test_rz() -> None:
     import pyzx as zx
 

--- a/tests/test_pyzx.py
+++ b/tests/test_pyzx.py
@@ -6,6 +6,11 @@ from copy import deepcopy
 from typing import TYPE_CHECKING
 
 import pytest
+import numpy as np
+from numpy.random import PCG64, Generator
+
+from graphix.opengraph import OpenGraph
+from graphix.random_objects import rand_circuit
 
 if TYPE_CHECKING:
     from pyzx.graph.base import BaseGraph
@@ -67,3 +72,25 @@ def test_random_clifford_t() -> None:
     for _ in range(15):
         g = clifford_t(4, 10, 0.1)
         assert_reconstructed_pyzx_graph_equal(g)
+
+
+@pytest.mark.skipif(_pyzx_notfound(), reason="pyzx not installed")
+@pytest.mark.parametrize("jumps", range(1, 11))
+def test_random_circuit(fx_bg: PCG64, jumps: int) -> None:
+    from graphix.pyzx import from_pyzx_graph, to_pyzx_graph
+    rng = Generator(fx_bg.jumped(jumps))
+    nqubits = 5
+    depth = 5
+    circuit = rand_circuit(nqubits, depth, rng)
+    pattern = circuit.transpile().pattern
+    opengraph = OpenGraph.from_pattern(pattern)
+    zx_graph = to_pyzx_graph(opengraph)
+    opengraph2 = from_pyzx_graph(zx_graph)
+    pattern2 = opengraph2.to_pattern()
+    pattern.perform_pauli_measurements()
+    pattern.minimize_space()
+    state = pattern.simulate_pattern()
+    pattern2.perform_pauli_measurements()
+    pattern2.minimize_space()
+    state2 = pattern2.simulate_pattern()
+    assert np.abs(np.dot(state.flatten().conjugate(), state2.flatten())) == pytest.approx(1)

--- a/tests/test_pyzx.py
+++ b/tests/test_pyzx.py
@@ -11,6 +11,7 @@ from numpy.random import PCG64, Generator
 
 from graphix.opengraph import OpenGraph
 from graphix.random_objects import rand_circuit
+from graphix.transpiler import Circuit
 
 if TYPE_CHECKING:
     from pyzx.graph.base import BaseGraph
@@ -95,3 +96,20 @@ def test_random_circuit(fx_bg: PCG64, jumps: int) -> None:
     pattern2.minimize_space()
     state2 = pattern2.simulate_pattern()
     assert np.abs(np.dot(state.flatten().conjugate(), state2.flatten())) == pytest.approx(1)
+
+
+def test_rz() -> None:
+    import pyzx as zx
+
+    from graphix.pyzx import from_pyzx_graph
+
+    circuit = Circuit(1)
+    circuit.rz(0, np.pi / 4)
+    pattern = circuit.transpile().pattern
+    circ = zx.qasm("qreg q[1]; rz(pi/4) q[0];")
+    g = circ.to_graph()
+    og = from_pyzx_graph(g)
+    pattern_zx = og.to_pattern()
+    state = pattern.simulate_pattern()
+    state_zx = pattern_zx.simulate_pattern()
+    assert np.abs(np.dot(state_zx.flatten().conjugate(), state.flatten())) == pytest.approx(1)


### PR DESCRIPTION
This commit moves `pyzx` from `requirements-dev.txt` to `requirements-extra.txt`, because this is not a development requirement but an optional dependency.

Tests succeed with pyzx 0.9.0. I am no longer able to reproduce the errors mentioned in #252 and in
https://github.com/TeamGraphix/graphix/pull/250#issuecomment-2676562457

graphix-ibmq and graphix-perceval are broken (in particular, they are not installable with Python 3.12). They should be fixed in #261; I comment them for now.

Dependabot can now track pyzx again.