### PR TITLE
Fix #316: pin package version for `mypy` and `types-networkx`

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -13,26 +13,22 @@ def install_pytest(session: Session) -> None:
     session.install("pytest", "pytest-mock", "psutil")
 
 
-def run_pytest(session: Session) -> None:
-    """Run pytest."""
-    session.run("pytest", "--doctest-modules")
-
-
 @nox.session(python=["3.9", "3.10", "3.11", "3.12", "3.13"])
 def tests_minimal(session: Session) -> None:
     """Run the test suite with minimal dependencies."""
     session.install("-e", ".")
     install_pytest(session)
-    run_pytest(session)
+    # We cannot run `pytest --doctest-modules` here, since some tests
+    # involve optional dependencies, like pyzx.
+    session.run("pytest")
 
-    # Note that recent types-networkx versions don't support Python 3.9
 
-
+# Note that recent types-networkx versions don't support Python 3.9
 @nox.session(python=["3.10", "3.11", "3.12", "3.13"])
 def tests_dev(session: Session) -> None:
     """Run the test suite with dev dependencies."""
     session.install("-e", ".[dev]")
-    run_pytest(session)
+    session.run("pytest", "--doctest-modules")
 
 
 @nox.session(python=["3.9", "3.10", "3.11", "3.12", "3.13"])
@@ -40,14 +36,15 @@ def tests_extra(session: Session) -> None:
     """Run the test suite with extra dependencies."""
     session.install("-e", ".[extra]")
     install_pytest(session)
-    run_pytest(session)
+    session.install("nox")  # needed for --doctest-modules
+    session.run("pytest", "--doctest-modules")
 
 
 @nox.session(python=["3.10", "3.11", "3.12", "3.13"])
 def tests_all(session: Session) -> None:
     """Run the test suite with all dependencies."""
     session.install("-e", ".[dev,extra]")
-    run_pytest(session)
+    session.run("pytest", "--doctest-modules")
 
 
 # TODO: Add 3.13 CI
@@ -56,6 +53,7 @@ def tests_symbolic(session: Session) -> None:
     """Run the test suite of graphix-symbolic."""
     session.install("-e", ".")
     install_pytest(session)
+    session.install("nox")  # needed for --doctest-modules
     # Use `session.cd` as a context manager to ensure that the
     # working directory is restored afterward. This is important
     # because Windows cannot delete a temporary directory while it
@@ -65,4 +63,4 @@ def tests_symbolic(session: Session) -> None:
         # session.run("git", "clone", "-b", "branch-name", "https://github.com/TeamGraphix/graphix-symbolic")
         session.run("git", "clone", "https://github.com/TeamGraphix/graphix-symbolic")
         with session.cd("graphix-symbolic"):
-            run_pytest(session)
+            session.run("pytest", "--doctest-modules")

--- a/noxfile.py
+++ b/noxfile.py
@@ -28,7 +28,9 @@ def tests_minimal(session: Session) -> None:
 def tests_dev(session: Session) -> None:
     """Run the test suite with dev dependencies."""
     session.install("-e", ".[dev]")
-    session.run("pytest", "--doctest-modules")
+    # We cannot run `pytest --doctest-modules` here, since some tests
+    # involve optional dependencies, like pyzx.
+    session.run("pytest")
 
 
 @nox.session(python=["3.9", "3.10", "3.11", "3.12", "3.13"])
@@ -36,7 +38,7 @@ def tests_extra(session: Session) -> None:
     """Run the test suite with extra dependencies."""
     session.install("-e", ".[extra]")
     install_pytest(session)
-    session.install("nox")  # needed for --doctest-modules
+    session.install("nox")  # needed for `--doctest-modules`
     session.run("pytest", "--doctest-modules")
 
 
@@ -53,7 +55,7 @@ def tests_symbolic(session: Session) -> None:
     """Run the test suite of graphix-symbolic."""
     session.install("-e", ".")
     install_pytest(session)
-    session.install("nox")  # needed for --doctest-modules
+    session.install("nox")  # needed for `--doctest-modules`
     # Use `session.cd` as a context manager to ensure that the
     # working directory is restored afterward. This is important
     # because Windows cannot delete a temporary directory while it

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,13 +7,16 @@ from tempfile import TemporaryDirectory
 import nox
 from nox import Session
 
+
 def install_pytest(session: Session) -> None:
     """Install pytest when requirements-dev.txt is not installed."""
     session.install("pytest", "pytest-mock", "psutil")
 
+
 def run_pytest(session: Session) -> None:
     """Run pytest."""
     session.run("pytest", "--doctest-modules")
+
 
 @nox.session(python=["3.9", "3.10", "3.11", "3.12", "3.13"])
 def tests_minimal(session: Session) -> None:
@@ -22,8 +25,9 @@ def tests_minimal(session: Session) -> None:
     install_pytest(session)
     run_pytest(session)
 
-
     # Note that recent types-networkx versions don't support Python 3.9
+
+
 @nox.session(python=["3.10", "3.11", "3.12", "3.13"])
 def tests_dev(session: Session) -> None:
     """Run the test suite with dev dependencies."""

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,9 +16,24 @@ def tests_minimal(session: Session) -> None:
     session.run("pytest")
 
 
+# Note that recent types-networkx versions don't support Python 3.9
+@nox.session(python=["3.10", "3.11", "3.12", "3.13"])
+def tests_dev(session: Session) -> None:
+    """Run the test suite with dev dependencies."""
+    session.install("-e", ".[dev]")
+    session.run("pytest", "--doctest-modules")
+
+
 @nox.session(python=["3.9", "3.10", "3.11", "3.12", "3.13"])
-def tests(session: Session) -> None:
-    """Run the test suite with full dependencies."""
+def tests_extra(session: Session) -> None:
+    """Run the test suite with extra dependencies."""
+    session.install("-e", ".[extra]")
+    session.run("pytest", "--doctest-modules")
+
+
+@nox.session(python=["3.10", "3.11", "3.12", "3.13"])
+def tests_all(session: Session) -> None:
+    """Run the test suite with all dependencies."""
     session.install("-e", ".[dev,extra]")
     session.run("pytest", "--doctest-modules")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,42 +7,51 @@ from tempfile import TemporaryDirectory
 import nox
 from nox import Session
 
+def install_pytest(session: Session) -> None:
+    """Install pytest when requirements-dev.txt is not installed."""
+    session.install("pytest", "pytest-mock", "psutil")
+
+def run_pytest(session: Session) -> None:
+    """Run pytest."""
+    session.run("pytest", "--doctest-modules")
 
 @nox.session(python=["3.9", "3.10", "3.11", "3.12", "3.13"])
 def tests_minimal(session: Session) -> None:
     """Run the test suite with minimal dependencies."""
     session.install("-e", ".")
-    session.install("pytest", "pytest-mock", "psutil")
-    session.run("pytest")
+    install_pytest(session)
+    run_pytest(session)
 
 
-# Note that recent types-networkx versions don't support Python 3.9
+    # Note that recent types-networkx versions don't support Python 3.9
 @nox.session(python=["3.10", "3.11", "3.12", "3.13"])
 def tests_dev(session: Session) -> None:
     """Run the test suite with dev dependencies."""
     session.install("-e", ".[dev]")
-    session.run("pytest", "--doctest-modules")
+    run_pytest(session)
 
 
 @nox.session(python=["3.9", "3.10", "3.11", "3.12", "3.13"])
 def tests_extra(session: Session) -> None:
     """Run the test suite with extra dependencies."""
     session.install("-e", ".[extra]")
-    session.run("pytest", "--doctest-modules")
+    install_pytest(session)
+    run_pytest(session)
 
 
 @nox.session(python=["3.10", "3.11", "3.12", "3.13"])
 def tests_all(session: Session) -> None:
     """Run the test suite with all dependencies."""
     session.install("-e", ".[dev,extra]")
-    session.run("pytest", "--doctest-modules")
+    run_pytest(session)
 
 
 # TODO: Add 3.13 CI
 @nox.session(python=["3.9", "3.10", "3.11", "3.12"])
 def tests_symbolic(session: Session) -> None:
     """Run the test suite of graphix-symbolic."""
-    session.install("-e", ".[dev]")
+    session.install("-e", ".")
+    install_pytest(session)
     # Use `session.cd` as a context manager to ensure that the
     # working directory is restored afterward. This is important
     # because Windows cannot delete a temporary directory while it
@@ -52,4 +61,4 @@ def tests_symbolic(session: Session) -> None:
         # session.run("git", "clone", "-b", "branch-name", "https://github.com/TeamGraphix/graphix-symbolic")
         session.run("git", "clone", "https://github.com/TeamGraphix/graphix-symbolic")
         with session.cd("graphix-symbolic"):
-            session.run("pytest")
+            run_pytest(session)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,11 @@
 # Lint/format
-mypy
+mypy==1.17.0
 pre-commit # for language-agnostic hooks
 pyright
 ruff==0.12.3
 
 # Stubs
-types-networkx
+types-networkx==3.5.0.20250701
 types-psutil
 types-setuptools
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ pyright
 ruff==0.12.3
 
 # Stubs
-types-networkx==3.5.0.20250701
+types-networkx==3.5.0.20250712
 types-psutil
 types-setuptools
 


### PR DESCRIPTION
This commit pins the package version for `mypy==1.17.0` and `types-networkx==3.5.0.20250701`. It's a continuation of PR #243 where we pinned the version of `ruff`.

Pinning these package should make the PR review process smoother.

- In #315, CI broke due to a regression introduced in `mypy==1.17`, even though the PR was only about updating `ruff`.

- In #309, CI broke due to stricter typing in newer versions of `types-networkx`, which required changes in parts of the code not touched by the PR.

By pinning these packages and relying on Dependabot to open dedicated PRs for updates:

- We avoid unpredicatable CI failures caused by unexpected version updates.

- We prevent unrelated changes from being added to PRs just because a package update occurred during the review process.

- We get dedicated PRs to manage and test updates.

- We are notified when updates break the CI, even if no new code has been pushed since the update was released.