### PR TITLE
Feature pattern from pflow

### DIFF
--- a/graphix/generator.py
+++ b/graphix/generator.py
@@ -118,7 +118,7 @@ def _flow2pattern(
         pattern.add(N(node=i))
     for e in graph.edges:
         pattern.add(E(nodes=e))
-    measured = []
+    measured: list[int] = []
     for i in range(depth, 0, -1):  # i from depth, depth-1, ... 1
         for j in layers[i]:
             measured.append(j)
@@ -179,7 +179,7 @@ def _pflow2pattern(
         for j in layers[i]:
             pattern.add(M(node=j, plane=meas_planes[j], angle=angles[j]))
             odd_neighbors = find_odd_neighbor(graph, p[j])
-            future_nodes = set.union(
+            future_nodes: set[int] = set.union(
                 *(nodes for (layer, nodes) in layers.items() if layer < i)
             )  # {k | k > j}, with "j" last corrected node and ">" the Pauli flow ordering
             for k in odd_neighbors & future_nodes:

--- a/graphix/gflow.py
+++ b/graphix/gflow.py
@@ -233,7 +233,7 @@ def gflowaux(
 
 
 def find_flow(
-    graph: nx.Graph,
+    graph: nx.Graph[int],
     iset: set[int],
     oset: set[int],
     meas_planes: dict[int, Plane] | None = None,
@@ -359,7 +359,7 @@ def flowaux(
 
 
 def find_pauliflow(
-    graph: nx.Graph,
+    graph: nx.Graph[int],
     iset: set[int],
     oset: set[int],
     meas_planes: dict[int, Plane],
@@ -898,7 +898,7 @@ def search_neighbor(node: int, edges: set[tuple[int, int]]) -> set[int]:
     return nb
 
 
-def get_min_depth(l_k: dict[int, int]) -> int:
+def get_min_depth(l_k: Mapping[int, int]) -> int:
     """Get minimum depth of graph.
 
     Parameters
@@ -914,7 +914,7 @@ def get_min_depth(l_k: dict[int, int]) -> int:
     return max(l_k.values())
 
 
-def find_odd_neighbor(graph: nx.Graph, vertices: AbstractSet[int]) -> set[int]:
+def find_odd_neighbor(graph: nx.Graph[int], vertices: AbstractSet[int]) -> set[int]:
     """Return the set containing the odd neighbor of a set of vertices.
 
     Parameters
@@ -952,7 +952,7 @@ def get_layers(l_k: Mapping[int, int]) -> tuple[int, dict[int, set[int]]]:
         components of each layer
     """
     d = get_min_depth(l_k)
-    layers = {k: set() for k in range(d + 1)}
+    layers: dict[int, set[int]] = {k: set() for k in range(d + 1)}
     for i, val in l_k.items():
         layers[val] |= {i}
     return d, layers

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -37,7 +37,10 @@ class TestGenerator:
         outputs = [9, 8]
 
         # Heuristic mixture of Pauli and non-Pauli angles ensuring there's no gflow but there's pflow.
-        meas_angles = {**dict.fromkeys(range(4), 0), **dict(zip(range(4, 8), (2 * fx_rng.random(4)).tolist()))}
+        meas_angles: dict[int, float] = {
+            **dict.fromkeys(range(4), 0),
+            **dict(zip(range(4, 8), (2 * fx_rng.random(4)).tolist())),
+        }
         meas_planes = dict.fromkeys(range(8), Plane.XY)
         meas = {i: Measurement(angle, plane) for (i, angle), plane in zip(meas_angles.items(), meas_planes.values())}
 


### PR DESCRIPTION
**Description of the change**

Extended `:func: graphix.generator.generate_from_graph` to generate patterns from open graphs which have Pauli flow only according to theorem 4 of [Browne et al., NJP 9, 250 (2007)].

To facilitate the PR review, the new code follows closely the existing structure for constructing a pattern from causal flow or gflow. In future versions, `:func: graphix.generator.generate_from_graph` could be abstracted, e.g., by introducing new callables `flow2pattern`, `gflow2pattern`, `pflow2pattern` (which could be methods of an eventual Flow class).

Additionally, this PR fixes https://github.com/qat-inria/graphix/issues/3 and https://github.com/qat-inria/graphix/issues/3.

**Additional comments**

Minor changes in gflow.py to enable type-checking for generator.py and test_generator.py