### PR TITLE
Fix flow detection when generating patterns without internal node

### DIFF
--- a/graphix/generator.py
+++ b/graphix/generator.py
@@ -74,7 +74,7 @@ def generate_from_graph(
 
     # search for flow first
     f, l_k = find_flow(graph, set(inputs), set(outputs), meas_planes=meas_planes)
-    if f:
+    if f is not None:
         # flow found
         depth, layers = get_layers(l_k)
         pattern = Pattern(input_nodes=inputs)
@@ -98,7 +98,7 @@ def generate_from_graph(
     else:
         # no flow found - we try gflow
         g, l_k = find_gflow(graph, set(inputs), set(outputs), meas_planes=meas_planes)
-        if g:
+        if g is not None:
             # gflow found
             depth, layers = get_layers(l_k)
             pattern = Pattern(input_nodes=inputs)

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -82,9 +82,8 @@ class TestGenerator:
         state_mbqc = pattern2.simulate_pattern(rng=fx_rng)
         assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
-
     def test_pattern_generation_no_internal_nodes(self) -> None:
         g = nx.Graph()
         g.add_edges_from([(0, 1), (1, 2)])
-        pattern = generate_from_graph(g, dict(), {0, 1, 2}, {0, 1, 2}, dict())
+        pattern = generate_from_graph(g, {}, {0, 1, 2}, {0, 1, 2}, {})
         assert pattern.get_graph() == ([0, 1, 2], [(0, 1), (1, 2)])

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -83,7 +83,7 @@ class TestGenerator:
         assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
 
     def test_pattern_generation_no_internal_nodes(self) -> None:
-        g = nx.Graph()
+        g: nx.Graph[int] = nx.Graph()
         g.add_edges_from([(0, 1), (1, 2)])
         pattern = generate_from_graph(g, {}, {0, 1, 2}, {0, 1, 2}, {})
         assert pattern.get_graph() == ([0, 1, 2], [(0, 1), (1, 2)])

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -81,3 +81,10 @@ class TestGenerator:
         state = circuit.simulate_statevector().statevec
         state_mbqc = pattern2.simulate_pattern(rng=fx_rng)
         assert np.abs(np.dot(state_mbqc.flatten().conjugate(), state.flatten())) == pytest.approx(1)
+
+
+    def test_pattern_generation_no_internal_nodes(self) -> None:
+        g = nx.Graph()
+        g.add_edges_from([(0, 1), (1, 2)])
+        pattern = generate_from_graph(g, dict(), {0, 1, 2}, {0, 1, 2}, dict())
+        assert pattern.get_graph() == ([0, 1, 2], [(0, 1), (1, 2)])


### PR DESCRIPTION
This commit fixes `generate_from_graph` so that it correctly constructs patterns from graphs that have no internal nodes (i.e., when the input set and output set are equal). In this case, `find_flow` returns an empty flow, which should be distinguished from `None`.