### PR TITLE
Fix handling of plane YZ in Pauli flow

### DIFF
--- a/graphix/gflow.py
+++ b/graphix/gflow.py
@@ -19,11 +19,12 @@ from typing import TYPE_CHECKING
 import networkx as nx
 import numpy as np
 import sympy as sp
+from typing_extensions import assert_never
 
-from graphix import utils
 from graphix.command import CommandKind
-from graphix.fundamentals import Plane
+from graphix.fundamentals import Axis, Plane
 from graphix.linalg import MatGF2
+from graphix.measurements import PauliMeasurement
 
 if TYPE_CHECKING:
     from graphix.pattern import Pattern
@@ -1349,19 +1350,15 @@ def get_pauli_nodes(
     check_meas_planes(meas_planes)
     l_x, l_y, l_z = set(), set(), set()
     for node, plane in meas_planes.items():
-        if plane == Plane.XY:
-            if utils.is_integer(meas_angles[node]):  # measurement angle is integer
-                l_x |= {node}
-            elif utils.is_integer(2 * meas_angles[node]):  # measurement angle is half integer
-                l_y |= {node}
-        elif plane == Plane.XZ:
-            if utils.is_integer(meas_angles[node]):
-                l_z |= {node}
-            elif utils.is_integer(2 * meas_angles[node]):
-                l_x |= {node}
-        elif plane == Plane.YZ:
-            if utils.is_integer(meas_angles[node]):
-                l_y |= {node}
-            elif utils.is_integer(2 * meas_angles[node]):
-                l_z |= {node}
+        pm = PauliMeasurement.try_from(plane, meas_angles[node])
+        if pm is None:
+            continue
+        if pm.axis == Axis.X:
+            l_x |= {node}
+        elif pm.axis == Axis.Y:
+            l_y |= {node}
+        elif pm.axis == Axis.Z:
+            l_z |= {node}
+        else:
+            assert_never(pm.axis)
     return l_x, l_y, l_z

--- a/tests/test_gflow.py
+++ b/tests/test_gflow.py
@@ -272,7 +272,7 @@ def _graph8() -> GraphForTest:
         2: Plane.XY,
         3: Plane.YZ,
     }
-    meas_angles = {0: 0.5, 1: 0, 2: 0.5, 3: 0}
+    meas_angles = {0: 0, 1: 0, 2: 0.5, 3: 0.5}
     return GraphForTest(
         graph,
         inputs,
@@ -301,7 +301,7 @@ def _graph9() -> GraphForTest:
     graph.add_nodes_from(nodes)
     graph.add_edges_from(edges)
     meas_planes = {0: Plane.YZ, 1: Plane.XZ, 2: Plane.XY}
-    meas_angles = {0: 0.5, 1: 0.1, 2: 0.5}
+    meas_angles = {0: 0, 1: 0.1, 2: 0.5}
     return GraphForTest(
         graph,
         inputs,


### PR DESCRIPTION
@Newtech66 reported that the plane YZ was not handled correctly in Pauli flow (https://github.com/TeamGraphix/graphix/issues/279#issuecomment-2940199696):

> It's because the `get_pauli_nodes` method in `gflow.py` is incorrect. See here. Specifically, the cases for the Y Z plane are switched.

Test cases were written following the same incorrect convention and failed to detect the issue.  This commit fixes the test cases and uses the `PauliMeasurement.try_from` constructor instead of reimplementing the Pauli axis computation, ensuring the convention is defined in one place and for all.
