### PR TITLE
Pin reviewdog/action-suggester to v1.22.0

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -64,6 +64,6 @@ jobs:
           corepack enable pnpm
           pnpm dlx prettier --write .
 
-      - uses: reviewdog/action-suggester@v1
+      - uses: reviewdog/action-suggester@v1.22.0
         with:
           tool_name: ":art: text-formatter"


### PR DESCRIPTION
Recent versions (v1.23.0 and v1 tag) fail with installation error:
```
🐶 Installing reviewdog ... https://github.com/reviewdog/reviewdog
cat: /home/runner/work/_actions/reviewdog/action-suggester/v1/install-reviewdog.sh: No such file or directory
Error: Process completed with exit code 1.
```

This temporarily pins the version to v1.22.0, which was working before the regression, until the upstream issue is resolved.

Ref: https://github.com/reviewdog/action-suggester/issues/95
