### PR TITLE
Fix #328: Add file `py.typed` for marking installed `graphix` package as typed

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -32,3 +32,33 @@ jobs:
       - run: mypy
 
       - run: pyright
+
+  # Check that `mypy` find installed `graphix` package (#328)
+  #
+  # Note that `mypy` does not find editable packages (installed with
+  # the option `pip install -e`), unless they are installed in
+  # `compat` or `strict` mode.
+  #
+  # pip install -e . --config-settings editable_mode=strict
+  #
+  # See https://github.com/pypa/setuptools/issues/3518.
+  typed-package:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.python-version }}
+
+      - name: Install graphix and mypy
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev]
+
+      - name: Test type-checking
+        run: |
+          cd ${{ runner.temp }}
+          echo "from graphix import Pattern" > test_graphix_type.py
+          mypy test_graphix_type.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,3 +70,28 @@ enable the linter and basic type checking on save:
 ```
 
 and you are ready to commit the changes.
+
+## Type-checking other Python projects that import `graphix` when installed as an editable package
+
+If `graphix` is installed with the command given above:
+
+```bash
+pip install -e .[dev]
+```
+
+Then `mypy` fails to type-check other Python projects that import `graphix`, showing the following error:
+
+```
+error: Skipping analyzing "graphix": module is installed, but missing library stubs or py.typed marker  [import-untyped]
+```
+
+Neither `mypy` nor `pyright` detect editable packages (installed with
+`pip install -e`), unless they are installed in `compat` or `strict`
+mode. A workaround is to install `graphix` in `strict` mode by running
+the following command in the `graphix` repository.
+
+```bash
+pip install -e . --config-settings editable_mode=strict
+```
+
+See https://github.com/pypa/setuptools/issues/3518 for more details.


### PR DESCRIPTION
This PR adds the file `py.typed` to the `graphix` source tree to mark the `graphix` package as typed upon installation.

According to the Python documentation [Type information in libraries](https://typing.python.org/en/latest/spec/distributing.html#packaging-typed-libraries):

> Package maintainers who wish to support type checking of their code MUST add a marker file named `py.typed` to their package supporting typing.

This PR adds the CI job `typed-package` in the workflow `typecheck.yml` to check that `mypy` finds the package when installed. Note that the first commit of this PR, d1af283, is expected to fail, in order to verify that the bug described in #328 is reproducible. The failure can be observed [here](https://github.com/TeamGraphix/graphix/actions/runs/16858442811/job/47755007390).

This PR also documents in `CONTRIBUTING.md` that `mypy` and `pyright` still fail to detect `graphix` when type-checking other Python projects when `graphix` is installed as an editable package, and documents the workaround, which consists of installing `graphix` in `compat` or `strict` mode.

```bash
pip install -e . --config-settings editable_mode=strict
```

See https://github.com/pypa/setuptools/issues/3518 for more details.