### PR TITLE
Replace ValueError with PatternError 

### DIFF
--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -211,7 +211,7 @@ class Pattern:
         nodes_p2 = other.extract_nodes() | other.results.keys()
 
         if not mapping.keys() <= nodes_p2:
-            raise ValueError("Keys of `mapping` must correspond to the nodes of `other`.")
+            raise PatternError("Keys of `mapping` must correspond to the nodes of `other`.")
 
         # Cast to set for improved performance in membership test
         mapping_values_set = set(mapping.values())
@@ -219,14 +219,14 @@ class Pattern:
         i2_set = set(other.input_nodes)
 
         if len(mapping) != len(mapping_values_set):
-            raise ValueError("Values of `mapping` contain duplicates.")
+            raise PatternError("Values of `mapping` contain duplicates.")
 
         if mapping_values_set & nodes_p1 - o1_set:
-            raise ValueError("Values of `mapping` must not contain measured nodes of pattern `self`.")
+            raise PatternError("Values of `mapping` must not contain measured nodes of pattern `self`.")
 
         for k, v in mapping.items():
             if v in o1_set and k not in i2_set:
-                raise ValueError(
+                raise PatternError(
                     f"Mapping {k} -> {v} is not valid. {v} is an output of pattern `self` but {k} is not an input of pattern `other`."
                 )
 
@@ -506,7 +506,7 @@ class Pattern:
                     self._commute_with_following(target)
                 target += 1
             return signal_dict
-        raise ValueError("Invalid method")
+        raise PatternError("Invalid method")
 
     def shift_signals_direct(self) -> dict[int, set[int]]:
         """Perform signal shifting procedure."""
@@ -1153,7 +1153,7 @@ class Pattern:
         for cmd in self.__seq:
             if cmd.kind == CommandKind.N:
                 if cmd.state != BasicStates.PLUS:
-                    raise ValueError(
+                    raise PatternError(
                         f"Open graph extraction requires N commands to represent a |+⟩ state. Error found in {cmd}."
                     )
                 nodes.add(cmd.node)
@@ -1411,7 +1411,7 @@ class Pattern:
 
         """
         if self.input_nodes:
-            raise ValueError("Remove inputs with `self.remove_input_nodes()` before performing Pauli presimulation.")
+            raise PatternError("Remove inputs with `self.remove_input_nodes()` before performing Pauli presimulation.")
         self.__dict__.update(measure_pauli(self, ignore_pauli_with_deps=ignore_pauli_with_deps).__dict__)
 
     def draw_graph(
@@ -1596,6 +1596,10 @@ class Pattern:
                 check_active(cmd, cmd.node)
 
 
+class PatternError(Exception):
+    """Exception subclass to handle pattern errors."""
+
+
 class RunnabilityErrorReason(Enum):
     """Describe the reason for a pattern not being runnable."""
 
@@ -1616,7 +1620,7 @@ class RunnabilityErrorReason(Enum):
 
 
 @dataclass
-class RunnabilityError(Exception):
+class RunnabilityError(PatternError):
     """Error raised by :method:`Pattern.check_runnability`."""
 
     cmd: Command
@@ -1778,7 +1782,7 @@ def pauli_nodes(pattern: optimization.StandardizedPattern) -> tuple[list[tuple[c
                 else:
                     pauli_node.append((cmd, pm))
             else:
-                raise ValueError("Unknown Pauli measurement basis")
+                raise PatternError("Unknown Pauli measurement basis")
         else:
             non_pauli_node.add(cmd.node)
     return pauli_node, non_pauli_node
@@ -1788,12 +1792,12 @@ def assert_permutation(original: list[int], user: list[int]) -> None:
     """Check that the provided `user` node list is a permutation from `original`."""
     node_set = set(user)
     if node_set != set(original):
-        raise ValueError(f"{node_set} != {set(original)}")
+        raise PatternError(f"{node_set} != {set(original)}")
     for node in user:
         if node in node_set:
             node_set.remove(node)
         else:
-            raise ValueError(f"{node} appears twice")
+            raise PatternError(f"{node} appears twice")
 
 
 @dataclass

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -19,7 +19,7 @@ from graphix.flow.exceptions import (
 from graphix.fundamentals import ANGLE_PI, Angle, Plane
 from graphix.measurements import Measurement, Outcome, PauliMeasurement
 from graphix.opengraph import OpenGraph
-from graphix.pattern import Pattern, RunnabilityError, RunnabilityErrorReason, shift_outcomes
+from graphix.pattern import Pattern, PatternError, RunnabilityError, RunnabilityErrorReason, shift_outcomes
 from graphix.random_objects import rand_circuit, rand_gate
 from graphix.sim.density_matrix import DensityMatrix
 from graphix.sim.statevec import Statevec
@@ -53,7 +53,7 @@ class TestPattern:
         pattern = Pattern(input_nodes=[1, 0], cmds=[N(node=2), M(node=1)], output_nodes=[2, 0])
         assert pattern.input_nodes == [1, 0]
         assert pattern.output_nodes == [2, 0]
-        with pytest.raises(ValueError):
+        with pytest.raises(PatternError):
             Pattern(input_nodes=[1, 0], cmds=[N(node=2), M(node=1)], output_nodes=[0, 1, 2])
 
     def test_eq(self) -> None:
@@ -300,7 +300,7 @@ class TestPattern:
         circuit = rand_circuit(nqubits, depth, fx_rng)
         pattern = circuit.transpile().pattern
         pattern.standardize()
-        with pytest.raises(ValueError):
+        with pytest.raises(PatternError):
             pattern.perform_pauli_measurements()
 
     def test_pauli_measurement_leave_input(self) -> None:
@@ -321,7 +321,7 @@ class TestPattern:
         swap(circuit, 0, 2)
         pattern = circuit.transpile().pattern
         pattern.standardize()
-        with pytest.raises(ValueError):
+        with pytest.raises(PatternError):
             pattern.perform_pauli_measurements()
 
     @pytest.mark.parametrize("jumps", range(1, 6))
@@ -527,17 +527,19 @@ class TestPattern:
         assert pc == p
         assert mapping_c == {0: 1, 2: 5}
 
-        with pytest.raises(ValueError, match=r"Keys of `mapping` must correspond to the nodes of `other`."):
+        with pytest.raises(PatternError, match=r"Keys of `mapping` must correspond to the nodes of `other`."):
             p1.compose(p2, mapping={0: 1, 2: 5, 1: 2})
 
-        with pytest.raises(ValueError, match=r"Values of `mapping` contain duplicates."):
+        with pytest.raises(PatternError, match=r"Values of `mapping` contain duplicates."):
             p1.compose(p2, mapping={0: 1, 2: 1})
 
-        with pytest.raises(ValueError, match=r"Values of `mapping` must not contain measured nodes of pattern `self`."):
+        with pytest.raises(
+            PatternError, match=r"Values of `mapping` must not contain measured nodes of pattern `self`."
+        ):
             p1.compose(p2, mapping={0: 1, 2: 0})
 
         with pytest.raises(
-            ValueError,
+            PatternError,
             match=r"Mapping 2 -> 1 is not valid. 1 is an output of pattern `self` but 2 is not an input of pattern `other`.",
         ):
             p1.compose(p2, mapping={2: 1})


### PR DESCRIPTION
Before submitting, please check the following:

- Make sure you have tests for the new code and that test passes (run `nox`)
- If applicable, add a line to the [unreleased] part of CHANGELOG.md, following [keep-a-changelog](https://keepachangelog.com/en/1.0.0/).
- Format added code by `ruff`
  - See `CONTRIBUTING.md` for more details
- Make sure the checks (github actions) pass.

Then, please fill in below:

**Context (if applicable):**

Most exceptions raised in `graphix.pattern.Pattern` were generic `ValueError` exceptions, which hindered robust exception handling. Issue #390 proposed introducing a new `PatternError` exception to improve error handling specificity and maintainability.

**Description of the change:**

Added a new `PatternError` exception class as a specialized exception for pattern-related errors. Made `RunnabilityError` inherit from `PatternError` to establish a proper exception hierarchy. Replaced all `ValueError` raises in `graphix/pattern.py` with `PatternError` to enable more precise exception handling. Updated corresponding test cases to catch `PatternError` instead of `ValueError`.

**Related issue:**

Fixes #390