### PR TITLE
Add version contraint on Qiskit to circumvent a bug in Mypy

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,7 +21,10 @@ pytest-mock
 pytest-mpl
 
 # Optional dependencies
-qiskit>=1.0
+
+# There is a bug with Mypy and Qiskit 2.4.0
+# See https://github.com/python/mypy/issues/21263
+qiskit>=1.0,<2.4
 qiskit_qasm3_import
 qiskit-aer
 


### PR DESCRIPTION
There is currently a bug when using Mypy to type-check code using the latest Qiskit release (2.4.0, released on 2026-04-16).

See https://github.com/python/mypy/issues/21263

This bug makes the CI `typecheck` workflow fails systematically. See for instance:
- PR #484: https://github.com/TeamGraphix/graphix/actions/runs/24565948645/job/71826055256
- PR #481 (I pushed a commit on that branch to fix the problem afterwards): https://github.com/TeamGraphix/graphix/actions/runs/24528928441/job/71707158586

The temporary fix proposed in this commit is to add an upperbound in `requirements-dev.txt`, `qiskit<2.4`, while the bug is not fixed.