### PR TITLE
Instruct Dependabot to ignore Qiskit 2.4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,8 @@ updates:
       python-packages:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "qiskit"
+        # There is a bug with Mypy and Qiskit 2.4.0
+        # See https://github.com/python/mypy/issues/21263
+        versions: [ ">=2.4" ]


### PR DESCRIPTION
Mypy currently fails when type-checking code against the latest Qiskit release (2.4.0; see #485 and python/mypy#21263).

While #485 added an upperbound `qiskit<2.4` to `requirements-dev.txt`, it did not configure Dependabot to respect this limit, causing PR reverts (see commit bd9c491 in #486).

This commit adds the necessary configuration to prevent those updates.