### PR TITLE
Removed `_pauli_preprocessed` flag from `Pattern` class functions.

### DIFF
--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -42,11 +42,7 @@ if TYPE_CHECKING:
     from numpy.random import Generator
 
     from graphix.flow.core import CausalFlow, GFlow, XZCorrections
-    from graphix.parameter import (
-        ExpressionOrSupportsComplex,
-        ExpressionOrSupportsFloat,
-        Parameter,
-    )
+    from graphix.parameter import ExpressionOrSupportsComplex, ExpressionOrSupportsFloat, Parameter
     from graphix.sim import Backend, Data, DensityMatrixBackend, StatevectorBackend
     from graphix.sim.base_backend import _StateT_co
     from graphix.sim.tensornet import TensorNetworkBackend


### PR DESCRIPTION
Building on PR #392 and resolving the last of issue #413 , this PR removes the `_pauli_preprocessed` flag from Graphix entirely. Functions now will proceed with their logic whatever the preprocessed status.

For discussion:
* This means `extract_causal_flow` proceeds without checking if Pauli preprocessing has occurred. Is this a problem, given that some extraction will proceed without raising a `FlowError`?