### PR TITLE
Fix #173: introduce `StandardizedPattern` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   inherit from `DenseState`. Note that the class hierarchy of
   `BackendState` mirrors that of `Backend`.
 
-- #322: Added a new `optimization` module containing:
+- #322, #332: Added a new `optimization` module containing:
 
   * a functional version of `standardize` that returns a standardized
     pattern as a new object;
@@ -43,7 +43,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     The resulting pattern is suitable for flow analysis. In
     particular, if a pattern has a flow, it is preserved by
     `perform_pauli_measurements` after applying `standardize` and
-    `incorporate_pauli_results`.
+    `incorporate_pauli_results`;
+
+  * a class `StandardizedPattern` that contains the decomposed parts
+    of a standardized pattern.
 
 ### Fixed
 
@@ -62,6 +65,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - #302, #308, #312: `Pattern`, `Circuit`, `PatternSimulator`, and
   backends are now type-checked.
+
+- #173, #332: `Pattern.extract_measurement_commands` does not
+  modify the pattern and returns unstandardized measurements.
 
 ### Changed
 
@@ -97,6 +103,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   specific state representation. Covariance is sound in this context
   because the classes are frozen, and it ensures that
   `Backend[BackendState]` is a supertype of all backend classes.
+
+- #220, #332: `Pattern.get_measurements_commands` is renamed into
+  `Pattern.extract_measurement_commands`.
 
 ## [0.3.1] - 2025-04-21
 

--- a/graphix/optimization.py
+++ b/graphix/optimization.py
@@ -42,112 +42,175 @@ def standardize(pattern: Pattern) -> Pattern:
     standardized : Pattern
         The standardized pattern, if it exists.
     """
-    n_list: list[command.N] = []
-    e_list: list[command.E] = []
-    m_list: list[command.M] = []
-    c_dict: dict[int, Clifford] = {}
-    z_dict: dict[int, set[Node]] = {}
-    x_dict: dict[int, set[Node]] = {}
+    return StandardizedPattern(pattern).to_pattern()
 
-    def add_correction_domain(domain_dict: dict[Node, set[Node]], node: Node, domain: set[Node]) -> None:
-        """Merge a correction domain into ``domain_dict`` for ``node``.
 
-        Parameters
-        ----------
-        domain_dict : dict[int, Command]
-            Mapping from node index to accumulated domain.
-        node : int
-            Target node whose domain should be updated.
-        domain : set[int]
-            Domain to merge with the existing one.
+class StandardizedPattern:
+    """Pattern in standardized form.
+
+    Use the method :meth:`to_pattern()` to get the standardized pattern.
+    Note that the attribute :attr:`pattern` contains the original pattern.
+
+    Attributes
+    ----------
+    pattern: Pattern
+        The original pattern.
+    n_list: list[command.N]
+        The N commands.
+    e_list: list[command.E]
+        The E commands.
+    m_list: list[command.M]
+        The M commands.
+    c_dict: dict[int, Clifford]
+        Mapping associating Clifford corrections to some nodes.
+    z_dict: dict[int, set[Node]]
+        Mapping associating Z-domains to some nodes.
+    x_dict: dict[int, set[Node]]
+        Mapping associating X-domains to some nodes.
+    """
+
+    pattern: Pattern
+    n_list: list[command.N]
+    e_list: list[command.E]
+    m_list: list[command.M]
+    c_dict: dict[int, Clifford]
+    z_dict: dict[int, set[Node]]
+    x_dict: dict[int, set[Node]]
+
+    def __init__(self, pattern: Pattern) -> None:
+        """Compute the standardized form of the given pattern."""
+        s_domain: set[Node]
+        t_domain: set[Node]
+        s_domain_opt: set[Node] | None
+        t_domain_opt: set[Node] | None
+
+        self.pattern = pattern
+        self.n_list = []
+        self.e_list = []
+        self.m_list = []
+        self.c_dict = {}
+        self.z_dict = {}
+        self.x_dict = {}
+
+        for cmd in pattern:
+            if cmd.kind == CommandKind.N:
+                self.n_list.append(cmd)
+            elif cmd.kind == CommandKind.E:
+                for side in (0, 1):
+                    i, j = cmd.nodes[side], cmd.nodes[1 - side]
+                    if clifford_gate := self.c_dict.get(i):
+                        _commute_clifford(clifford_gate, self.c_dict, i, j)
+                    if s_domain_opt := self.x_dict.get(i):
+                        _add_correction_domain(self.z_dict, j, s_domain_opt)
+                self.e_list.append(cmd)
+            elif cmd.kind == CommandKind.M:
+                new_cmd = cmd
+                if clifford_gate := self.c_dict.pop(cmd.node, None):
+                    new_cmd = new_cmd.clifford(clifford_gate)
+                if t_domain_opt := self.z_dict.pop(cmd.node, None):
+                    # The original domain should not be mutated
+                    new_cmd.t_domain = new_cmd.t_domain ^ t_domain_opt  # noqa: PLR6104
+                if s_domain_opt := self.x_dict.pop(cmd.node, None):
+                    # The original domain should not be mutated
+                    new_cmd.s_domain = new_cmd.s_domain ^ s_domain_opt  # noqa: PLR6104
+                self.m_list.append(new_cmd)
+            # Use of `==` here for mypy
+            elif cmd.kind == CommandKind.X or cmd.kind == CommandKind.Z:  # noqa: PLR1714
+                if cmd.kind == CommandKind.X:
+                    s_domain = cmd.domain
+                    t_domain = set()
+                else:
+                    s_domain = set()
+                    t_domain = cmd.domain
+                domains = self.c_dict.get(cmd.node, Clifford.I).commute_domains(Domains(s_domain, t_domain))
+                if domains.t_domain:
+                    _add_correction_domain(self.z_dict, cmd.node, domains.t_domain)
+                if domains.s_domain:
+                    _add_correction_domain(self.x_dict, cmd.node, domains.s_domain)
+            elif cmd.kind == CommandKind.C:
+                # Each pattern command is applied by left multiplication: if a clifford `C`
+                # has been already applied to a node, applying a clifford `C'` to the same
+                # node is equivalent to apply `C'C` to a fresh node.
+                self.c_dict[cmd.node] = cmd.clifford @ self.c_dict.get(cmd.node, Clifford.I)
+
+    def extract_graph(self) -> tuple[list[int], list[tuple[int, int]]]:
+        """Return the list of nodes and edges from the command sequence, extracted from 'N' and 'E' commands.
+
+        Returns
+        -------
+        node_list : list
+            list of node indices.
+        edge_list : list
+            list of tuples (i,j) specifying edges
         """
-        if previous_domain := domain_dict.get(node):
-            previous_domain ^= domain
-        else:
-            domain_dict[node] = domain.copy()
+        # We rely on the fact that pattern.input_nodes returns a copy
+        node_list: list[int]
+        edge_list: list[tuple[int, int]]
+        node_list, edge_list = self.pattern.input_nodes, []
+        for cmd_n in self.n_list:
+            node_list.append(cmd_n.node)
+        for cmd_e in self.e_list:
+            edge_list.append(cmd_e.nodes)
+        return node_list, edge_list
 
-    def commute_clifford(clifford_gate: Clifford, c_dict: dict[int, Clifford], i: int, j: int) -> None:
-        """Commute a Clifford with an entanglement command.
+    def to_pattern(self) -> Pattern:
+        """Return the standardized pattern."""
+        result = graphix.pattern.Pattern(input_nodes=self.pattern.input_nodes)
+        result.results = self.pattern.results
+        result.extend(
+            self.n_list,
+            self.e_list,
+            self.m_list,
+            (command.Z(node=node, domain=domain) for node, domain in self.z_dict.items()),
+            (command.X(node=node, domain=domain) for node, domain in self.x_dict.items()),
+            (command.C(node=node, clifford=clifford_gate) for node, clifford_gate in self.c_dict.items()),
+        )
+        return result
 
-        Parameters
-        ----------
-        clifford_gate : Clifford
-            Clifford gate before the entanglement command
-        c_dict : dict[int, Clifford]
-            Mapping from the node index to accumulated Clifford commands.
-        i : int
-            First node of the entanglement command where the Clifford is applied.
-        j : int
-            Second node of the entanglement command where the Clifford is applied.
-        """
-        if clifford_gate in {Clifford.I, Clifford.Z, Clifford.S, Clifford.SDG}:
-            # Clifford gate commutes with the entanglement command.
-            pass
-        elif clifford_gate in {Clifford.X, Clifford.Y, Clifford(9), Clifford(10)}:
-            # Clifford gate commutes with the entanglement command up to a Z Clifford on the other index.
-            c_dict[j] = Clifford.Z @ c_dict.get(j, Clifford.I)
-        else:
-            # Clifford gate commutes with the entanglement command up to a two-qubit Clifford
-            raise NotImplementedError(
-                f"Pattern contains a Clifford followed by an E command on qubit {i} which only commute up to a two-qubit Clifford. Standarization is not supported."
-            )
 
-    s_domain: set[Node]
-    t_domain: set[Node]
-    s_domain_opt: set[Node] | None
-    t_domain_opt: set[Node] | None
+def _add_correction_domain(domain_dict: dict[Node, set[Node]], node: Node, domain: set[Node]) -> None:
+    """Merge a correction domain into ``domain_dict`` for ``node``.
 
-    for cmd in pattern:
-        if cmd.kind == CommandKind.N:
-            n_list.append(cmd)
-        elif cmd.kind == CommandKind.E:
-            for side in (0, 1):
-                i, j = cmd.nodes[side], cmd.nodes[1 - side]
-                if clifford_gate := c_dict.get(i):
-                    commute_clifford(clifford_gate, c_dict, i, j)
-                if s_domain_opt := x_dict.get(i):
-                    add_correction_domain(z_dict, j, s_domain_opt)
-            e_list.append(cmd)
-        elif cmd.kind == CommandKind.M:
-            new_cmd = cmd
-            if clifford_gate := c_dict.pop(cmd.node, None):
-                new_cmd = new_cmd.clifford(clifford_gate)
-            if t_domain_opt := z_dict.pop(cmd.node, None):
-                # The original domain should not be mutated
-                new_cmd.t_domain = new_cmd.t_domain ^ t_domain_opt  # noqa: PLR6104
-            if s_domain_opt := x_dict.pop(cmd.node, None):
-                # The original domain should not be mutated
-                new_cmd.s_domain = new_cmd.s_domain ^ s_domain_opt  # noqa: PLR6104
-            m_list.append(new_cmd)
-        # Use of `==` here for mypy
-        elif cmd.kind == CommandKind.X or cmd.kind == CommandKind.Z:  # noqa: PLR1714
-            if cmd.kind == CommandKind.X:
-                s_domain = cmd.domain
-                t_domain = set()
-            else:
-                s_domain = set()
-                t_domain = cmd.domain
-            domains = c_dict.get(cmd.node, Clifford.I).commute_domains(Domains(s_domain, t_domain))
-            if domains.t_domain:
-                add_correction_domain(z_dict, cmd.node, domains.t_domain)
-            if domains.s_domain:
-                add_correction_domain(x_dict, cmd.node, domains.s_domain)
-        elif cmd.kind == CommandKind.C:
-            # Each pattern command is applied by left multiplication: if a clifford `C`
-            # has been already applied to a node, applying a clifford `C'` to the same
-            # node is equivalent to apply `C'C` to a fresh node.
-            c_dict[cmd.node] = cmd.clifford @ c_dict.get(cmd.node, Clifford.I)
-    result = graphix.pattern.Pattern(input_nodes=pattern.input_nodes)
-    result.results = pattern.results
-    result.extend(
-        n_list,
-        e_list,
-        m_list,
-        (command.Z(node=node, domain=domain) for node, domain in z_dict.items()),
-        (command.X(node=node, domain=domain) for node, domain in x_dict.items()),
-        (command.C(node=node, clifford=clifford_gate) for node, clifford_gate in c_dict.items()),
-    )
-    return result
+    Parameters
+    ----------
+    domain_dict : dict[int, Command]
+        Mapping from node index to accumulated domain.
+    node : int
+        Target node whose domain should be updated.
+    domain : set[int]
+        Domain to merge with the existing one.
+    """
+    if previous_domain := domain_dict.get(node):
+        previous_domain ^= domain
+    else:
+        domain_dict[node] = domain.copy()
+
+
+def _commute_clifford(clifford_gate: Clifford, c_dict: dict[int, Clifford], i: int, j: int) -> None:
+    """Commute a Clifford with an entanglement command.
+
+    Parameters
+    ----------
+    clifford_gate : Clifford
+        Clifford gate before the entanglement command
+    c_dict : dict[int, Clifford]
+        Mapping from the node index to accumulated Clifford commands.
+    i : int
+        First node of the entanglement command where the Clifford is applied.
+    j : int
+        Second node of the entanglement command where the Clifford is applied.
+    """
+    if clifford_gate in {Clifford.I, Clifford.Z, Clifford.S, Clifford.SDG}:
+        # Clifford gate commutes with the entanglement command.
+        pass
+    elif clifford_gate in {Clifford.X, Clifford.Y, Clifford(9), Clifford(10)}:
+        # Clifford gate commutes with the entanglement command up to a Z Clifford on the other index.
+        c_dict[j] = Clifford.Z @ c_dict.get(j, Clifford.I)
+    else:
+        # Clifford gate commutes with the entanglement command up to a two-qubit Clifford
+        raise NotImplementedError(
+            f"Pattern contains a Clifford followed by an E command on qubit {i} which only commute up to a two-qubit Clifford. Standarization is not supported."
+        )
 
 
 def _incorporate_pauli_results_in_domain(

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -128,7 +128,7 @@ class TestGenerator:
         g.add_edges_from(edges)
         input_list = [0, 1, 2]
         angles: dict[int, float] = {}
-        for cmd in pattern.get_measurement_commands():
+        for cmd in pattern.extract_measurement_commands():
             assert isinstance(cmd.angle, float)
             angles[cmd.node] = float(cmd.angle)
         meas_planes = pattern.get_meas_plane()


### PR DESCRIPTION
This commit introduces the `StandardizedPattern` class in the optimization module. The code from the `standardize` function has been moved into this class, allowing access to the decomposed parts of the standardized pattern through class attributes.

This class enables Pauli preprocessing to avoid relying on `Pattern.get_measurements_commands` and `Pattern.get_graph`, since the relevant commands are now extracted during the standardization process.

Previously, the method checked `Pattern.get_measurements_commands` to determine whether the pattern was standardized (which was always true in the context of Pauli preprocessing), and standardized it if necessary. It then extracted the portion of the pattern consisting of consecutive M commands. Although this optimization stopped just after the last M command, checking for standardization still required iterating over the entire pattern.

This method has now been replaced by `extract_measurement_commands`. This renaming follows the recommendation in #220 to avoid `get_` and `set_` method names. The new method produces an iterator over the M commands, regardless of whether the pattern is standardized.
