### PR TITLE
Fix reverse dependency in `noxfile.py`: use temporary directory

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -26,8 +26,15 @@ def tests(session: Session) -> None:
 def tests_symbolic(session: Session) -> None:
     """Run the test suite of graphix-symbolic."""
     session.install("-e", ".[dev]")
-    # If you need a specific branch:
-    # session.run("git", "clone", "-b", "branch-name", "https://github.com/TeamGraphix/graphix-symbolic")
-    session.run("git", "clone", "https://github.com/TeamGraphix/graphix-symbolic")
-    session.cd("graphix-symbolic")
-    session.run("pytest")
+    # Temporary directory, otherwise nox clones graphix-symbolic in the working directory
+    original_dir = Path.cwd()
+    with TemporaryDirectory() as tmpdir:
+        session.cd(tmpdir)
+        # If you need a specific branch:
+        # session.run("git", "clone", "-b", "branch-name", "https://github.com/TeamGraphix/graphix-symbolic")
+        session.run("git", "clone", "https://github.com/TeamGraphix/graphix-symbolic")
+        session.cd("graphix-symbolic")
+        session.run("pytest")
+        # Leave the directory before exiting `with` so that the
+        # temporary directory can be deleted even on Windows
+        session.cd(original_dir)


### PR DESCRIPTION
This commit updates `noxfile.py` to use a temporary directory when cloning the reverse dependency `graphix-symbolic`.

@EarlMilkea [suggested](https://github.com/TeamGraphix/graphix/pull/302#discussion_r2144162380) extracting this specific change from #302, as it is unrelated to the rest of that PR.

Previously, `noxfile.py` cloned `graphix-symbolic` directly into the working directory without cleanup. As a result, the `graphix-symbolic` directory persisted after running `nox`, causing subsequent calls to `pytest` to fail due to multiple `conftest.py` files being present (one in `tests/`, and another in `graphix-symbolic/tests/`).