### PR TITLE
Fix #73: Remove ptrace mention from the `remove_qubit` docstring

### DIFF
--- a/graphix/sim/statevec.py
+++ b/graphix/sim/statevec.py
@@ -251,9 +251,6 @@ class Statevec(DenseState):
             Care needs to be taken when using this method.
             Checks for separability will be implemented soon as an option.
 
-        .. seealso::
-            :meth:`graphix.sim.statevec.Statevec.ptrace` and warning therein.
-
         Parameters
         ----------
         qarg : int


### PR DESCRIPTION
The `Statevec.ptrace` method has been removed in #312.