### PR TITLE
Fix #314: Add `optimization` module with correct standardization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Method for `OpenGraph`: `compose`
+- #310: Method for `OpenGraph`: `compose`
 
 - #277: Methods for pretty-printing `Pattern`: `to_ascii`,
   `to_unicode`, `to_latex`.
 
+- #322: Added a new `optimization` module containing:
+
+  * a functional version of `standardize` that returns a standardized
+    pattern as a new object;
+
+  * a function `incorporate_pauli_results` that returns an equivalent
+    pattern in which the `results` are incorporated into measurement
+    and correction domains.  
+    The resulting pattern is suitable for flow analysis. In
+    particular, if a pattern has a flow, it is preserved by
+    `perform_pauli_measurements` after applying `standardize` and
+    `incorporate_pauli_results`.
+
 ### Fixed
+
+- #314, #322: The method `Pattern.standardize()` now correctly returns
+  an equivalent pattern even in the presence of C commands, or raises
+  an error if no standardized form exists.
 
 - #277: The result of `repr()` for `Pattern`, `Circuit`, `Command`,
   `Instruction`, `Plane`, `Axis` and `Sign` is now a valid Python
@@ -28,7 +45,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - #277: The method `Pattern.print_pattern` is now deprecated.
-- #261: Moved all device interface functionalities to an external library and removed their implementation from this library.
+
+- #261: Moved all device interface functionalities to an external
+  library and removed their implementation from this library.
+
+- #314, #322: The method `Pattern.standardize()` now places C commands
+  after X and Z commands, making the resulting patterns suitable for
+  flow analysis.  
+  The `flow_from_pattern` functions now fail if the input pattern is
+  not strictly standardized (as checked by
+  `Pattern.is_standard(strict=True)`, which requires C commands to be
+  last).  
+  Note: the method `perform_pauli_measurements` still places C
+  commands before X and Z commands.
 
 ## [0.3.1] - 2025-04-21
 

--- a/graphix/gflow.py
+++ b/graphix/gflow.py
@@ -656,6 +656,8 @@ def flow_from_pattern(pattern: Pattern) -> tuple[dict[int, set[int]], dict[int, 
     l_k: dict
         layers obtained by flow algorithm. l_k[d] is a node set of depth d.
     """
+    if not pattern.is_standard(strict=True):
+        raise ValueError("The pattern should be standardized first.")
     meas_planes = pattern.get_meas_plane()
     for plane in meas_planes.values():
         if plane != Plane.XY:
@@ -708,6 +710,8 @@ def gflow_from_pattern(pattern: Pattern) -> tuple[dict[int, set[int]], dict[int,
     l_k: dict
         layers obtained by gflow algorithm. l_k[d] is a node set of depth d.
     """
+    if not pattern.is_standard(strict=True):
+        raise ValueError("The pattern should be standardized first.")
     g = nx.Graph()
     nodes, edges = pattern.get_graph()
     g.add_nodes_from(nodes)
@@ -768,6 +772,8 @@ def pauliflow_from_pattern(pattern: Pattern, mode="single") -> tuple[dict[int, s
     l_k: dict
         layers obtained by Pauli flow algorithm. l_k[d] is a node set of depth d.
     """
+    if not pattern.is_standard(strict=True):
+        raise ValueError("The pattern should be standardized first.")
     g = nx.Graph()
     nodes, edges = pattern.get_graph()
     nodes = set(nodes)

--- a/graphix/optimization.py
+++ b/graphix/optimization.py
@@ -1,0 +1,204 @@
+"""Optimization procedures for patterns."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import graphix
+from graphix import command
+from graphix.clifford import Clifford
+from graphix.command import CommandKind
+from graphix.measurements import Domains
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from collections.abc import Set as AbstractSet
+
+    from graphix import Pattern
+
+
+def standardize(pattern: Pattern) -> Pattern:
+    """Return a standardized form to the given pattern.
+
+    A standardized form is an equivalent pattern where the commands
+    appear in the following order: `N`, `E`, `M`, `Z`, `X`, `C`.
+
+    Note that a standardized form does not always exist in presence of
+    `C` commands. For instance, there is no standardized form for the
+    following pattern (written in the right-to-left convention):
+    `E(0, 1) C(0, H) N(1) N(0)`.
+
+    The function raises `NotImplementedError` if there is no
+    standardized form. This behavior can change in the future.
+
+
+    Parameters
+    ----------
+    pattern : Pattern
+        The original pattern.
+
+    Returns
+    -------
+    standardized : Pattern
+        The standardized pattern, if it exists.
+    """
+    n_list = []
+    e_list = []
+    m_list = []
+    c_dict: dict[int, Clifford] = {}
+    z_dict: dict[int, set[command.Node]] = {}
+    x_dict: dict[int, set[command.Node]] = {}
+
+    def add_correction_domain(
+        domain_dict: dict[command.Node, set[command.Node]], node: command.Node, domain: set[command.Node]
+    ) -> None:
+        """Merge a correction domain into ``domain_dict`` for ``node``.
+
+        Parameters
+        ----------
+        domain_dict : dict[int, Command]
+            Mapping from node index to accumulated domain.
+        node : int
+            Target node whose domain should be updated.
+        domain : set[int]
+            Domain to merge with the existing one.
+        """
+        if previous_domain := domain_dict.get(node):
+            previous_domain ^= domain
+        else:
+            domain_dict[node] = domain.copy()
+
+    def commute_clifford(clifford_gate: Clifford, c_dict: dict[int, Clifford], i: int, j: int) -> None:
+        """Commute a Clifford with an entanglement command.
+
+        Parameters
+        ----------
+        clifford_gate : Clifford
+            Clifford gate before the entanglement command
+        c_dict : dict[int, Clifford]
+            Mapping from the node index to accumulated Clifford commands.
+        i : int
+            First node of the entanglement command where the Clifford is applied.
+        j : int
+            Second node of the entanglement command where the Clifford is applied.
+        """
+        if clifford_gate in {Clifford.I, Clifford.Z, Clifford.S, Clifford.SDG}:
+            # Clifford gate commutes with the entanglement command.
+            pass
+        elif clifford_gate in {Clifford.X, Clifford.Y, Clifford(9), Clifford(10)}:
+            # Clifford gate commutes with the entanglement command up to a Z Clifford on the other index.
+            c_dict[j] = Clifford.Z @ c_dict.get(j, Clifford.I)
+        else:
+            # Clifford gate commutes with the entanglement command up to a two-qubit Clifford
+            raise NotImplementedError(
+                f"Pattern contains a Clifford followed by an E command on qubit {i} which only commute up to a two-qubit Clifford. Standarization is not supported."
+            )
+
+    for cmd in pattern:
+        if cmd.kind == CommandKind.N:
+            n_list.append(cmd)
+        elif cmd.kind == CommandKind.E:
+            for side in (0, 1):
+                i, j = cmd.nodes[side], cmd.nodes[1 - side]
+                if clifford_gate := c_dict.get(i):
+                    commute_clifford(clifford_gate, c_dict, i, j)
+                if s_domain := x_dict.get(i):
+                    add_correction_domain(z_dict, j, s_domain)
+            e_list.append(cmd)
+        elif cmd.kind == CommandKind.M:
+            new_cmd = cmd
+            if clifford_gate := c_dict.pop(cmd.node, None):
+                new_cmd = new_cmd.clifford(clifford_gate)
+            if t_domain := z_dict.pop(cmd.node, None):
+                # The original domain should not be mutated
+                new_cmd.t_domain = new_cmd.t_domain ^ t_domain  # noqa: PLR6104
+            if s_domain := x_dict.pop(cmd.node, None):
+                # The original domain should not be mutated
+                new_cmd.s_domain = new_cmd.s_domain ^ s_domain  # noqa: PLR6104
+            m_list.append(new_cmd)
+        # Use of `==` here for mypy
+        elif cmd.kind == CommandKind.X or cmd.kind == CommandKind.Z:  # noqa: PLR1714
+            if cmd.kind == CommandKind.X:
+                s_domain = cmd.domain
+                t_domain = set()
+            else:
+                s_domain = set()
+                t_domain = cmd.domain
+            domains = c_dict.get(cmd.node, Clifford.I).commute_domains(Domains(s_domain, t_domain))
+            if domains.t_domain:
+                add_correction_domain(z_dict, cmd.node, domains.t_domain)
+            if domains.s_domain:
+                add_correction_domain(x_dict, cmd.node, domains.s_domain)
+        elif cmd.kind == CommandKind.C:
+            # Each pattern command is applied by left multiplication: if a clifford `C`
+            # has been already applied to a node, applying a clifford `C'` to the same
+            # node is equivalent to apply `C'C` to a fresh node.
+            c_dict[cmd.node] = cmd.clifford @ c_dict.get(cmd.node, Clifford.I)
+    result = graphix.Pattern(input_nodes=pattern.input_nodes)
+    result.results = pattern.results
+    result.extend(
+        [
+            *n_list,
+            *e_list,
+            *m_list,
+            *(command.Z(node=node, domain=domain) for node, domain in z_dict.items()),
+            *(command.X(node=node, domain=domain) for node, domain in x_dict.items()),
+            *(command.C(node=node, clifford=clifford_gate) for node, clifford_gate in c_dict.items()),
+        ]
+    )
+    return result
+
+
+def _incorporate_pauli_results_in_domain(
+    results: Mapping[int, int], domain: AbstractSet[int]
+) -> tuple[bool, set[int]] | None:
+    if not (results.keys() & domain):
+        return None
+    new_domain = set(domain - results.keys())
+    odd_outcome = sum(outcome for node, outcome in results.items() if node in domain) % 2
+    return odd_outcome == 1, new_domain
+
+
+def incorporate_pauli_results(pattern: Pattern) -> Pattern:
+    """Return an equivalent pattern where results from Pauli presimulation are integrated in corrections."""
+    result = graphix.Pattern(input_nodes=pattern.input_nodes)
+    for cmd in pattern:
+        if cmd.kind == CommandKind.M:
+            s = _incorporate_pauli_results_in_domain(pattern.results, cmd.s_domain)
+            t = _incorporate_pauli_results_in_domain(pattern.results, cmd.t_domain)
+            if s or t:
+                if s:
+                    apply_x, new_s_domain = s
+                else:
+                    apply_x = False
+                    new_s_domain = cmd.s_domain
+                if t:
+                    apply_z, new_t_domain = t
+                else:
+                    apply_z = False
+                    new_t_domain = cmd.t_domain
+                new_cmd = command.M(cmd.node, cmd.plane, cmd.angle, new_s_domain, new_t_domain)
+                if apply_x:
+                    new_cmd = new_cmd.clifford(Clifford.X)
+                if apply_z:
+                    new_cmd = new_cmd.clifford(Clifford.Z)
+                result.add(new_cmd)
+            else:
+                result.add(cmd)
+        # Use == for mypy
+        elif cmd.kind == CommandKind.X or cmd.kind == CommandKind.Z:  # noqa: PLR1714
+            signal = _incorporate_pauli_results_in_domain(pattern.results, cmd.domain)
+            if signal:
+                apply_c, new_domain = signal
+                if new_domain:
+                    cmd_cstr = command.X if cmd.kind == CommandKind.X else command.Z
+                    result.add(cmd_cstr(cmd.node, new_domain))
+                if apply_c:
+                    c = Clifford.X if cmd.kind == CommandKind.X else Clifford.Z
+                    result.add(command.C(cmd.node, c))
+            else:
+                result.add(cmd)
+        else:
+            result.add(cmd)
+    result.reorder_output_nodes(pattern.output_nodes)
+    return result

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -17,13 +17,13 @@ from typing import TYPE_CHECKING, SupportsFloat
 import networkx as nx
 from typing_extensions import assert_never, override
 
-from graphix import command, parameter
+from graphix import command, optimization, parameter
 from graphix.clifford import Clifford
 from graphix.command import Command, CommandKind
 from graphix.fundamentals import Axis, Plane, Sign
 from graphix.gflow import find_flow, find_gflow, get_layers
 from graphix.graphsim import GraphState
-from graphix.measurements import Domains, PauliMeasurement
+from graphix.measurements import PauliMeasurement
 from graphix.pretty_print import OutputFormat, pattern_to_str
 from graphix.simulator import PatternSimulator
 from graphix.states import BasicStates
@@ -279,110 +279,29 @@ class Pattern:
         )
         print(pattern_to_str(self, OutputFormat.ASCII, left_to_right=True, limit=lim, target=target))
 
-    def standardize(self, method: str = "direct") -> None:
+    def standardize(self, method: str | None = None) -> None:
         """Execute standardization of the pattern.
 
-        'standard' pattern is one where commands are sorted in the order of
-        'N', 'E', 'M' and then byproduct commands ('X' and 'Z').
+        'standard' pattern is one where commands are sorted in the
+        order of 'N', 'E', 'M' and then byproduct commands ('X' and
+        'Z') and finally Clifford commands ('C').
+        """
+        if method is not None:
+            warnings.warn(
+                "Use of `standardize(method=...) is deprecated. Please remove the optional `method=` argument. See https://github.com/TeamGraphix/graphix/issues/314 for details.",
+                DeprecationWarning,
+                stacklevel=1,
+            )
+
+        self.__seq = optimization.standardize(self).__seq
+
+    def is_standard(self, strict: bool = False) -> bool:
+        """Determine whether the command sequence is standard.
 
         Parameters
         ----------
-        method : str, optional
-            'mc' corresponds to a conventional standardization defined in original measurement calculus paper, executed on Pattern class.
-            'direct' fast standardization implemented as *standardize_direct()*
-            defaults to 'direct'
-        """
-        if method == "direct":  # faster implementation
-            self.standardize_direct()
-            return
-        if method == "mc":  # direct measuremment calculus implementation
-            self._move_n_to_left()
-            self._move_byproduct_to_right()
-            self._move_e_after_n()
-            return
-        raise ValueError("Invalid method")
-
-    def standardize_direct(self) -> None:
-        """Execute standardization of the pattern.
-
-        This algorithm sort the commands in the following order:
-        `N`, `E`, `M`, `C`, `Z`, `X`.
-        """
-        n_list = []
-        e_list = []
-        m_list = []
-        c_dict: dict[int, Clifford] = {}
-        z_dict: dict[int, set[command.Node]] = {}
-        x_dict: dict[int, set[command.Node]] = {}
-
-        def add_correction_domain(
-            domain_dict: dict[command.Node, set[command.Node]], node: command.Node, domain: set[command.Node]
-        ) -> None:
-            """Merge a correction domain into ``domain_dict`` for ``node``.
-
-            Parameters
-            ----------
-            domain_dict : dict[int, Command]
-                Mapping from node index to accumulated domain.
-            node : int
-                Target node whose domain should be updated.
-            domain : set[int]
-                Domain to merge with the existing one.
-            """
-            if previous_domain := domain_dict.get(node):
-                previous_domain ^= domain
-            else:
-                domain_dict[node] = domain.copy()
-
-        for cmd in self:
-            if cmd.kind == CommandKind.N:
-                n_list.append(cmd)
-            elif cmd.kind == CommandKind.E:
-                for side in (0, 1):
-                    if s_domain := x_dict.get(cmd.nodes[side], None):
-                        add_correction_domain(z_dict, cmd.nodes[1 - side], s_domain)
-                e_list.append(cmd)
-            elif cmd.kind == CommandKind.M:
-                new_cmd = cmd
-                if clifford_gate := c_dict.pop(cmd.node, None):
-                    new_cmd = new_cmd.clifford(clifford_gate)
-                if t_domain := z_dict.pop(cmd.node, None):
-                    # The original domain should not be mutated
-                    new_cmd.t_domain = new_cmd.t_domain ^ t_domain  # noqa: PLR6104
-                if s_domain := x_dict.pop(cmd.node, None):
-                    # The original domain should not be mutated
-                    new_cmd.s_domain = new_cmd.s_domain ^ s_domain  # noqa: PLR6104
-                m_list.append(new_cmd)
-            elif cmd.kind == CommandKind.Z:
-                add_correction_domain(z_dict, cmd.node, cmd.domain)
-            elif cmd.kind == CommandKind.X:
-                add_correction_domain(x_dict, cmd.node, cmd.domain)
-            elif cmd.kind == CommandKind.C:
-                # If some `X^sZ^t` have been applied to the node, compute `X^s'Z^t'`
-                # such that `CX^sZ^t = X^s'Z^t'C` since the Clifford command will
-                # be applied first (i.e., in right-most position).
-                t_domain = z_dict.pop(cmd.node, set())
-                s_domain = x_dict.pop(cmd.node, set())
-                domains = cmd.clifford.conj.commute_domains(Domains(s_domain, t_domain))
-                if domains.t_domain:
-                    z_dict[cmd.node] = domains.t_domain
-                if domains.s_domain:
-                    x_dict[cmd.node] = domains.s_domain
-                # Each pattern command is applied by left multiplication: if a clifford `C`
-                # has been already applied to a node, applying a clifford `C'` to the same
-                # node is equivalent to apply `C'C` to a fresh node.
-                c_dict[cmd.node] = cmd.clifford @ c_dict.get(cmd.node, Clifford.I)
-        self.__seq = [
-            *n_list,
-            *e_list,
-            *m_list,
-            *(command.C(node=node, clifford=clifford_gate) for node, clifford_gate in c_dict.items()),
-            *(command.Z(node=node, domain=domain) for node, domain in z_dict.items()),
-            *(command.X(node=node, domain=domain) for node, domain in x_dict.items()),
-        ]
-
-    def is_standard(self) -> bool:
-        """Determine whether the command sequence is standard.
+        strict : bool, optional
+            If True, ensures that C commands are the last ones.
 
         Returns
         -------
@@ -398,9 +317,16 @@ class Pattern:
                 kind = next(it).kind
             while kind == CommandKind.M:
                 kind = next(it).kind
-            xzc = {CommandKind.X, CommandKind.Z, CommandKind.C}
-            while kind in xzc:
-                kind = next(it).kind
+            if strict:
+                xz = {CommandKind.X, CommandKind.Z}
+                while kind in xz:
+                    kind = next(it).kind
+                while kind == CommandKind.C:
+                    kind = next(it).kind
+            else:
+                xzc = {CommandKind.X, CommandKind.Z, CommandKind.C}
+                while kind in xzc:
+                    kind = next(it).kind
         except StopIteration:
             return True
         else:
@@ -1234,7 +1160,6 @@ class Pattern:
         prepared = set(self.input_nodes)
         measured: set[int] = set()
         new: list[Command] = []
-        c_list = []
         cmd: Command
 
         for cmd in meas_commands:
@@ -1256,14 +1181,12 @@ class Pattern:
             if cmd.kind == CommandKind.N and cmd.node not in prepared:
                 new.append(command.N(node=cmd.node))
             elif (
-                cmd.kind == CommandKind.E and all(node in self.output_nodes for node in cmd.nodes)
-            ) or cmd.kind == CommandKind.C:
+                (cmd.kind == CommandKind.E and all(node in self.output_nodes for node in cmd.nodes))
+                or cmd.kind == CommandKind.C
+                or cmd.kind in {CommandKind.Z, CommandKind.X}
+            ):
                 new.append(cmd)
-            elif cmd.kind in {CommandKind.Z, CommandKind.X}:  # Add corrections
-                c_list.append(cmd)
 
-        # c_list = self.correction_commands()
-        new.extend(c_list)
         self.__seq = new
 
     def max_space(self) -> int:

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from numpy.random import PCG64, Generator
+
+from graphix.clifford import Clifford
+from graphix.command import C, Command, CommandKind, E, N
+from graphix.fundamentals import Plane
+from graphix.gflow import gflow_from_pattern
+from graphix.optimization import incorporate_pauli_results
+from graphix.pattern import Pattern
+from graphix.random_objects import rand_circuit
+from graphix.states import PlanarState
+
+
+def test_standardize_clifford_entanglement(fx_rng: Generator) -> None:
+    alpha = 2 * np.pi * fx_rng.random()
+    i_lst = [0]
+    o_lst = [0, 1]
+
+    supported_gates = {0, 1, 2, 3, 4, 5, 9, 10}
+
+    for i in range(24):
+        for j in range(24):
+            cmds: list[Command] = [N(1), C(0, Clifford(i)), C(1, Clifford(j)), E((0, 1))]
+            p = Pattern(input_nodes=i_lst, output_nodes=o_lst, cmds=cmds)
+            p_ref = p.copy()
+
+            if i not in supported_gates:
+                with pytest.raises(
+                    NotImplementedError,
+                    match=r"Pattern contains a Clifford followed by an E command on qubit 0 which only commute up to a two-qubit Clifford. Standarization is not supported.",
+                ):
+                    p.standardize()
+            elif j not in supported_gates:
+                with pytest.raises(
+                    NotImplementedError,
+                    match=r"Pattern contains a Clifford followed by an E command on qubit 1 which only commute up to a two-qubit Clifford. Standarization is not supported.",
+                ):
+                    p.standardize()
+            else:
+                p.standardize()
+
+                # check C commands are at the end
+                assert p[0].kind == CommandKind.N
+                assert p[1].kind == CommandKind.E
+                assert p[2].kind == CommandKind.C
+                assert p[3].kind == CommandKind.C
+
+                state_ref = p_ref.simulate_pattern(input_state=PlanarState(Plane.XY, alpha))
+                state_p = p.simulate_pattern(input_state=PlanarState(Plane.XY, alpha))
+                assert np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())) == pytest.approx(1)
+
+
+@pytest.mark.parametrize("jumps", range(1, 11))
+def test_incorporate_pauli_results(fx_bg: PCG64, jumps: int) -> None:
+    rng = Generator(fx_bg.jumped(jumps))
+    nqubits = 3
+    depth = 3
+    circuit = rand_circuit(nqubits, depth, rng)
+    pattern = circuit.transpile().pattern
+    pattern.standardize()
+    pattern.shift_signals()
+    pattern.perform_pauli_measurements()
+    pattern2 = incorporate_pauli_results(pattern)
+    state = pattern.simulate_pattern(rng=rng)
+    state2 = pattern2.simulate_pattern(rng=rng)
+    assert np.abs(np.dot(state.flatten().conjugate(), state2.flatten())) == pytest.approx(1)
+
+
+@pytest.mark.parametrize("jumps", range(1, 11))
+def test_flow_after_pauli_preprocessing(fx_bg: PCG64, jumps: int) -> None:
+    rng = Generator(fx_bg.jumped(jumps))
+    nqubits = 3
+    depth = 3
+    circuit = rand_circuit(nqubits, depth, rng)
+    pattern = circuit.transpile().pattern
+    pattern.standardize()
+    pattern.shift_signals()
+    pattern.perform_pauli_measurements()
+    pattern2 = incorporate_pauli_results(pattern)
+    pattern2.standardize()
+    f, _l = gflow_from_pattern(pattern2)
+    assert f is not None

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -78,7 +78,7 @@ class TestPattern:
         circuit = rand_circuit(nqubits, depth, fx_rng)
         pattern = circuit.transpile().pattern
 
-        pattern.standardize(method="mc")
+        pattern.standardize()
         assert pattern.is_standard()
         state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern(rng=fx_rng)
@@ -89,7 +89,7 @@ class TestPattern:
         depth = 5
         circuit = rand_circuit(nqubits, depth, fx_rng)
         pattern = circuit.transpile().pattern
-        pattern.standardize(method="direct")
+        pattern.standardize()
         pattern.minimize_space()
         state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern(rng=fx_rng)
@@ -114,7 +114,7 @@ class TestPattern:
         pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
         circuit = rand_gate(nqubits, depth, pairs, rng)
         pattern = circuit.transpile().pattern
-        pattern.standardize(method="mc")
+        pattern.standardize()
         pattern.shift_signals(method="mc")
         pattern.perform_pauli_measurements()
         pattern.minimize_space()
@@ -153,7 +153,7 @@ class TestPattern:
             pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
             circuit = rand_gate(nqubits, depth, pairs, fx_rng)
             pattern = circuit.transpile().pattern
-            pattern.standardize(method="mc")
+            pattern.standardize()
             pattern.minimize_space()
             assert pattern.max_space() == nqubits + 1
 
@@ -162,7 +162,7 @@ class TestPattern:
         depth = 1
         circuit = rand_circuit(nqubits, depth, fx_rng)
         pattern = circuit.transpile().pattern
-        pattern.standardize(method="mc")
+        pattern.standardize()
         pattern.parallelize_pattern()
         state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern(rng=fx_rng)
@@ -175,7 +175,7 @@ class TestPattern:
         depth = 1
         circuit = rand_circuit(nqubits, depth, rng)
         pattern = circuit.transpile().pattern
-        pattern.standardize(method="mc")
+        pattern.standardize()
         pattern.shift_signals(method="mc")
         assert pattern.is_standard()
         state = circuit.simulate_statevector().statevec
@@ -191,7 +191,7 @@ class TestPattern:
         depth = 3
         circuit = rand_circuit(nqubits, depth, rng)
         pattern = circuit.transpile().pattern
-        pattern.standardize(method="mc")
+        pattern.standardize()
         pattern.shift_signals(method="mc")
         pattern.perform_pauli_measurements()
         pattern.minimize_space()
@@ -209,7 +209,7 @@ class TestPattern:
         depth = 3
         circuit = rand_circuit(nqubits, depth, rng)
         pattern = circuit.transpile().pattern
-        pattern.standardize(method="mc")
+        pattern.standardize()
         pattern.shift_signals(method="mc")
         pattern.perform_pauli_measurements(ignore_pauli_with_deps=ignore_pauli_with_deps)
         assert ignore_pauli_with_deps or not any(
@@ -235,7 +235,7 @@ class TestPattern:
         depth = 3
         circuit = rand_circuit(nqubits, depth, rng)
         pattern = circuit.transpile().pattern
-        pattern.standardize(method="mc")
+        pattern.standardize()
         pattern.shift_signals(method="mc")
         pattern.perform_pauli_measurements(leave_input=True)
         pattern.minimize_space()
@@ -261,7 +261,7 @@ class TestPattern:
         swap(circuit, 0, 2)
 
         pattern = circuit.transpile().pattern
-        pattern.standardize(method="mc")
+        pattern.standardize()
         pattern.shift_signals(method="mc")
         pattern.perform_pauli_measurements()
 
@@ -289,7 +289,7 @@ class TestPattern:
         swap(circuit, 0, 2)
 
         pattern = circuit.transpile().pattern
-        pattern.standardize(method="mc")
+        pattern.standardize()
         pattern.shift_signals(method="mc")
         pattern.perform_pauli_measurements(leave_input=True)
 
@@ -341,7 +341,7 @@ class TestPattern:
         pattern.add(M(node=2, angle=0.5, plane=plane, s_domain={0}, t_domain={1}))
         pattern.add(Z(node=3, domain={2}))
         pattern_ref = copy.deepcopy(pattern)
-        pattern.standardize(method="mc")
+        pattern.standardize()
         signal_dict = pattern.shift_signals(method=method)
         # Test for every possible outcome of each measure
         zero_one: list[Literal[0, 1]] = [0, 1]
@@ -361,7 +361,7 @@ class TestPattern:
         depth = 4
         circuit = rand_circuit(nqubits, depth, rng)
         pattern = circuit.transpile().pattern
-        pattern.standardize(method="direct")
+        pattern.standardize()
         assert pattern.is_standard()
         pattern.minimize_space()
         state_p = pattern.simulate_pattern()
@@ -383,15 +383,14 @@ class TestPattern:
         assert np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())) == pytest.approx(1)
 
     @pytest.mark.parametrize("jumps", range(1, 11))
-    @pytest.mark.parametrize("method", ["mc", "direct"])
-    def test_pauli_measurement_then_standardize(self, fx_bg: PCG64, jumps: int, method: str) -> None:
+    def test_pauli_measurement_then_standardize(self, fx_bg: PCG64, jumps: int) -> None:
         rng = Generator(fx_bg.jumped(jumps))
         nqubits = 3
         depth = 3
         circuit = rand_circuit(nqubits, depth, rng)
         pattern = circuit.transpile().pattern
         pattern.perform_pauli_measurements()
-        pattern.standardize(method=method)
+        pattern.standardize()
         pattern.minimize_space()
         state = circuit.simulate_statevector().statevec
         state_mbqc = pattern.simulate_pattern()
@@ -405,7 +404,7 @@ class TestPattern:
         pattern.add(C(node=0, clifford=Clifford(c0)))
         pattern.add(C(node=0, clifford=Clifford(c1)))
         pattern_ref = pattern.copy()
-        pattern.standardize(method="direct")
+        pattern.standardize()
         state_ref = pattern_ref.simulate_pattern()
         state_p = pattern.simulate_pattern()
         assert np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())) == pytest.approx(1)
@@ -422,7 +421,7 @@ class TestPattern:
         pattern.add(Z(node=0, domain={2}))
         pattern.add(C(node=0, clifford=Clifford(c)))
         pattern_ref = pattern.copy()
-        pattern.standardize(method="direct")
+        pattern.standardize()
         state_ref = pattern_ref.simulate_pattern()
         state_p = pattern.simulate_pattern()
         assert np.abs(np.dot(state_p.flatten().conjugate(), state_ref.flatten())) == pytest.approx(1)
@@ -549,9 +548,9 @@ class TestMCOps:
         depth = 4
         circuit = rand_circuit(nqubits, depth, rng)
         pattern = circuit.transpile().pattern
-        pattern.standardize(method="direct")
+        pattern.standardize()
         pattern_mc = circuit.transpile().pattern
-        pattern_mc.standardize(method="mc")
+        pattern_mc.standardize()
         assert pattern.is_standard()
         pattern.minimize_space()
         pattern_mc.minimize_space()
@@ -566,10 +565,10 @@ class TestMCOps:
         depth = 4
         circuit = rand_circuit(nqubits, depth, rng)
         pattern = circuit.transpile().pattern
-        pattern.standardize(method="direct")
+        pattern.standardize()
         pattern.shift_signals(method="direct")
         pattern_mc = circuit.transpile().pattern
-        pattern_mc.standardize(method="mc")
+        pattern_mc.standardize()
         pattern_mc.shift_signals(method="mc")
         assert pattern.is_standard()
         pattern.minimize_space()
@@ -597,12 +596,12 @@ class TestMCOps:
     def test_mixed_pattern_operations(self, fx_bg: PCG64, jumps: int) -> None:
         rng = Generator(fx_bg.jumped(jumps))
         processes = [
-            [["standardize", "direct"], ["standardize", "mc"]],
-            [["standardize", "direct"], ["signal", "mc"], ["signal", "direct"]],
+            [["standardize"]],
+            [["standardize"], ["signal", "mc"], ["signal", "direct"]],
             [
-                ["standardize", "direct"],
+                ["standardize"],
                 ["signal", "mc"],
-                ["standardize", "mc"],
+                ["standardize"],
                 ["signal", "direct"],
             ],
         ]
@@ -614,7 +613,7 @@ class TestMCOps:
             pattern = circuit.transpile().pattern
             for operation in process:
                 if operation[0] == "standardize":
-                    pattern.standardize(method=operation[1])
+                    pattern.standardize()
                 elif operation[0] == "signal":
                     pattern.shift_signals(method=operation[1])
             assert pattern.is_standard()


### PR DESCRIPTION
This commit introduces a new module `optimization.py` containing:

- A functional version of `standardize` that returns a standardized pattern as a new object.  This function now correctly handles patterns with C commands, returning an equivalent standardized pattern or raising an error if no such form exists, thus fixing #314.

- A new function `incorporate_pauli_results` that returns an equivalent pattern where `results` are incorporated into measurement and correction domains. The resulting pattern is suitable for flow analysis. In particular, if a pattern has a flow, it is preserved by `perform_pauli_measurements` after applying `standardize` and `incorporate_pauli_results`.

Standardized patterns now place C commands after X and Z commands. The `flow_from_pattern` functions now fail if the input pattern is not strictly standardized, as checked by
`Pattern.is_standard(strict=True)` (which requires C commands to be at the end).

The `method` parameter of `standardize` is now deprecated.  The method `mc` has been removed, as it did not guarantee the equivalence of the resulting pattern.

These algorithms are placed in a new module to reduce the algorithmic contents of `pattern.py`. For backward compatibility and convenience, the `Pattern` class retains an in-place `standardize` method, which internally calls `optimization.standardize`.

As a result, there is now an intentional import loop between `pattern.py` and `optimization.py`: `Pattern` calls `optimization.standardize`, and `optimization.standardize` instantiates `graphix.Pattern`. To manage this safely, we avoid `from ... import` statements between these modules, except in type-checking blocks, thereby guaranteeing that there is no import-time execution cycle.