### PR TITLE
Fix #231: define `IXYZ = Literal[I] | Axis`

### DIFF
--- a/graphix/_db.py
+++ b/graphix/_db.py
@@ -7,7 +7,7 @@ from typing import NamedTuple
 import numpy as np
 
 from graphix import utils
-from graphix.fundamentals import IXYZ, Sign
+from graphix.fundamentals import Axis, Sign
 from graphix.ops import Ops
 
 # 24 unique 1-qubit Clifford gates
@@ -128,7 +128,7 @@ CLIFFORD_CONJ = (0, 1, 2, 3, 5, 4, 6, 15, 12, 9, 10, 11, 8, 13, 14, 7, 20, 22, 2
 class _CM(NamedTuple):
     """Pauli string and sign."""
 
-    pstr: IXYZ
+    pstr: Axis
     sign: Sign
 
 
@@ -144,30 +144,30 @@ class _CMTuple(NamedTuple):
 # i.e. C @ P @ C^dagger result in Pauli group, i.e. {\pm} \times {X, Y, Z}.
 # CLIFFORD_MEASURE contains the effect of Clifford conjugation of Pauli gates.
 CLIFFORD_MEASURE = (
-    _CMTuple(_CM(IXYZ.X, Sign.PLUS), _CM(IXYZ.Y, Sign.PLUS), _CM(IXYZ.Z, Sign.PLUS)),
-    _CMTuple(_CM(IXYZ.X, Sign.PLUS), _CM(IXYZ.Y, Sign.MINUS), _CM(IXYZ.Z, Sign.MINUS)),
-    _CMTuple(_CM(IXYZ.X, Sign.MINUS), _CM(IXYZ.Y, Sign.PLUS), _CM(IXYZ.Z, Sign.MINUS)),
-    _CMTuple(_CM(IXYZ.X, Sign.MINUS), _CM(IXYZ.Y, Sign.MINUS), _CM(IXYZ.Z, Sign.PLUS)),
-    _CMTuple(_CM(IXYZ.Y, Sign.MINUS), _CM(IXYZ.X, Sign.PLUS), _CM(IXYZ.Z, Sign.PLUS)),
-    _CMTuple(_CM(IXYZ.Y, Sign.PLUS), _CM(IXYZ.X, Sign.MINUS), _CM(IXYZ.Z, Sign.PLUS)),
-    _CMTuple(_CM(IXYZ.Z, Sign.PLUS), _CM(IXYZ.Y, Sign.MINUS), _CM(IXYZ.X, Sign.PLUS)),
-    _CMTuple(_CM(IXYZ.X, Sign.PLUS), _CM(IXYZ.Z, Sign.MINUS), _CM(IXYZ.Y, Sign.PLUS)),
-    _CMTuple(_CM(IXYZ.Z, Sign.PLUS), _CM(IXYZ.Y, Sign.PLUS), _CM(IXYZ.X, Sign.MINUS)),
-    _CMTuple(_CM(IXYZ.Y, Sign.MINUS), _CM(IXYZ.X, Sign.MINUS), _CM(IXYZ.Z, Sign.MINUS)),
-    _CMTuple(_CM(IXYZ.Y, Sign.PLUS), _CM(IXYZ.X, Sign.PLUS), _CM(IXYZ.Z, Sign.MINUS)),
-    _CMTuple(_CM(IXYZ.Z, Sign.MINUS), _CM(IXYZ.Y, Sign.MINUS), _CM(IXYZ.X, Sign.MINUS)),
-    _CMTuple(_CM(IXYZ.Z, Sign.MINUS), _CM(IXYZ.Y, Sign.PLUS), _CM(IXYZ.X, Sign.PLUS)),
-    _CMTuple(_CM(IXYZ.X, Sign.MINUS), _CM(IXYZ.Z, Sign.MINUS), _CM(IXYZ.Y, Sign.MINUS)),
-    _CMTuple(_CM(IXYZ.X, Sign.MINUS), _CM(IXYZ.Z, Sign.PLUS), _CM(IXYZ.Y, Sign.PLUS)),
-    _CMTuple(_CM(IXYZ.X, Sign.PLUS), _CM(IXYZ.Z, Sign.PLUS), _CM(IXYZ.Y, Sign.MINUS)),
-    _CMTuple(_CM(IXYZ.Z, Sign.PLUS), _CM(IXYZ.X, Sign.PLUS), _CM(IXYZ.Y, Sign.PLUS)),
-    _CMTuple(_CM(IXYZ.Z, Sign.MINUS), _CM(IXYZ.X, Sign.PLUS), _CM(IXYZ.Y, Sign.MINUS)),
-    _CMTuple(_CM(IXYZ.Z, Sign.MINUS), _CM(IXYZ.X, Sign.MINUS), _CM(IXYZ.Y, Sign.PLUS)),
-    _CMTuple(_CM(IXYZ.Z, Sign.PLUS), _CM(IXYZ.X, Sign.MINUS), _CM(IXYZ.Y, Sign.MINUS)),
-    _CMTuple(_CM(IXYZ.Y, Sign.PLUS), _CM(IXYZ.Z, Sign.PLUS), _CM(IXYZ.X, Sign.PLUS)),
-    _CMTuple(_CM(IXYZ.Y, Sign.MINUS), _CM(IXYZ.Z, Sign.MINUS), _CM(IXYZ.X, Sign.PLUS)),
-    _CMTuple(_CM(IXYZ.Y, Sign.PLUS), _CM(IXYZ.Z, Sign.MINUS), _CM(IXYZ.X, Sign.MINUS)),
-    _CMTuple(_CM(IXYZ.Y, Sign.MINUS), _CM(IXYZ.Z, Sign.PLUS), _CM(IXYZ.X, Sign.MINUS)),
+    _CMTuple(_CM(Axis.X, Sign.PLUS), _CM(Axis.Y, Sign.PLUS), _CM(Axis.Z, Sign.PLUS)),
+    _CMTuple(_CM(Axis.X, Sign.PLUS), _CM(Axis.Y, Sign.MINUS), _CM(Axis.Z, Sign.MINUS)),
+    _CMTuple(_CM(Axis.X, Sign.MINUS), _CM(Axis.Y, Sign.PLUS), _CM(Axis.Z, Sign.MINUS)),
+    _CMTuple(_CM(Axis.X, Sign.MINUS), _CM(Axis.Y, Sign.MINUS), _CM(Axis.Z, Sign.PLUS)),
+    _CMTuple(_CM(Axis.Y, Sign.MINUS), _CM(Axis.X, Sign.PLUS), _CM(Axis.Z, Sign.PLUS)),
+    _CMTuple(_CM(Axis.Y, Sign.PLUS), _CM(Axis.X, Sign.MINUS), _CM(Axis.Z, Sign.PLUS)),
+    _CMTuple(_CM(Axis.Z, Sign.PLUS), _CM(Axis.Y, Sign.MINUS), _CM(Axis.X, Sign.PLUS)),
+    _CMTuple(_CM(Axis.X, Sign.PLUS), _CM(Axis.Z, Sign.MINUS), _CM(Axis.Y, Sign.PLUS)),
+    _CMTuple(_CM(Axis.Z, Sign.PLUS), _CM(Axis.Y, Sign.PLUS), _CM(Axis.X, Sign.MINUS)),
+    _CMTuple(_CM(Axis.Y, Sign.MINUS), _CM(Axis.X, Sign.MINUS), _CM(Axis.Z, Sign.MINUS)),
+    _CMTuple(_CM(Axis.Y, Sign.PLUS), _CM(Axis.X, Sign.PLUS), _CM(Axis.Z, Sign.MINUS)),
+    _CMTuple(_CM(Axis.Z, Sign.MINUS), _CM(Axis.Y, Sign.MINUS), _CM(Axis.X, Sign.MINUS)),
+    _CMTuple(_CM(Axis.Z, Sign.MINUS), _CM(Axis.Y, Sign.PLUS), _CM(Axis.X, Sign.PLUS)),
+    _CMTuple(_CM(Axis.X, Sign.MINUS), _CM(Axis.Z, Sign.MINUS), _CM(Axis.Y, Sign.MINUS)),
+    _CMTuple(_CM(Axis.X, Sign.MINUS), _CM(Axis.Z, Sign.PLUS), _CM(Axis.Y, Sign.PLUS)),
+    _CMTuple(_CM(Axis.X, Sign.PLUS), _CM(Axis.Z, Sign.PLUS), _CM(Axis.Y, Sign.MINUS)),
+    _CMTuple(_CM(Axis.Z, Sign.PLUS), _CM(Axis.X, Sign.PLUS), _CM(Axis.Y, Sign.PLUS)),
+    _CMTuple(_CM(Axis.Z, Sign.MINUS), _CM(Axis.X, Sign.PLUS), _CM(Axis.Y, Sign.MINUS)),
+    _CMTuple(_CM(Axis.Z, Sign.MINUS), _CM(Axis.X, Sign.MINUS), _CM(Axis.Y, Sign.PLUS)),
+    _CMTuple(_CM(Axis.Z, Sign.PLUS), _CM(Axis.X, Sign.MINUS), _CM(Axis.Y, Sign.MINUS)),
+    _CMTuple(_CM(Axis.Y, Sign.PLUS), _CM(Axis.Z, Sign.PLUS), _CM(Axis.X, Sign.PLUS)),
+    _CMTuple(_CM(Axis.Y, Sign.MINUS), _CM(Axis.Z, Sign.MINUS), _CM(Axis.X, Sign.PLUS)),
+    _CMTuple(_CM(Axis.Y, Sign.PLUS), _CM(Axis.Z, Sign.MINUS), _CM(Axis.X, Sign.MINUS)),
+    _CMTuple(_CM(Axis.Y, Sign.MINUS), _CM(Axis.Z, Sign.PLUS), _CM(Axis.X, Sign.MINUS)),
 )
 
 # Decomposition of Clifford gates with H, S and Z (up to phase).

--- a/graphix/clifford.py
+++ b/graphix/clifford.py
@@ -19,7 +19,7 @@ from graphix._db import (
     CLIFFORD_MUL,
     CLIFFORD_TO_QASM3,
 )
-from graphix.fundamentals import IXYZ, ComplexUnit
+from graphix.fundamentals import Axis, ComplexUnit, I
 from graphix.measurements import Domains
 from graphix.pauli import Pauli
 
@@ -126,14 +126,14 @@ class Clifford(Enum):
 
     def measure(self, pauli: Pauli) -> Pauli:
         """Compute C† P C."""
-        if pauli.symbol == IXYZ.I:
+        if pauli.symbol == I:
             return copy.deepcopy(pauli)
         table = CLIFFORD_MEASURE[self.value]
-        if pauli.symbol == IXYZ.X:
+        if pauli.symbol == Axis.X:
             symbol, sign = table.x
-        elif pauli.symbol == IXYZ.Y:
+        elif pauli.symbol == Axis.Y:
             symbol, sign = table.y
-        elif pauli.symbol == IXYZ.Z:
+        elif pauli.symbol == Axis.Z:
             symbol, sign = table.z
         else:
             typing_extensions.assert_never(pauli.symbol)

--- a/graphix/fundamentals.py
+++ b/graphix/fundamentals.py
@@ -6,7 +6,7 @@ import enum
 import typing
 from abc import ABC, ABCMeta, abstractmethod
 from enum import Enum, EnumMeta
-from typing import TYPE_CHECKING, SupportsComplex, SupportsFloat, SupportsIndex, overload
+from typing import TYPE_CHECKING, Literal, SupportsComplex, SupportsFloat, SupportsIndex, overload
 
 import typing_extensions
 
@@ -18,6 +18,8 @@ from graphix.parameter import cos_sin
 from graphix.repr_mixins import EnumReprMixin
 
 if TYPE_CHECKING:
+    from typing import TypeAlias
+
     import numpy as np
     import numpy.typing as npt
 
@@ -190,28 +192,6 @@ class ComplexUnit(EnumReprMixin, Enum):
         return ComplexUnit((self.value + 2) % 4)
 
 
-class IXYZ(Enum):
-    """I, X, Y or Z."""
-
-    I = enum.auto()
-    X = enum.auto()
-    Y = enum.auto()
-    Z = enum.auto()
-
-    @property
-    def matrix(self) -> npt.NDArray[np.complex128]:
-        """Return the matrix representation."""
-        if self == IXYZ.I:
-            return Ops.I
-        if self == IXYZ.X:
-            return Ops.X
-        if self == IXYZ.Y:
-            return Ops.Y
-        if self == IXYZ.Z:
-            return Ops.Z
-        typing_extensions.assert_never(self)
-
-
 class CustomMeta(ABCMeta, EnumMeta):
     """Custom metaclass to allow multiple inheritance from `Enum` and `ABC`."""
 
@@ -299,6 +279,24 @@ class Axis(AbstractMeasurement, EnumReprMixin, Enum, metaclass=CustomMeta):
     @override
     def to_plane_or_axis(self) -> Axis:
         return self
+
+
+class SingletonI(Enum):
+    """Singleton I."""
+
+    I = enum.auto()
+
+    @property
+    def matrix(self) -> npt.NDArray[np.complex128]:
+        """Return the matrix representation."""
+        return Ops.I
+
+
+I = SingletonI.I
+
+IXYZ: TypeAlias = Literal[SingletonI.I] | Axis
+
+IXYZ_VALUES: tuple[IXYZ, ...] = (I, Axis.X, Axis.Y, Axis.Z)
 
 
 class Plane(AbstractPlanarMeasurement, EnumReprMixin, Enum, metaclass=CustomMeta):

--- a/graphix/pauli.py
+++ b/graphix/pauli.py
@@ -7,8 +7,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 import typing_extensions
 
-from graphix.fundamentals import IXYZ, Axis, ComplexUnit, SupportsComplexCtor
-from graphix.ops import Ops
+from graphix.fundamentals import IXYZ_VALUES, Axis, ComplexUnit, I, SupportsComplexCtor
 from graphix.states import BasicStates
 
 if TYPE_CHECKING:
@@ -17,6 +16,7 @@ if TYPE_CHECKING:
     import numpy as np
     import numpy.typing as npt
 
+    from graphix.fundamentals import IXYZ
     from graphix.states import PlanarState
 
 
@@ -35,7 +35,7 @@ class Pauli(metaclass=_PauliMeta):
     and can be negated.
     """
 
-    symbol: IXYZ = IXYZ.I
+    symbol: IXYZ = I
     unit: ComplexUnit = ComplexUnit.ONE
     I: ClassVar[Pauli]
     X: ClassVar[Pauli]
@@ -45,7 +45,7 @@ class Pauli(metaclass=_PauliMeta):
     @staticmethod
     def from_axis(axis: Axis) -> Pauli:
         """Return the Pauli associated to the given axis."""
-        return Pauli(IXYZ[axis.name])
+        return Pauli(axis)
 
     @property
     def axis(self) -> Axis:
@@ -53,36 +53,28 @@ class Pauli(metaclass=_PauliMeta):
 
         Fails if the Pauli is identity.
         """
-        if self.symbol == IXYZ.I:
+        if self.symbol == I:
             raise ValueError("I is not an axis.")
-        return Axis[self.symbol.name]
+        return self.symbol
 
     @property
     def matrix(self) -> npt.NDArray[np.complex128]:
         """Return the matrix of the Pauli gate."""
         co = complex(self.unit)
-        if self.symbol == IXYZ.I:
-            return co * Ops.I
-        if self.symbol == IXYZ.X:
-            return co * Ops.X
-        if self.symbol == IXYZ.Y:
-            return co * Ops.Y
-        if self.symbol == IXYZ.Z:
-            return co * Ops.Z
-        typing_extensions.assert_never(self.symbol)
+        return co * self.symbol.matrix
 
     def eigenstate(self, binary: int = 0) -> PlanarState:
         """Return the eigenstate of the Pauli."""
         if binary not in {0, 1}:
             raise ValueError("b must be 0 or 1.")
-        if self.symbol == IXYZ.X:
+        if self.symbol == Axis.X:
             return BasicStates.PLUS if binary == 0 else BasicStates.MINUS
-        if self.symbol == IXYZ.Y:
+        if self.symbol == Axis.Y:
             return BasicStates.PLUS_I if binary == 0 else BasicStates.MINUS_I
-        if self.symbol == IXYZ.Z:
+        if self.symbol == Axis.Z:
             return BasicStates.ZERO if binary == 0 else BasicStates.ONE
         # Any state is eigenstate of the identity
-        if self.symbol == IXYZ.I:
+        if self.symbol == I:
             return BasicStates.PLUS
         typing_extensions.assert_never(self.symbol)
 
@@ -112,25 +104,25 @@ class Pauli(metaclass=_PauliMeta):
     @staticmethod
     def _matmul_impl(lhs: IXYZ, rhs: IXYZ) -> Pauli:
         """Return the product of ``lhs`` and ``rhs`` ignoring units."""
-        if lhs == IXYZ.I:
+        if lhs == I:
             return Pauli(rhs)
-        if rhs == IXYZ.I:
+        if rhs == I:
             return Pauli(lhs)
         if lhs == rhs:
             return Pauli()
         lr = (lhs, rhs)
-        if lr == (IXYZ.X, IXYZ.Y):
-            return Pauli(IXYZ.Z, ComplexUnit.J)
-        if lr == (IXYZ.Y, IXYZ.X):
-            return Pauli(IXYZ.Z, ComplexUnit.MINUS_J)
-        if lr == (IXYZ.Y, IXYZ.Z):
-            return Pauli(IXYZ.X, ComplexUnit.J)
-        if lr == (IXYZ.Z, IXYZ.Y):
-            return Pauli(IXYZ.X, ComplexUnit.MINUS_J)
-        if lr == (IXYZ.Z, IXYZ.X):
-            return Pauli(IXYZ.Y, ComplexUnit.J)
-        if lr == (IXYZ.X, IXYZ.Z):
-            return Pauli(IXYZ.Y, ComplexUnit.MINUS_J)
+        if lr == (Axis.X, Axis.Y):
+            return Pauli(Axis.Z, ComplexUnit.J)
+        if lr == (Axis.Y, Axis.X):
+            return Pauli(Axis.Z, ComplexUnit.MINUS_J)
+        if lr == (Axis.Y, Axis.Z):
+            return Pauli(Axis.X, ComplexUnit.J)
+        if lr == (Axis.Z, Axis.Y):
+            return Pauli(Axis.X, ComplexUnit.MINUS_J)
+        if lr == (Axis.Z, Axis.X):
+            return Pauli(Axis.Y, ComplexUnit.J)
+        if lr == (Axis.X, Axis.Z):
+            return Pauli(Axis.Y, ComplexUnit.MINUS_J)
         raise RuntimeError("Unreachable.")  # pragma: no cover
 
     def __matmul__(self, other: Pauli) -> Pauli:
@@ -162,12 +154,12 @@ class Pauli(metaclass=_PauliMeta):
             symbol_only (bool, optional): Exclude the unit in the iteration. Defaults to False.
         """
         us = (ComplexUnit.ONE,) if symbol_only else tuple(ComplexUnit)
-        for symbol in IXYZ:
+        for symbol in IXYZ_VALUES:
             for unit in us:
                 yield Pauli(symbol, unit)
 
 
-Pauli.I = Pauli(IXYZ.I)
-Pauli.X = Pauli(IXYZ.X)
-Pauli.Y = Pauli(IXYZ.Y)
-Pauli.Z = Pauli(IXYZ.Z)
+Pauli.I = Pauli(I)
+Pauli.X = Pauli(Axis.X)
+Pauli.Y = Pauli(Axis.Y)
+Pauli.Z = Pauli(Axis.Z)

--- a/tests/test_clifford.py
+++ b/tests/test_clifford.py
@@ -12,7 +12,7 @@ import numpy as np
 import pytest
 
 from graphix.clifford import Clifford
-from graphix.fundamentals import IXYZ, ComplexUnit, Sign
+from graphix.fundamentals import IXYZ_VALUES, ComplexUnit, Sign
 from graphix.pauli import Pauli
 
 if TYPE_CHECKING:
@@ -62,7 +62,7 @@ class TestClifford:
             Clifford,
             (
                 Pauli(sym, u)
-                for sym in IXYZ
+                for sym in IXYZ_VALUES
                 for u in (
                     ComplexUnit.from_properties(sign=Sign.PLUS, is_imag=False),
                     ComplexUnit.from_properties(sign=Sign.MINUS, is_imag=False),


### PR DESCRIPTION
This commit replaces the `IXYZ` enum class with a type alias defined as the union `Literal[I] | Axis`, where `I` is defined in the singleton enum `SingletonI`. This change makes `Alias` a subtype of `IXYZ`, removes cumbersome conversions between `IXYZ` and `Axis`, and eliminates some code duplication.