### PR TITLE
Resolve import loops

### DIFF
--- a/graphix/command.py
+++ b/graphix/command.py
@@ -18,8 +18,8 @@ from graphix.measurements import Domains
 # Ruff suggests to move this import to a type-checking block, but dataclass requires it here
 from graphix.parameter import ExpressionOrFloat  # noqa: TC001
 from graphix.pauli import Pauli
-from graphix.pretty_print import DataclassPrettyPrintMixin
 from graphix.states import BasicStates, State
+from graphix.utils import DataclassPrettyPrintMixin
 
 Node = int
 

--- a/graphix/command.py
+++ b/graphix/command.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import dataclasses
 import enum
+import math
 import sys
 from enum import Enum
-from typing import ClassVar, Literal, Union
+from typing import ClassVar, Literal, SupportsFloat, Union
 
 import numpy as np
 
@@ -18,6 +19,7 @@ from graphix.measurements import Domains
 # Ruff suggests to move this import to a type-checking block, but dataclass requires it here
 from graphix.parameter import ExpressionOrFloat  # noqa: TC001
 from graphix.pauli import Pauli
+from graphix.pretty_print import SUBSCRIPTS, SUPERSCRIPTS, OutputFormat, angle_to_str, domain_to_str
 from graphix.states import BasicStates, State
 from graphix.utils import DataclassPrettyPrintMixin
 
@@ -35,6 +37,96 @@ class CommandKind(Enum):
     Z = enum.auto()
     S = enum.auto()
     T = enum.auto()
+
+
+def command_to_str(cmd: Command, output: OutputFormat) -> str:
+    """Return the string representation of a command according to the given format.
+
+    Parameters
+    ----------
+    cmd: Command
+        The command to pretty print.
+    output: OutputFormat
+        The expected format.
+    """
+    out = [cmd.kind.name]
+
+    if cmd.kind == CommandKind.E:
+        u, v = cmd.nodes
+        if output == OutputFormat.LaTeX:
+            out.append(f"_{{{u},{v}}}")
+        elif output == OutputFormat.Unicode:
+            u_subscripts = str(u).translate(SUBSCRIPTS)
+            v_subscripts = str(v).translate(SUBSCRIPTS)
+            out.append(f"{u_subscripts}₋{v_subscripts}")
+        else:
+            out.append(f"({u},{v})")
+    elif cmd.kind == CommandKind.T:
+        pass
+    else:
+        # All other commands have a field `node` to print, together
+        # with some other arguments and/or domains.
+        arguments = []
+        if cmd.kind == CommandKind.M:
+            if cmd.plane != Plane.XY:
+                arguments.append(cmd.plane.name)
+            # We use `SupportsFloat` since `isinstance(cmd.angle, float)`
+            # is `False` if `cmd.angle` is an integer.
+            if isinstance(cmd.angle, SupportsFloat):
+                angle = float(cmd.angle)
+                if not math.isclose(angle, 0.0):
+                    arguments.append(angle_to_str(angle, output))
+            else:
+                # If the angle is a symbolic expression, we can only delegate the printing
+                # TODO: We should have a mean to specify the format
+                arguments.append(str(cmd.angle * math.pi))
+        elif cmd.kind == CommandKind.C:
+            arguments.append(str(cmd.clifford))
+        # Use of `==` here for mypy
+        command_domain = (
+            cmd.domain
+            if cmd.kind == CommandKind.X  # noqa: PLR1714
+            or cmd.kind == CommandKind.Z
+            or cmd.kind == CommandKind.S
+            else None
+        )
+        if output == OutputFormat.LaTeX:
+            out.append(f"_{{{cmd.node}}}")
+            if arguments:
+                out.append(f"^{{{','.join(arguments)}}}")
+        elif output == OutputFormat.Unicode:
+            node_subscripts = str(cmd.node).translate(SUBSCRIPTS)
+            out.append(f"{node_subscripts}")
+            if arguments:
+                out.append(f"({','.join(arguments)})")
+        else:
+            arguments = [str(cmd.node), *arguments]
+            if command_domain:
+                arguments.append(domain_to_str(command_domain))
+                command_domain = None
+            out.append(f"({','.join(arguments)})")
+        if cmd.kind == CommandKind.M and (cmd.s_domain or cmd.t_domain):
+            out = ["[", *out, "]"]
+            if cmd.t_domain:
+                if output == OutputFormat.LaTeX:
+                    t_domain_str = f"{{}}_{{{','.join(str(node) for node in cmd.t_domain)}}}"
+                elif output == OutputFormat.Unicode:
+                    t_domain_subscripts = [str(node).translate(SUBSCRIPTS) for node in cmd.t_domain]
+                    t_domain_str = "₊".join(t_domain_subscripts)
+                else:
+                    t_domain_str = f"{{{','.join(str(node) for node in cmd.t_domain)}}}"
+                out = [t_domain_str, *out]
+            command_domain = cmd.s_domain
+        if command_domain:
+            if output == OutputFormat.LaTeX:
+                domain_str = f"^{{{','.join(str(node) for node in command_domain)}}}"
+            elif output == OutputFormat.Unicode:
+                domain_superscripts = [str(node).translate(SUPERSCRIPTS) for node in command_domain]
+                domain_str = "⁺".join(domain_superscripts)
+            else:
+                domain_str = f"{{{','.join(str(node) for node in command_domain)}}}"
+            out.append(domain_str)
+    return f"{''.join(out)}"
 
 
 class _KindChecker:

--- a/graphix/fundamentals.py
+++ b/graphix/fundamentals.py
@@ -12,7 +12,7 @@ import typing_extensions
 
 from graphix.ops import Ops
 from graphix.parameter import cos_sin
-from graphix.pretty_print import EnumPrettyPrintMixin
+from graphix.utils import EnumPrettyPrintMixin
 
 if TYPE_CHECKING:
     import numpy as np

--- a/graphix/instruction.py
+++ b/graphix/instruction.py
@@ -14,7 +14,8 @@ from graphix.fundamentals import Plane
 
 # Ruff suggests to move this import to a type-checking block, but dataclass requires it here
 from graphix.parameter import ExpressionOrFloat  # noqa: TC001
-from graphix.pretty_print import DataclassPrettyPrintMixin, OutputFormat, angle_to_str
+from graphix.pretty_print import OutputFormat, angle_to_str
+from graphix.utils import DataclassPrettyPrintMixin
 
 
 def repr_angle(angle: ExpressionOrFloat) -> str:

--- a/graphix/pretty_print.py
+++ b/graphix/pretty_print.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import dataclasses
 import enum
 import math
 import string
-from dataclasses import MISSING
 from enum import Enum
 from fractions import Fraction
 from typing import TYPE_CHECKING, SupportsFloat
@@ -15,9 +13,6 @@ from graphix import command
 
 if TYPE_CHECKING:
     from collections.abc import Container
-
-    # these live only in the stub package, not at runtime
-    from _typeshed import DataclassInstance
 
     from graphix.command import Node
     from graphix.pattern import Pattern
@@ -223,64 +218,3 @@ def pattern_to_str(
     if truncated:
         return f"{result}...({len(command_list) - limit + 1} more commands)"
     return result
-
-
-class DataclassPrettyPrintMixin:
-    """
-    Mixin for a concise, eval-friendly `repr` of dataclasses.
-
-    Compared to the default dataclass `repr`:
-      - Class variables are omitted (dataclasses.fields only returns actual fields).
-      - Fields whose values equal their defaults are omitted.
-      - Field names are only shown when preceding fields have been omitted, ensuring positional listings when possible.
-
-    Use with `@dataclass(repr=False)` on the target class.
-    """
-
-    def __repr__(self: DataclassInstance) -> str:
-        """Return a representation string for a dataclass."""
-        cls_name = type(self).__name__
-        arguments = []
-        saw_omitted = False
-        for field in dataclasses.fields(self):
-            value = getattr(self, field.name)
-            if field.default is not MISSING or field.default_factory is not MISSING:
-                default = field.default_factory() if field.default_factory is not MISSING else field.default
-                if value == default:
-                    saw_omitted = True
-                    continue
-            custom_repr = field.metadata.get("repr")
-            value_str = custom_repr(value) if custom_repr else repr(value)
-            if saw_omitted:
-                arguments.append(f"{field.name}={value_str}")
-            else:
-                arguments.append(value_str)
-        arguments_str = ", ".join(arguments)
-        return f"{cls_name}({arguments_str})"
-
-
-class EnumPrettyPrintMixin:
-    """
-    Mixin to provide a concise, eval-friendly repr for Enum members.
-
-    Compared to the default `<ClassName.MEMBER_NAME: value>`, this mixin's `__repr__`
-    returns `ClassName.MEMBER_NAME`, which can be evaluated in Python (assuming the
-    enum class is in scope) to retrieve the same member.
-    """
-
-    def __repr__(self) -> str:
-        """
-        Return a representation string of an Enum member.
-
-        Returns
-        -------
-        str
-            A string in the form `ClassName.MEMBER_NAME`.
-        """
-        # Equivalently (as of Python 3.12), `str(value)` also produces
-        # "ClassName.MEMBER_NAME", but we build it explicitly here for
-        # clarity.
-        if not isinstance(self, Enum):
-            msg = "EnumMixin can only be used with Enum classes."
-            raise TypeError(msg)
-        return f"{self.__class__.__name__}.{self.name}"

--- a/graphix/pretty_print.py
+++ b/graphix/pretty_print.py
@@ -7,15 +7,6 @@ import math
 import string
 from enum import Enum
 from fractions import Fraction
-from typing import TYPE_CHECKING, SupportsFloat
-
-from graphix import command
-
-if TYPE_CHECKING:
-    from collections.abc import Container
-
-    from graphix.command import Node
-    from graphix.pattern import Pattern
 
 
 class OutputFormat(Enum):
@@ -82,139 +73,10 @@ def angle_to_str(angle: float, output: OutputFormat, max_denominator: int = 1000
     return f"{sign}{mkfrac(num_str, den_str)}"
 
 
-def domain_to_str(domain: set[Node]) -> str:
+def domain_to_str(domain: set[int]) -> str:
     """Return the string representation of a domain."""
     return f"{{{','.join(str(node) for node in domain)}}}"
 
 
 SUBSCRIPTS = str.maketrans(string.digits, "₀₁₂₃₄₅₆₇₈₉")
 SUPERSCRIPTS = str.maketrans(string.digits, "⁰¹²³⁴⁵⁶⁷⁸⁹")
-
-
-def command_to_str(cmd: command.Command, output: OutputFormat) -> str:
-    """Return the string representation of a command according to the given format.
-
-    Parameters
-    ----------
-    cmd: Command
-        The command to pretty print.
-    output: OutputFormat
-        The expected format.
-    """
-    # Circumvent circular import
-    from graphix.fundamentals import Plane
-
-    out = [cmd.kind.name]
-
-    if cmd.kind == command.CommandKind.E:
-        u, v = cmd.nodes
-        if output == OutputFormat.LaTeX:
-            out.append(f"_{{{u},{v}}}")
-        elif output == OutputFormat.Unicode:
-            u_subscripts = str(u).translate(SUBSCRIPTS)
-            v_subscripts = str(v).translate(SUBSCRIPTS)
-            out.append(f"{u_subscripts}₋{v_subscripts}")
-        else:
-            out.append(f"({u},{v})")
-    elif cmd.kind == command.CommandKind.T:
-        pass
-    else:
-        # All other commands have a field `node` to print, together
-        # with some other arguments and/or domains.
-        arguments = []
-        if cmd.kind == command.CommandKind.M:
-            if cmd.plane != Plane.XY:
-                arguments.append(cmd.plane.name)
-            # We use `SupportsFloat` since `isinstance(cmd.angle, float)`
-            # is `False` if `cmd.angle` is an integer.
-            if isinstance(cmd.angle, SupportsFloat):
-                angle = float(cmd.angle)
-                if not math.isclose(angle, 0.0):
-                    arguments.append(angle_to_str(angle, output))
-            else:
-                # If the angle is a symbolic expression, we can only delegate the printing
-                # TODO: We should have a mean to specify the format
-                arguments.append(str(cmd.angle * math.pi))
-        elif cmd.kind == command.CommandKind.C:
-            arguments.append(str(cmd.clifford))
-        # Use of `==` here for mypy
-        command_domain = (
-            cmd.domain
-            if cmd.kind == command.CommandKind.X  # noqa: PLR1714
-            or cmd.kind == command.CommandKind.Z
-            or cmd.kind == command.CommandKind.S
-            else None
-        )
-        if output == OutputFormat.LaTeX:
-            out.append(f"_{{{cmd.node}}}")
-            if arguments:
-                out.append(f"^{{{','.join(arguments)}}}")
-        elif output == OutputFormat.Unicode:
-            node_subscripts = str(cmd.node).translate(SUBSCRIPTS)
-            out.append(f"{node_subscripts}")
-            if arguments:
-                out.append(f"({','.join(arguments)})")
-        else:
-            arguments = [str(cmd.node), *arguments]
-            if command_domain:
-                arguments.append(domain_to_str(command_domain))
-                command_domain = None
-            out.append(f"({','.join(arguments)})")
-        if cmd.kind == command.CommandKind.M and (cmd.s_domain or cmd.t_domain):
-            out = ["[", *out, "]"]
-            if cmd.t_domain:
-                if output == OutputFormat.LaTeX:
-                    t_domain_str = f"{{}}_{{{','.join(str(node) for node in cmd.t_domain)}}}"
-                elif output == OutputFormat.Unicode:
-                    t_domain_subscripts = [str(node).translate(SUBSCRIPTS) for node in cmd.t_domain]
-                    t_domain_str = "₊".join(t_domain_subscripts)
-                else:
-                    t_domain_str = f"{{{','.join(str(node) for node in cmd.t_domain)}}}"
-                out = [t_domain_str, *out]
-            command_domain = cmd.s_domain
-        if command_domain:
-            if output == OutputFormat.LaTeX:
-                domain_str = f"^{{{','.join(str(node) for node in command_domain)}}}"
-            elif output == OutputFormat.Unicode:
-                domain_superscripts = [str(node).translate(SUPERSCRIPTS) for node in command_domain]
-                domain_str = "⁺".join(domain_superscripts)
-            else:
-                domain_str = f"{{{','.join(str(node) for node in command_domain)}}}"
-            out.append(domain_str)
-    return f"{''.join(out)}"
-
-
-def pattern_to_str(
-    pattern: Pattern,
-    output: OutputFormat,
-    left_to_right: bool = False,
-    limit: int = 40,
-    target: Container[command.CommandKind] | None = None,
-) -> str:
-    """Return the string representation of a pattern according to the given format.
-
-    Parameters
-    ----------
-    pattern: Pattern
-        The pattern to pretty print.
-    output: OutputFormat
-        The expected format.
-    left_to_right: bool
-        Optional. If `True`, the first command will appear on the beginning of
-        the resulting string. If `False` (the default), the first command will
-        appear at the end of the string.
-    """
-    separator = r"\," if output == OutputFormat.LaTeX else " "
-    command_list = list(pattern)
-    if target is not None:
-        command_list = [command for command in command_list if command.kind in target]
-    if not left_to_right:
-        command_list.reverse()
-    truncated = len(command_list) > limit
-    short_command_list = command_list[: limit - 1] if truncated else command_list
-    result = separator.join(command_to_str(command, output) for command in short_command_list)
-    if output == OutputFormat.LaTeX:
-        result = f"\\({result}\\)"
-    if truncated:
-        return f"{result}...({len(command_list) - limit + 1} more commands)"
-    return result

--- a/graphix/random_objects.py
+++ b/graphix/random_objects.py
@@ -13,6 +13,7 @@ from scipy.stats import unitary_group
 from graphix.channels import KrausChannel, KrausData
 from graphix.ops import Ops
 from graphix.rng import ensure_rng
+from graphix.sim.density_matrix import DensityMatrix
 from graphix.transpiler import Circuit
 
 if TYPE_CHECKING:
@@ -21,7 +22,6 @@ if TYPE_CHECKING:
     from numpy.random import Generator
 
     from graphix.parameter import Parameter
-    from graphix.sim.density_matrix import DensityMatrix
 
 
 def rand_herm(sz: int, rng: Generator | None = None) -> npt.NDArray:
@@ -80,8 +80,6 @@ def rand_dm(
     dm = rand_u @ dm @ rand_u.transpose().conj()
 
     if dm_dtype:
-        from graphix.sim.density_matrix import DensityMatrix  # circumvent circular import
-
         # will raise an error if incorrect dimension
         return DensityMatrix(data=dm)
     return dm

--- a/graphix/utils.py
+++ b/graphix/utils.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import dataclasses
 import sys
 import typing
+from dataclasses import MISSING
+from enum import Enum
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, SupportsInt, TypeVar
 
 import numpy as np
@@ -11,6 +14,9 @@ import numpy.typing as npt
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
+
+    # these live only in the stub package, not at runtime
+    from _typeshed import DataclassInstance
 
 _T = TypeVar("_T")
 
@@ -82,3 +88,64 @@ def iter_empty(it: Iterator[_T]) -> bool:
     This function consumes the iterator.
     """
     return all(False for _ in it)
+
+
+class DataclassPrettyPrintMixin:
+    """
+    Mixin for a concise, eval-friendly `repr` of dataclasses.
+
+    Compared to the default dataclass `repr`:
+      - Class variables are omitted (dataclasses.fields only returns actual fields).
+      - Fields whose values equal their defaults are omitted.
+      - Field names are only shown when preceding fields have been omitted, ensuring positional listings when possible.
+
+    Use with `@dataclass(repr=False)` on the target class.
+    """
+
+    def __repr__(self: DataclassInstance) -> str:
+        """Return a representation string for a dataclass."""
+        cls_name = type(self).__name__
+        arguments = []
+        saw_omitted = False
+        for field in dataclasses.fields(self):
+            value = getattr(self, field.name)
+            if field.default is not MISSING or field.default_factory is not MISSING:
+                default = field.default_factory() if field.default_factory is not MISSING else field.default
+                if value == default:
+                    saw_omitted = True
+                    continue
+            custom_repr = field.metadata.get("repr")
+            value_str = custom_repr(value) if custom_repr else repr(value)
+            if saw_omitted:
+                arguments.append(f"{field.name}={value_str}")
+            else:
+                arguments.append(value_str)
+        arguments_str = ", ".join(arguments)
+        return f"{cls_name}({arguments_str})"
+
+
+class EnumPrettyPrintMixin:
+    """
+    Mixin to provide a concise, eval-friendly repr for Enum members.
+
+    Compared to the default `<ClassName.MEMBER_NAME: value>`, this mixin's `__repr__`
+    returns `ClassName.MEMBER_NAME`, which can be evaluated in Python (assuming the
+    enum class is in scope) to retrieve the same member.
+    """
+
+    def __repr__(self) -> str:
+        """
+        Return a representation string of an Enum member.
+
+        Returns
+        -------
+        str
+            A string in the form `ClassName.MEMBER_NAME`.
+        """
+        # Equivalently (as of Python 3.12), `str(value)` also produces
+        # "ClassName.MEMBER_NAME", but we build it explicitly here for
+        # clarity.
+        if not isinstance(self, Enum):
+            msg = "EnumMixin can only be used with Enum classes."
+            raise TypeError(msg)
+        return f"{self.__class__.__name__}.{self.name}"

--- a/graphix/utils.py
+++ b/graphix/utils.py
@@ -37,7 +37,7 @@ def check_kind(cls: type, scope: dict[str, Any]) -> None:
         # MEMO: `inspect.get_annotations` unavailable
         return
 
-    import inspect
+    import inspect  # noqa: PLC0415
 
     ann = inspect.get_annotations(cls, eval_str=True, locals=scope).get("kind")
     if ann is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ extend-ignore = [
   "DOC",     # Docstring
   "E501",    # Line too long
   "EM10",    # Raise string
-  "PLC0415", # Import not at the top level
   "PLR1702", # Too many nests
   "PLW1641", # __hash__ missing
   "PT011",   # pytest raises too broad
@@ -110,8 +109,15 @@ docstring-code-format = true
 ]
 "tests/*.py" = [
   "D10",     # Allow undocumented items
+  "PLC0415", # Allow dynamic imports
   "PLC2701", # Allow private imports
   "PLR6301", # self not used
+]
+"graphix/device_interface.py" = [
+  "PLC0415", # Allow dynamic imports
+]
+"graphix/pyzx.py" = [
+  "PLC0415", # Allow dynamic imports
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/tests/test_pretty_print.py
+++ b/tests/test_pretty_print.py
@@ -8,8 +8,8 @@ from numpy.random import PCG64, Generator
 from graphix import command, instruction
 from graphix.clifford import Clifford
 from graphix.fundamentals import Plane
-from graphix.pattern import Pattern
-from graphix.pretty_print import OutputFormat, pattern_to_str
+from graphix.pattern import Pattern, pattern_to_str
+from graphix.pretty_print import OutputFormat
 from graphix.random_objects import rand_circuit
 from graphix.transpiler import Circuit
 


### PR DESCRIPTION
**Context (if applicable):**

This PR fixes another import loop causing problems in #280 .

**Description of the change:**

- Resolve import loops caused by `prety_print.py` 
- Enforce top-level imports by `ruff`
  - Some exceptions exist: see `pyproject.toml` .

After merging this PR, for all the typed files, `import` will become completely loop-free.

![loops-pruned](https://github.com/user-attachments/assets/08343a4c-1ec2-4238-91a2-45d0383287f0)

