### PR TITLE
Revert `BaseM` removed in #205

### DIFF
--- a/graphix/command.py
+++ b/graphix/command.py
@@ -67,10 +67,10 @@ class N(_KindChecker, DataclassReprMixin):
 class BaseM(DataclassReprMixin):
     """Base measurement command.
 
-    Represent a measurement of a node. In `graphix`, a measurement is an instance of 
-    class `M`, with given plane, angles, and domains. The base class `BaseM` allows users to define 
-    new class of measurements with different abstractions. For example, in the context 
-    of blind computations, the server only knows which node is measured, and the parameters 
+    Represent a measurement of a node. In `graphix`, a measurement is an instance of
+    class `M`, with given plane, angles, and domains. The base class `BaseM` allows users to define
+    new class of measurements with different abstractions. For example, in the context
+    of blind computations, the server only knows which node is measured, and the parameters
     are given by the :class:`graphix.simulator.MeasureMethod` provided by the client.
     """
 


### PR DESCRIPTION
This reverts the removal of `BaseM`, which was deleted in commit a07197ae2097403ae0b2d62108b46ef7659a4331.

This commit subsumes #237, which restores `BaseM` but lacks the associated documentation

Currently, `BaseM` is a type alias for `M`, which is not particularly useful. However, `BaseM` is used in Veriphix in blind patterns: the server only knows which node is measured, and the measurement itself is specified by the client's `MeasureMethod`.

This commit is a step towards upstreaming Graphix's features needed for Veriphix (and for UBQC in general).

Before submitting, please check the following:

- Make sure you have tests for the new code and that test passes (run `nox`)
- If applicable, add a line to the [unreleased] part of CHANGELOG.md, following [keep-a-changelog](https://keepachangelog.com/en/1.0.0/).
- Format added code by `ruff`
  - See `CONTRIBUTING.md` for more details
- Make sure the checks (github actions) pass.

Then, please fill in below:

**Context (if applicable):**

**Description of the change:**

**Related issue:**
