### PR TITLE
Feature compose open graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Method for `OpenGraph`: `compose`
+
 - #277: Methods for pretty-printing `Pattern`: `to_ascii`,
   `to_unicode`, `to_latex`.
 

--- a/graphix/opengraph.py
+++ b/graphix/opengraph.py
@@ -126,7 +126,7 @@ class OpenGraph:
         other : OpenGraph
             open graph to be composed with `self`.
         mapping: dict[int, int]
-            Partial relabelling of the nodes in `other`, with `keys` and `values` denoting the new and old node label, respectively.
+            Partial relabelling of the nodes in `other`, with `keys` and `values` denoting the old and new node label, respectively.
 
         Returns
         -------

--- a/graphix/opengraph.py
+++ b/graphix/opengraph.py
@@ -154,8 +154,6 @@ class OpenGraph:
         """
         if not set(custom_mapping.keys()) <= set(other.inside.nodes):
             raise ValueError("Keys of custom_mapping must be correspond to nodes of other.")
-        if len(custom_mapping.keys()) != len(set(custom_mapping.keys())):
-            raise ValueError("Keys in custom_mapping contain duplicates.")
         if len(custom_mapping.values()) != len(set(custom_mapping.values())):
             raise ValueError("Values in custom_mapping contain duplicates.")
         for v, u in custom_mapping.items():

--- a/graphix/opengraph.py
+++ b/graphix/opengraph.py
@@ -173,7 +173,7 @@ class OpenGraph:
 
         merged = set(mapping.values()) & set(self.inside.nodes())
 
-        def merge_ports(p1, p2):
+        def merge_ports(p1: list[int], p2: list[int]) -> list[int]:
             p2_mapped = [mapping[node] for node in p2]
             p2_set = set(p2_mapped)
             part1 = [node for node in p1 if node not in merged or node in p2_set]

--- a/graphix/opengraph.py
+++ b/graphix/opengraph.py
@@ -173,13 +173,15 @@ class OpenGraph:
 
         merged = set(mapping.values()) & set(self.inside.nodes())
 
-        i1 = set(self.inputs)
-        i2 = {mapping[i] for i in other.inputs}
-        inputs = (i1 - (i1 & merged)) | (i2 - (i2 & merged)) | (i1 & i2 & merged)
+        def merge_ports(p1, p2):
+            p2_mapped = [mapping[node] for node in p2]
+            p2_set = set(p2_mapped)
+            part1 = [node for node in p1 if node not in merged or node in p2_set]
+            part2 = [node for node in p2_mapped if node not in merged]
+            return part1 + part2
 
-        o1 = set(self.outputs)
-        o2 = {mapping[i] for i in other.outputs}
-        outputs = (o1 - (o1 & merged)) | (o2 - (o2 & merged)) | (o1 & o2 & merged)
+        inputs = merge_ports(self.inputs, other.inputs)
+        outputs = merge_ports(self.outputs, other.outputs)
 
         measurements_shifted = {
             mapping[i]: meas for i, meas in other.measurements.items()

--- a/graphix/opengraph.py
+++ b/graphix/opengraph.py
@@ -151,9 +151,9 @@ class OpenGraph:
         - If only one node of the pair `{v:u}` is measured, this measure is assigned to :math:`u \in V` in the resulting open graph.
         - Input (and, respectively, output) nodes in the returned open graph have the order of the open graph `self` followed by those of the open graph `other`. Merged nodes are removed, except when they are input (or output) nodes in both open graphs, in which case, they appear in the order they originally had in the graph `self`.
         """
-        if not mapping.keys() <= other.inside.nodes:
+        if not (mapping.keys() <= other.inside.nodes):
             raise ValueError("Keys of mapping must be correspond to nodes of other.")
-        if len(mapping.values()) != len(set(mapping.values())):
+        if len(mapping) != len(set(mapping.values())):
             raise ValueError("Values in mapping contain duplicates.")
         for v, u in mapping.items():
             if (

--- a/graphix/opengraph.py
+++ b/graphix/opengraph.py
@@ -145,8 +145,8 @@ class OpenGraph:
         - :math:`V \subseteq V_2`.
         - If both `v` and `u` are measured, the corresponding measurements must have the same plane and angle.
          The returned open graph follows this convention:
-        - :math:`I = [I_1 \setminus (I_1 \cap M)] \cup [I_2 \setminus (I_2 \cap M)] \cup (I_1 \cap I_2 \cap M)`,
-        - :math:`O = [O_1 \setminus (O_1 \cap M)] \cup [O_2 \setminus (O_2 \cap M)] \cup (O_1 \cap O_2 \cap M)`,
+        - :math:`I = (I_1 \cup I_2) \setminus M \cup (I_1 \cap I_2 \cap M)`,
+        - :math:`O = (O_1 \cup O_2) \setminus M \cup (O_1 \cap O_2 \cap M)`,
         - If only one node of the pair `{v:u}` is measured, this measure is assigned to :math:`u \in V` in the resulting open graph.
         """
         if not set(mapping.keys()) <= set(other.inside.nodes):

--- a/graphix/opengraph.py
+++ b/graphix/opengraph.py
@@ -176,7 +176,7 @@ class OpenGraph:
         g2_shifted = nx.relabel_nodes(other.inside, mapping)
         g = nx.compose(self.inside, g2_shifted)
 
-        merged = {i for i in custom_mapping.values() if i in self.inside.nodes()}
+        merged = set(custom_mapping.values()) & set(self.inside.nodes())
 
         i1 = set(self.inputs)
         i2 = {mapping[i] for i in other.inputs}

--- a/graphix/opengraph.py
+++ b/graphix/opengraph.py
@@ -188,4 +188,4 @@ class OpenGraph:
         }
         measurements = {**self.measurements, **measurements_shifted}
 
-        return OpenGraph(g, measurements, sorted(inputs), sorted(outputs))
+        return OpenGraph(g, measurements, inputs, outputs)

--- a/graphix/opengraph.py
+++ b/graphix/opengraph.py
@@ -141,13 +141,16 @@ class OpenGraph:
         Notes
         -----
         Let's denote :math:`\{G(V_1, E_1), I_1, O_1\}` the open graph `self`, :math:`\{G(V_2, E_2), I_2, O_2\}` the open graph `other`, :math:`\{G(V, E), I, O\}` the open graph `og` and `{v:u}` an element of `custom_mapping`.
+
+        We define :math:`V, U` the set of nodes in `custom_mapping.keys()` and `custom_mapping.values()`, and :math:`M = U \cap V_1` the set of merged nodes.
+
         The open graph composition requires that
-        - :math:`v \in V_2`.
+        - :math:`V \subseteq V_2`.
         - If both `v` and `u` are measured, the corresponding measurements must have the same plane and angle.
-        Further:
-        - :math:`u \in I \iff v \in I_1, u \in I_2`,
-        - :math:`u \in O \iff v \in O_1, u \in O_2`,
-        - If only one node of the pair `{v:u}` is measured, this measure is kept in the resulting open graph.
+         The returned open graph follows this convention:
+        - :math:`I = [I_1 \setminus (I_1 \cap M)] \cup [I_2 \setminus (I_2 \cap M)] \cup (I_1 \cap I_2 \cap M)`,
+        - :math:`O = [O_1 \setminus (O_1 \cap M)] \cup [O_2 \setminus (O_2 \cap M)] \cup (O_1 \cap O_2 \cap M)`,
+        - If only one node of the pair `{v:u}` is measured, this measure is assigned to :math:`u \in V` in the resulting open graph.
         """
         if not set(custom_mapping.keys()) <= set(other.inside.nodes):
             raise ValueError("Keys of custom_mapping must be correspond to nodes of other.")

--- a/graphix/opengraph.py
+++ b/graphix/opengraph.py
@@ -16,7 +16,6 @@ if TYPE_CHECKING:
     from graphix.pattern import Pattern
 
 
-
 @dataclass(frozen=True)
 class OpenGraph:
     """Open graph contains the graph, measurement, and input and output nodes.

--- a/graphix/opengraph.py
+++ b/graphix/opengraph.py
@@ -162,7 +162,7 @@ class OpenGraph:
             if v in other.measurements and u in self.measurements and not other.measurements[v].isclose(self.measurements[u]):
                     raise ValueError(f"Attempted to merge nodes {v}:{u} but have different measurements")
 
-        shift = max(chain(self.inside.nodes, custom_mapping.values())) + 1
+        shift = max(*self.inside.nodes, *custom_mapping.values()) + 1
 
         mapping = {
             node: shift + i

--- a/graphix/opengraph.py
+++ b/graphix/opengraph.py
@@ -124,7 +124,7 @@ class OpenGraph:
         return generate_from_graph(g, angles, inputs, outputs, planes)
 
     def compose(self, other: OpenGraph, custom_mapping: dict[int, int]) -> OpenGraph:
-        r"""Composes two open graphs by merging a subset of nodes of `self` and a subset of nodes of `other`.
+        r"""Compose two open graphs by merging a subset of nodes of `self` and a subset of nodes of `other`.
 
         Parameters
         ----------

--- a/graphix/opengraph.py
+++ b/graphix/opengraph.py
@@ -80,7 +80,10 @@ class OpenGraph:
         if set(self.measurements.keys()) != set(other.measurements.keys()):
             return False
 
-        return all(m.isclose(other.measurements[node], rel_tol=rel_tol, abs_tol=abs_tol) for node, m in self.measurements.items())
+        return all(
+            m.isclose(other.measurements[node], rel_tol=rel_tol, abs_tol=abs_tol)
+            for node, m in self.measurements.items()
+        )
 
     @staticmethod
     def from_pattern(pattern: Pattern) -> OpenGraph:
@@ -95,10 +98,7 @@ class OpenGraph:
 
         meas_planes = pattern.get_meas_plane()
         meas_angles = pattern.get_angles()
-        meas = {
-            node: Measurement(meas_angles[node], meas_planes[node])
-            for node in meas_angles
-        }
+        meas = {node: Measurement(meas_angles[node], meas_planes[node]) for node in meas_angles}
 
         return OpenGraph(g, meas, inputs, outputs)
 
@@ -153,14 +153,18 @@ class OpenGraph:
         if len(mapping.values()) != len(set(mapping.values())):
             raise ValueError("Values in mapping contain duplicates.")
         for v, u in mapping.items():
-            if v in other.measurements and u in self.measurements and not other.measurements[v].isclose(self.measurements[u]):
-                    raise ValueError(f"Attempted to merge nodes {v}:{u} but have different measurements")
+            if (
+                v in other.measurements
+                and u in self.measurements
+                and not other.measurements[v].isclose(self.measurements[u])
+            ):
+                raise ValueError(f"Attempted to merge nodes {v}:{u} but have different measurements")
 
         shift = max(*self.inside.nodes, *mapping.values()) + 1
 
         mapping_sequential = {
-            node: i
-            for i, node in enumerate(sorted(set(other.inside.nodes) - mapping.keys()), start=shift)}  # assigns new labels to nodes in other not specified in mapping
+            node: i for i, node in enumerate(sorted(set(other.inside.nodes) - mapping.keys()), start=shift)
+        }  # assigns new labels to nodes in other not specified in mapping
 
         mapping = {**mapping, **mapping_sequential}
 
@@ -179,9 +183,7 @@ class OpenGraph:
         inputs = merge_ports(self.inputs, other.inputs)
         outputs = merge_ports(self.outputs, other.outputs)
 
-        measurements_shifted = {
-            mapping[i]: meas for i, meas in other.measurements.items()
-        }
+        measurements_shifted = {mapping[i]: meas for i, meas in other.measurements.items()}
         measurements = {**self.measurements, **measurements_shifted}
 
         return OpenGraph(g, measurements, inputs, outputs)

--- a/graphix/opengraph.py
+++ b/graphix/opengraph.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from itertools import chain
 from typing import TYPE_CHECKING
 
 import networkx as nx
@@ -12,7 +11,10 @@ from graphix.generator import generate_from_graph
 from graphix.measurements import Measurement
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from graphix.pattern import Pattern
+
 
 
 @dataclass(frozen=True)
@@ -118,7 +120,7 @@ class OpenGraph:
 
         return generate_from_graph(g, angles, inputs, outputs, planes)
 
-    def compose(self, other: OpenGraph, mapping: dict[int, int]) -> OpenGraph:
+    def compose(self, other: OpenGraph, mapping: Mapping[int, int]) -> OpenGraph:
         r"""Compose two open graphs by merging a subset of nodes of `self` and a subset of nodes of `other`.
 
         Parameters

--- a/graphix/opengraph.py
+++ b/graphix/opengraph.py
@@ -11,7 +11,7 @@ from graphix.generator import generate_from_graph
 from graphix.measurements import Measurement
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Iterable, Mapping
 
     from graphix.pattern import Pattern
 
@@ -176,7 +176,7 @@ class OpenGraph:
 
         merged = set(mapping_complete.values()) & self.inside.nodes
 
-        def merge_ports(p1: list[int], p2: list[int]) -> list[int]:
+        def merge_ports(p1: Iterable[int], p2: Iterable[int]) -> list[int]:
             p2_mapped = [mapping_complete[node] for node in p2]
             p2_set = set(p2_mapped)
             part1 = [node for node in p1 if node not in merged or node in p2_set]

--- a/graphix/opengraph.py
+++ b/graphix/opengraph.py
@@ -61,9 +61,7 @@ class OpenGraph:
         if len(set(self.outputs)) != len(self.outputs):
             raise ValueError("Output nodes contain duplicates.")
 
-    def isclose(
-        self, other: OpenGraph, rel_tol: float = 1e-09, abs_tol: float = 0.0
-    ) -> bool:
+    def isclose(self, other: OpenGraph, rel_tol: float = 1e-09, abs_tol: float = 0.0) -> bool:
         """Return `True` if two open graphs implement approximately the same unitary operator.
 
         Ensures the structure of the graphs are the same and all
@@ -81,10 +79,7 @@ class OpenGraph:
         if set(self.measurements.keys()) != set(other.measurements.keys()):
             return False
 
-        return all(
-            m.isclose(other.measurements[node], rel_tol=rel_tol, abs_tol=abs_tol)
-            for node, m in self.measurements.items()
-        )
+        return all(m.isclose(other.measurements[node], rel_tol=rel_tol, abs_tol=abs_tol) for node, m in self.measurements.items())
 
     @staticmethod
     def from_pattern(pattern: Pattern) -> OpenGraph:

--- a/graphix/opengraph.py
+++ b/graphix/opengraph.py
@@ -140,7 +140,7 @@ class OpenGraph:
 
         Notes
         -----
-        Let's denote :math:`\{G(V_1, E_1), I_1, O_1\}` the open graph `self`, :math:`\{G(V_2, E_2), I_2, O_2\}` the open graph `other`, :math:`\{G(V, E), I, O\}` the open graph `og` and `{v:u}` an element of `custom_mapping`.
+        Let's denote :math:`\{G(V_1, E_1), I_1, O_1\}` the open graph `self`, :math:`\{G(V_2, E_2), I_2, O_2\}` the open graph `other`, :math:`\{G(V, E), I, O\}` the resulting open graph `og` and `{v:u}` an element of `custom_mapping`.
 
         We define :math:`V, U` the set of nodes in `custom_mapping.keys()` and `custom_mapping.values()`, and :math:`M = U \cap V_1` the set of merged nodes.
 

--- a/graphix/opengraph.py
+++ b/graphix/opengraph.py
@@ -160,11 +160,8 @@ class OpenGraph:
         shift = max(*self.inside.nodes, *mapping.values()) + 1
 
         mapping_sequential = {
-            node: shift + i
-            for i, node in enumerate(
-                filter(lambda node: node not in mapping, other.inside.nodes)
-            )
-        }  # assigns new labels to nodes in other not specified in mapping
+            node: i
+            for i, node in enumerate(sorted(set(other.inside.nodes) - mapping.keys()), start=shift)}  # assigns new labels to nodes in other not specified in mapping
 
         mapping = {**mapping, **mapping_sequential}
 

--- a/graphix/opengraph.py
+++ b/graphix/opengraph.py
@@ -149,6 +149,7 @@ class OpenGraph:
         - :math:`I = (I_1 \cup I_2) \setminus M \cup (I_1 \cap I_2 \cap M)`,
         - :math:`O = (O_1 \cup O_2) \setminus M \cup (O_1 \cap O_2 \cap M)`,
         - If only one node of the pair `{v:u}` is measured, this measure is assigned to :math:`u \in V` in the resulting open graph.
+        - Input (and, respectively, output) nodes in the returned open graph have the order of the open graph `self` followed by those of the open graph `other`. Merged nodes are removed, except when they are input (or output) nodes in both open graphs, in which case, they appear in the order they originally had in the graph `self`.
         """
         if not set(mapping.keys()) <= set(other.inside.nodes):
             raise ValueError("Keys of mapping must be correspond to nodes of other.")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ pyright
 ruff==0.12.3
 
 # Stubs
-types-networkx<=3.5.0.20250610
+types-networkx<=3.5.0.20250701
 types-psutil
 types-setuptools
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ pyright
 ruff==0.12.3
 
 # Stubs
-types-networkx==3.5.0.20250610
+types-networkx==3.4.2.20250509
 types-psutil
 types-setuptools
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Lint/format
-mypy
+mypy==1.16.1
 pre-commit # for language-agnostic hooks
 pyright
 ruff==0.12.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ pyright
 ruff==0.12.3
 
 # Stubs
-types-networkx==3.4.2.20250509
+types-networkx<=3.5.0.20250610
 types-psutil
 types-setuptools
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ pyright
 ruff==0.12.3
 
 # Stubs
-types-networkx
+types-networkx==3.5.0.20250610
 types-psutil
 types-setuptools
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,11 @@
 # Lint/format
-mypy==1.16.1
+mypy
 pre-commit # for language-agnostic hooks
 pyright
 ruff==0.12.3
 
 # Stubs
-types-networkx<=3.5.0.20250701
+types-networkx
 types-psutil
 types-setuptools
 

--- a/tests/test_opengraph.py
+++ b/tests/test_opengraph.py
@@ -10,7 +10,6 @@ from graphix.opengraph import OpenGraph
 # Tests whether an open graph can be converted to and from a pattern and be
 # successfully reconstructed.
 def test_open_graph_to_pattern() -> None:
-    g: nx.Graph[int]
     g = nx.Graph([(0, 1), (1, 2)])
     inputs = [0]
     outputs = [2]
@@ -47,7 +46,6 @@ def test_open_graph_to_pattern() -> None:
 
 # Parallel composition
 def test_compose_1() -> None:
-
     # Graph 1
     # [1] -- (2)
     #
@@ -60,7 +58,6 @@ def test_compose_1() -> None:
     #
     # [100] -- (200)
 
-    g: nx.Graph[int]
     g = nx.Graph([(1, 2)])
     inputs = [1]
     outputs = [2]
@@ -83,7 +80,6 @@ def test_compose_1() -> None:
 
 # Series composition
 def test_compose_2() -> None:
-
     # Graph 1
     # [0] -- 17 -- (23)
     #        |
@@ -101,14 +97,12 @@ def test_compose_2() -> None:
     #        |     |     |
     # [3] -- 4  -- 13 -- o -- (200)
 
-    g: nx.Graph[int]
     g = nx.Graph([(0, 17), (17, 23), (17, 4), (3, 4), (4, 13)])
     inputs = [0, 3]
     outputs = [13, 23]
     meas = {i: Measurement(0, Plane.XY) for i in set(g.nodes()) - set(outputs)}
     og_1 = OpenGraph(g, meas, inputs, outputs)
 
-    g: nx.Graph[int]
     g = nx.Graph([(6, 7), (6, 17), (17, 1), (7, 4), (17, 4), (4, 2)])
     inputs = [6, 7]
     outputs = [1, 2]
@@ -119,7 +113,9 @@ def test_compose_2() -> None:
 
     og = og_1.compose(og_2, mapping)
 
-    expected_graph = nx.Graph([(0, 17), (17, 23), (17, 4), (3, 4), (4, 13), (23, 13), (23, 1), (13, 2), (1, 2), (1, 100), (2, 200)])
+    expected_graph = nx.Graph(
+        [(0, 17), (17, 23), (17, 4), (3, 4), (4, 13), (23, 13), (23, 1), (13, 2), (1, 2), (1, 100), (2, 200)]
+    )
     assert nx.is_isomorphic(og.inside, expected_graph)
     assert og.inputs == [0, 3]
     assert og.outputs == [100, 200]
@@ -130,7 +126,6 @@ def test_compose_2() -> None:
 
 # Full overlap
 def test_compose_3() -> None:
-
     # Graph 1
     # [0] -- 17 -- (23)
     #        |
@@ -142,7 +137,6 @@ def test_compose_3() -> None:
     #
     # Expected graph = Graph 1
 
-    g: nx.Graph[int]
     g = nx.Graph([(0, 17), (17, 23), (17, 4), (3, 4), (4, 13)])
     inputs = [0, 3]
     outputs = [13, 23]
@@ -158,7 +152,6 @@ def test_compose_3() -> None:
 
 # Overlap inputs/outputs
 def test_compose_4() -> None:
-
     # Graph 1
     # ([17]) -- (3)
     #   |
@@ -174,14 +167,12 @@ def test_compose_4() -> None:
     #                |
     #               [18]
 
-    g: nx.Graph[int]
     g = nx.Graph([(18, 17), (17, 3)])
     inputs = [17, 18]
     outputs = [3, 17]
     meas = {i: Measurement(0, Plane.XY) for i in set(g.nodes()) - set(outputs)}
     og_1 = OpenGraph(g, meas, inputs, outputs)
 
-    g: nx.Graph[int]
     g = nx.Graph([(1, 2), (2, 3)])
     inputs = [1]
     outputs = [3]
@@ -204,7 +195,6 @@ def test_compose_4() -> None:
 
 # Inverse series composition
 def test_compose_5() -> None:
-
     # Graph 1
     # [1] -- (2)
     #  |
@@ -220,14 +210,12 @@ def test_compose_5() -> None:
     #          |
     #         [3]
 
-    g: nx.Graph[int]
     g = nx.Graph([(1, 2), (1, 3)])
     inputs = [1, 3]
     outputs = [2]
     meas = {i: Measurement(0, Plane.XY) for i in set(g.nodes()) - set(outputs)}
     og_1 = OpenGraph(g, meas, inputs, outputs)
 
-    g: nx.Graph[int]
     g = nx.Graph([(3, 4)])
     inputs = [3]
     outputs = [4]

--- a/tests/test_opengraph.py
+++ b/tests/test_opengraph.py
@@ -232,7 +232,7 @@ def test_compose_5() -> None:
     assert og.inside.order() == 4
     assert og.inside.size() == 3
     assert og.inputs == [3, 300]
-    assert og.outputs == [2]  # the output character of node 17 is lost because node 1 (in G2) is not an output
+    assert og.outputs == [2]
 
     outputs_c = [i for i in og.inside.nodes() if i not in og.outputs]
     assert len(og.measurements) == len(outputs_c)

--- a/tests/test_opengraph.py
+++ b/tests/test_opengraph.py
@@ -65,9 +65,9 @@ def test_compose_1() -> None:
     meas = {i: Measurement(0, Plane.XY) for i in set(g.nodes()) - set(outputs)}
     og_1 = OpenGraph(g, meas, inputs, outputs)
 
-    custom_mapping = {1: 100, 2: 200}
+    mapping = {1: 100, 2: 200}
 
-    og = og_1.compose(og_1, custom_mapping)
+    og = og_1.compose(og_1, mapping)
 
     assert og.inside.order() == 4
     assert og.inside.size() == 2
@@ -111,9 +111,9 @@ def test_compose_2() -> None:
     meas = {i: Measurement(0, Plane.XY) for i in set(g.nodes()) - set(outputs)}
     og_2 = OpenGraph(g, meas, inputs, outputs)
 
-    custom_mapping = {6: 23, 7: 13, 1: 100, 2: 200}
+    mapping = {6: 23, 7: 13, 1: 100, 2: 200}
 
-    og = og_1.compose(og_2, custom_mapping)
+    og = og_1.compose(og_2, mapping)
 
     assert og.inside.order() == 10
     assert og.inside.size() == 11
@@ -143,9 +143,9 @@ def test_compose_3() -> None:
     meas = {i: Measurement(0, Plane.XY) for i in set(g.nodes()) - set(outputs)}
     og_1 = OpenGraph(g, meas, inputs, outputs)
 
-    custom_mapping = {i: i for i in g.nodes()}
+    mapping = {i: i for i in g.nodes()}
 
-    og = og_1.compose(og_1, custom_mapping)
+    og = og_1.compose(og_1, mapping)
 
     assert og.isclose(og_1)
 
@@ -180,9 +180,9 @@ def test_compose_4() -> None:
     meas = {i: Measurement(0, Plane.XY) for i in set(g.nodes()) - set(outputs)}
     og_2 = OpenGraph(g, meas, inputs, outputs)
 
-    custom_mapping = {1: 17, 3: 300}
+    mapping = {1: 17, 3: 300}
 
-    og = og_1.compose(og_2, custom_mapping)
+    og = og_1.compose(og_2, mapping)
 
     assert og.inside.order() == 5
     assert og.inside.size() == 4
@@ -224,9 +224,9 @@ def test_compose_5() -> None:
     meas = {i: Measurement(0, Plane.XY) for i in set(g.nodes()) - set(outputs)}
     og_2 = OpenGraph(g, meas, inputs, outputs)
 
-    custom_mapping = {4: 1, 3: 300}
+    mapping = {4: 1, 3: 300}
 
-    og = og_1.compose(og_2, custom_mapping)
+    og = og_1.compose(og_2, mapping)
 
     assert og.inside.order() == 4
     assert og.inside.size() == 3

--- a/tests/test_opengraph.py
+++ b/tests/test_opengraph.py
@@ -177,3 +177,44 @@ def test_compose_4() -> None:
     outputs_c = [i for i in og.inside.nodes() if i not in og.outputs]
     assert len(og.measurements) == len(outputs_c)
     assert set(og.measurements) == set(outputs_c)
+
+    # Overlap inputs/outputs
+
+
+# Inverse series composition
+def test_compose_5() -> None:
+
+    # Graph 1
+    # [1] -- (2)
+    #  |
+    # [3]
+    #
+    # Graph 2
+    # [3] -- (4)
+
+    g: nx.Graph[int]
+    g = nx.Graph([(1, 2), (1, 3)])
+    inputs = [1, 3]
+    outputs = [2]
+    meas = {i: Measurement(0, Plane.XY) for i in set(g.nodes()) - set(outputs)}
+    og_1 = OpenGraph(g, meas, inputs, outputs)
+
+    g: nx.Graph[int]
+    g = nx.Graph([(3, 4)])
+    inputs = [3]
+    outputs = [4]
+    meas = {i: Measurement(0, Plane.XY) for i in set(g.nodes()) - set(outputs)}
+    og_2 = OpenGraph(g, meas, inputs, outputs)
+
+    custom_mapping = {4: 1, 3: 300}
+
+    og = og_1.compose(og_2, custom_mapping)
+
+    assert og.inside.order() == 4
+    assert og.inside.size() == 3
+    assert og.inputs == [3, 300]
+    assert og.outputs == [2]  # the output character of node 17 is lost because node 1 (in G2) is not an output
+
+    outputs_c = [i for i in og.inside.nodes() if i not in og.outputs]
+    assert len(og.measurements) == len(outputs_c)
+    assert set(og.measurements) == set(outputs_c)

--- a/tests/test_opengraph.py
+++ b/tests/test_opengraph.py
@@ -64,7 +64,7 @@ def test_compose_1() -> None:
     g = nx.Graph([(1, 2)])
     inputs = [1]
     outputs = [2]
-    meas = {i: Measurement(0, Plane.XY) for i in set(g.nodes()) - set(outputs)}
+    meas = {i: Measurement(0, Plane.XY) for i in g.nodes - set(outputs)}
     og_1 = OpenGraph(g, meas, inputs, outputs)
 
     mapping = {1: 100, 2: 200}
@@ -77,7 +77,7 @@ def test_compose_1() -> None:
     assert og.inputs == [1, 100]
     assert og.outputs == [2, 200]
 
-    outputs_c = [i for i in og.inside.nodes() if i not in og.outputs]
+    outputs_c = [i for i in og.inside.nodes if i not in og.outputs]
     assert len(og.measurements) == len(outputs_c)
     assert set(og.measurements) == set(outputs_c)
     assert mapping.keys() <= mapping_complete.keys()
@@ -107,13 +107,13 @@ def test_compose_2() -> None:
     g = nx.Graph([(0, 17), (17, 23), (17, 4), (3, 4), (4, 13)])
     inputs = [0, 3]
     outputs = [13, 23]
-    meas = {i: Measurement(0, Plane.XY) for i in set(g.nodes()) - set(outputs)}
+    meas = {i: Measurement(0, Plane.XY) for i in g.nodes - set(outputs)}
     og_1 = OpenGraph(g, meas, inputs, outputs)
 
     g = nx.Graph([(6, 7), (6, 17), (17, 1), (7, 4), (17, 4), (4, 2)])
     inputs = [6, 7]
     outputs = [1, 2]
-    meas = {i: Measurement(0, Plane.XY) for i in set(g.nodes()) - set(outputs)}
+    meas = {i: Measurement(0, Plane.XY) for i in g.nodes - set(outputs)}
     og_2 = OpenGraph(g, meas, inputs, outputs)
 
     mapping = {6: 23, 7: 13, 1: 100, 2: 200}
@@ -128,8 +128,8 @@ def test_compose_2() -> None:
     assert og.inputs == [0, 3]
     assert og.outputs == [100, 200]
 
-    outputs_c = [i for i in og.inside.nodes() if i not in og.outputs]
-    assert og.measurements.keys() == set(outputs_c)
+    outputs_c = {i for i in og.inside.nodes if i not in og.outputs}
+    assert og.measurements.keys() == outputs_c
     assert mapping.keys() <= mapping_complete.keys()
     assert set(mapping.values()) <= set(mapping_complete.values())
 
@@ -151,10 +151,10 @@ def test_compose_3() -> None:
     g = nx.Graph([(0, 17), (17, 23), (17, 4), (3, 4), (4, 13)])
     inputs = [0, 3]
     outputs = [13, 23]
-    meas = {i: Measurement(0, Plane.XY) for i in set(g.nodes()) - set(outputs)}
+    meas = {i: Measurement(0, Plane.XY) for i in g.nodes - set(outputs)}
     og_1 = OpenGraph(g, meas, inputs, outputs)
 
-    mapping = {i: i for i in g.nodes()}
+    mapping = {i: i for i in g.nodes}
 
     og, mapping_complete = og_1.compose(og_1, mapping)
 
@@ -184,13 +184,13 @@ def test_compose_4() -> None:
     g = nx.Graph([(18, 17), (17, 3)])
     inputs = [17, 18]
     outputs = [3, 17]
-    meas = {i: Measurement(0, Plane.XY) for i in set(g.nodes()) - set(outputs)}
+    meas = {i: Measurement(0, Plane.XY) for i in g.nodes - set(outputs)}
     og_1 = OpenGraph(g, meas, inputs, outputs)
 
     g = nx.Graph([(1, 2), (2, 3)])
     inputs = [1]
     outputs = [3]
-    meas = {i: Measurement(0, Plane.XY) for i in set(g.nodes()) - set(outputs)}
+    meas = {i: Measurement(0, Plane.XY) for i in g.nodes - set(outputs)}
     og_2 = OpenGraph(g, meas, inputs, outputs)
 
     mapping = {1: 17, 3: 300}
@@ -203,9 +203,8 @@ def test_compose_4() -> None:
     assert og.inputs == [17, 18]  # the input character of node 17 is kept because node 1 (in G2) is an input
     assert og.outputs == [3, 300]  # the output character of node 17 is lost because node 1 (in G2) is not an output
 
-    outputs_c = [i for i in og.inside.nodes() if i not in og.outputs]
-    assert len(og.measurements) == len(outputs_c)
-    assert set(og.measurements) == set(outputs_c)
+    outputs_c = {i for i in og.inside.nodes if i not in og.outputs}
+    assert og.measurements.keys() == outputs_c
     assert mapping.keys() <= mapping_complete.keys()
     assert set(mapping.values()) <= set(mapping_complete.values())
 
@@ -231,13 +230,13 @@ def test_compose_5() -> None:
     g = nx.Graph([(1, 2), (1, 3)])
     inputs = [1, 3]
     outputs = [2]
-    meas = {i: Measurement(0, Plane.XY) for i in set(g.nodes()) - set(outputs)}
+    meas = {i: Measurement(0, Plane.XY) for i in g.nodes - set(outputs)}
     og_1 = OpenGraph(g, meas, inputs, outputs)
 
     g = nx.Graph([(3, 4)])
     inputs = [3]
     outputs = [4]
-    meas = {i: Measurement(0, Plane.XY) for i in set(g.nodes()) - set(outputs)}
+    meas = {i: Measurement(0, Plane.XY) for i in g.nodes - set(outputs)}
     og_2 = OpenGraph(g, meas, inputs, outputs)
 
     mapping = {4: 1, 3: 300}
@@ -250,8 +249,7 @@ def test_compose_5() -> None:
     assert og.inputs == [3, 300]
     assert og.outputs == [2]
 
-    outputs_c = [i for i in og.inside.nodes() if i not in og.outputs]
-    assert len(og.measurements) == len(outputs_c)
-    assert set(og.measurements) == set(outputs_c)
+    outputs_c = {i for i in og.inside.nodes if i not in og.outputs}
+    assert og.measurements.keys() == outputs_c
     assert mapping.keys() <= mapping_complete.keys()
     assert set(mapping.values()) <= set(mapping_complete.values())

--- a/tests/test_opengraph.py
+++ b/tests/test_opengraph.py
@@ -53,6 +53,8 @@ def test_compose_1() -> None:
     #
     # Graph 2 = Graph 1
     #
+    # Mapping: 1 -> 100, 2 -> 200
+    #
     # Expected graph
     #  [1]  --  (2)
     #
@@ -91,6 +93,8 @@ def test_compose_2() -> None:
     # [6] -- 17 -- (1)
     #  |     |
     # [7] -- 4  -- (2)
+    #
+    # Mapping: 6 -> 23, 7 -> 13, 1 -> 100, 2 -> 200
     #
     # Expected graph
     # [0] -- 17 -- 23 -- o -- (100)
@@ -134,6 +138,8 @@ def test_compose_3() -> None:
     #
     # Graph 2 = Graph 1
     #
+    # Mapping: 0 -> 0, 3 -> 3, 17 -> 17, 4 -> 4, 23 -> 23, 13 -> 13
+    #
     # Expected graph = Graph 1
 
     g: nx.Graph[int]
@@ -160,6 +166,8 @@ def test_compose_4() -> None:
     #
     # Graph 2
     # [1] -- 2 -- (3)
+    #
+    # Mapping: 1 -> 17, 3 -> 300
     #
     # Expected graph
     # (300) -- 2 -- [17] -- (3)
@@ -204,6 +212,8 @@ def test_compose_5() -> None:
     #
     # Graph 2
     # [3] -- (4)
+    #
+    # Mapping: 4 -> 1, 3 -> 300
     #
     # Expected graph
     # [300] -- 1 -- (2)

--- a/tests/test_opengraph.py
+++ b/tests/test_opengraph.py
@@ -51,8 +51,12 @@ def test_compose_1() -> None:
     # Graph 1
     # [1] -- (2)
     #
-    #
     # Graph 2 = Graph 1
+    #
+    # Expected graph
+    #  [1]  --  (2)
+    #
+    # [100] -- (200)
 
     g: nx.Graph[int]
     g = nx.Graph([(1, 2)])
@@ -87,6 +91,11 @@ def test_compose_2() -> None:
     # [6] -- 17 -- (1)
     #  |     |
     # [7] -- 4  -- (2)
+    #
+    # Expected graph
+    # [0] -- 17 -- 23 -- o -- (100)
+    #        |     |     |
+    # [3] -- 4  -- 13 -- o -- (200)
 
     g: nx.Graph[int]
     g = nx.Graph([(0, 17), (17, 23), (17, 4), (3, 4), (4, 13)])
@@ -125,6 +134,8 @@ def test_compose_3() -> None:
     # [3] -- 4  -- (13)
     #
     # Graph 2 = Graph 1
+    #
+    # Expected graph = Graph 1
 
     g: nx.Graph[int]
     g = nx.Graph([(0, 17), (17, 23), (17, 4), (3, 4), (4, 13)])
@@ -150,6 +161,11 @@ def test_compose_4() -> None:
     #
     # Graph 2
     # [1] -- 2 -- (3)
+    #
+    # Expected graph
+    # (300) -- 2 -- [17] -- (3)
+    #                |
+    #               [18]
 
     g: nx.Graph[int]
     g = nx.Graph([(18, 17), (17, 3)])
@@ -178,8 +194,6 @@ def test_compose_4() -> None:
     assert len(og.measurements) == len(outputs_c)
     assert set(og.measurements) == set(outputs_c)
 
-    # Overlap inputs/outputs
-
 
 # Inverse series composition
 def test_compose_5() -> None:
@@ -191,6 +205,11 @@ def test_compose_5() -> None:
     #
     # Graph 2
     # [3] -- (4)
+    #
+    # Expected graph
+    # [300] -- 1 -- (2)
+    #          |
+    #         [3]
 
     g: nx.Graph[int]
     g = nx.Graph([(1, 2), (1, 3)])

--- a/tests/test_opengraph.py
+++ b/tests/test_opengraph.py
@@ -10,6 +10,7 @@ from graphix.opengraph import OpenGraph
 # Tests whether an open graph can be converted to and from a pattern and be
 # successfully reconstructed.
 def test_open_graph_to_pattern() -> None:
+    g: nx.Graph[int]
     g = nx.Graph([(0, 1), (1, 2)])
     inputs = [0]
     outputs = [2]
@@ -59,6 +60,7 @@ def test_compose_1() -> None:
     #
     # [100] -- (200)
 
+    g: nx.Graph[int]
     g = nx.Graph([(1, 2)])
     inputs = [1]
     outputs = [2]
@@ -67,8 +69,9 @@ def test_compose_1() -> None:
 
     mapping = {1: 100, 2: 200}
 
-    og = og_1.compose(og_1, mapping)
+    og, mapping_complete = og_1.compose(og_1, mapping)
 
+    expected_graph: nx.Graph[int]
     expected_graph = nx.Graph([(1, 2), (100, 200)])
     assert nx.is_isomorphic(og.inside, expected_graph)
     assert og.inputs == [1, 100]
@@ -77,6 +80,8 @@ def test_compose_1() -> None:
     outputs_c = [i for i in og.inside.nodes() if i not in og.outputs]
     assert len(og.measurements) == len(outputs_c)
     assert set(og.measurements) == set(outputs_c)
+    assert mapping.keys() <= mapping_complete.keys()
+    assert set(mapping.values()) <= set(mapping_complete.values())
 
 
 # Series composition
@@ -98,6 +103,7 @@ def test_compose_2() -> None:
     #        |     |     |
     # [3] -- 4  -- 13 -- o -- (200)
 
+    g: nx.Graph[int]
     g = nx.Graph([(0, 17), (17, 23), (17, 4), (3, 4), (4, 13)])
     inputs = [0, 3]
     outputs = [13, 23]
@@ -112,8 +118,9 @@ def test_compose_2() -> None:
 
     mapping = {6: 23, 7: 13, 1: 100, 2: 200}
 
-    og = og_1.compose(og_2, mapping)
+    og, mapping_complete = og_1.compose(og_2, mapping)
 
+    expected_graph: nx.Graph[int]
     expected_graph = nx.Graph(
         [(0, 17), (17, 23), (17, 4), (3, 4), (4, 13), (23, 13), (23, 1), (13, 2), (1, 2), (1, 100), (2, 200)]
     )
@@ -123,6 +130,8 @@ def test_compose_2() -> None:
 
     outputs_c = [i for i in og.inside.nodes() if i not in og.outputs]
     assert og.measurements.keys() == set(outputs_c)
+    assert mapping.keys() <= mapping_complete.keys()
+    assert set(mapping.values()) <= set(mapping_complete.values())
 
 
 # Full overlap
@@ -138,6 +147,7 @@ def test_compose_3() -> None:
     #
     # Expected graph = Graph 1
 
+    g: nx.Graph[int]
     g = nx.Graph([(0, 17), (17, 23), (17, 4), (3, 4), (4, 13)])
     inputs = [0, 3]
     outputs = [13, 23]
@@ -146,9 +156,11 @@ def test_compose_3() -> None:
 
     mapping = {i: i for i in g.nodes()}
 
-    og = og_1.compose(og_1, mapping)
+    og, mapping_complete = og_1.compose(og_1, mapping)
 
     assert og.isclose(og_1)
+    assert mapping.keys() <= mapping_complete.keys()
+    assert set(mapping.values()) <= set(mapping_complete.values())
 
 
 # Overlap inputs/outputs
@@ -168,6 +180,7 @@ def test_compose_4() -> None:
     #                |
     #               [18]
 
+    g: nx.Graph[int]
     g = nx.Graph([(18, 17), (17, 3)])
     inputs = [17, 18]
     outputs = [3, 17]
@@ -182,8 +195,9 @@ def test_compose_4() -> None:
 
     mapping = {1: 17, 3: 300}
 
-    og = og_1.compose(og_2, mapping)
+    og, mapping_complete = og_1.compose(og_2, mapping)
 
+    expected_graph: nx.Graph[int]
     expected_graph = nx.Graph([(18, 17), (17, 3), (17, 2), (2, 300)])
     assert nx.is_isomorphic(og.inside, expected_graph)
     assert og.inputs == [17, 18]  # the input character of node 17 is kept because node 1 (in G2) is an input
@@ -192,6 +206,8 @@ def test_compose_4() -> None:
     outputs_c = [i for i in og.inside.nodes() if i not in og.outputs]
     assert len(og.measurements) == len(outputs_c)
     assert set(og.measurements) == set(outputs_c)
+    assert mapping.keys() <= mapping_complete.keys()
+    assert set(mapping.values()) <= set(mapping_complete.values())
 
 
 # Inverse series composition
@@ -211,6 +227,7 @@ def test_compose_5() -> None:
     #          |
     #         [3]
 
+    g: nx.Graph[int]
     g = nx.Graph([(1, 2), (1, 3)])
     inputs = [1, 3]
     outputs = [2]
@@ -225,8 +242,9 @@ def test_compose_5() -> None:
 
     mapping = {4: 1, 3: 300}
 
-    og = og_1.compose(og_2, mapping)
+    og, mapping_complete = og_1.compose(og_2, mapping)
 
+    expected_graph: nx.Graph[int]
     expected_graph = nx.Graph([(1, 2), (1, 3), (1, 300)])
     assert nx.is_isomorphic(og.inside, expected_graph)
     assert og.inputs == [3, 300]
@@ -235,3 +253,5 @@ def test_compose_5() -> None:
     outputs_c = [i for i in og.inside.nodes() if i not in og.outputs]
     assert len(og.measurements) == len(outputs_c)
     assert set(og.measurements) == set(outputs_c)
+    assert mapping.keys() <= mapping_complete.keys()
+    assert set(mapping.values()) <= set(mapping_complete.values())

--- a/tests/test_opengraph.py
+++ b/tests/test_opengraph.py
@@ -71,8 +71,8 @@ def test_compose_1() -> None:
 
     og = og_1.compose(og_1, mapping)
 
-    assert og.inside.order() == 4
-    assert og.inside.size() == 2
+    expected_graph = nx.Graph([(1, 2), (100, 200)])
+    assert nx.is_isomorphic(og.inside, expected_graph)
     assert og.inputs == [1, 100]
     assert og.outputs == [2, 200]
 
@@ -119,8 +119,8 @@ def test_compose_2() -> None:
 
     og = og_1.compose(og_2, mapping)
 
-    assert og.inside.order() == 10
-    assert og.inside.size() == 11
+    expected_graph = nx.Graph([(0, 17), (17, 23), (17, 4), (3, 4), (4, 13), (23, 13), (23, 1), (13, 2), (1, 2), (1, 100), (2, 200)])
+    assert nx.is_isomorphic(og.inside, expected_graph)
     assert og.inputs == [0, 3]
     assert og.outputs == [100, 200]
 
@@ -192,8 +192,8 @@ def test_compose_4() -> None:
 
     og = og_1.compose(og_2, mapping)
 
-    assert og.inside.order() == 5
-    assert og.inside.size() == 4
+    expected_graph = nx.Graph([(18, 17), (17, 3), (17, 2), (2, 300)])
+    assert nx.is_isomorphic(og.inside, expected_graph)
     assert og.inputs == [17, 18]  # the input character of node 17 is kept because node 1 (in G2) is an input
     assert og.outputs == [3, 300]  # the output character of node 17 is lost because node 1 (in G2) is not an output
 
@@ -238,8 +238,8 @@ def test_compose_5() -> None:
 
     og = og_1.compose(og_2, mapping)
 
-    assert og.inside.order() == 4
-    assert og.inside.size() == 3
+    expected_graph = nx.Graph([(1, 2), (1, 3), (1, 300)])
+    assert nx.is_isomorphic(og.inside, expected_graph)
     assert og.inputs == [3, 300]
     assert og.outputs == [2]
 

--- a/tests/test_opengraph.py
+++ b/tests/test_opengraph.py
@@ -77,9 +77,8 @@ def test_compose_1() -> None:
     assert og.inputs == [1, 100]
     assert og.outputs == [2, 200]
 
-    outputs_c = [i for i in og.inside.nodes if i not in og.outputs]
-    assert len(og.measurements) == len(outputs_c)
-    assert set(og.measurements) == set(outputs_c)
+    outputs_c = {i for i in og.inside.nodes if i not in og.outputs}
+    assert og.measurements.keys() == outputs_c
     assert mapping.keys() <= mapping_complete.keys()
     assert set(mapping.values()) <= set(mapping_complete.values())
 

--- a/tests/test_opengraph.py
+++ b/tests/test_opengraph.py
@@ -44,6 +44,7 @@ def test_open_graph_to_pattern() -> None:
 
 # Tests composition of two graphs
 
+
 # Parallel composition
 def test_compose_1() -> None:
     # Graph 1

--- a/tests/test_opengraph.py
+++ b/tests/test_opengraph.py
@@ -121,8 +121,7 @@ def test_compose_2() -> None:
     assert og.outputs == [100, 200]
 
     outputs_c = [i for i in og.inside.nodes() if i not in og.outputs]
-    assert len(og.measurements) == len(outputs_c)
-    assert set(og.measurements) == set(outputs_c)
+    assert og.measurements.keys() == set(outputs_c)
 
 
 # Full overlap


### PR DESCRIPTION
**Description of the change**

Added new method `:func: graphix.opengraph.OpenGraph.compose` for composing two open graphs by merging any number of nodes.

Expected behavior:

- Nodes of open graph `other` are relabelled according to a custom `mapping` or sequentially if not specified.

- Nodes that are not merged retain their properties (i.e., measurements and whether they are inputs and/or outputs).

- Input (and, respectively, output) nodes in the returned open graph have the order of the open graph `self` followed by those of the open graph `other`. Merged nodes are removed, except when they are input (or output) nodes in both open graphs, in which case, they appear in the order they originally had in the graph `self`.

- When the user seeks to merge two nodes (by specifying so through `mapping`):
  - If both are measured, they must have the same measurement (same plane and angle), otherwise an error is raised.
  - If only one of them is measured the resulting node keeps the measurement (this is the natural approach to compose open graphs sequentially, i.e., outputs_1 -> inputs_2).
  - The resulting node is an input (or output) iff the two "parent" nodes are inputs (or outputs).
