### PR TITLE
Fix CI badge in `README.md` by triggering `ci.yml` on `push` events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: ['master']
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Currently, the CI badge in [`README.md`](https://github.com/TeamGraphix/graphix/blob/master/README.md) displays a red **failing** status: [![CI](https://github.com/TeamGraphix/graphix/actions/workflows/ci.yml/badge.svg)](https://github.com/TeamGraphix/graphix/actions/workflows/ci.yml).

This occurs because this badge reflects the last known [status](https://github.com/TeamGraphix/graphix/actions/workflows/ci.yml) of the `ci.yml` workflow. According to [GitHub's documentation](https://docs.github.com/en/actions/how-tos/monitor-workflows/add-a-status-badge):

> By default, badges display the status of your default branch. If there are no workflow runs on your default branch, it will display the status of the most recent run across all branches.

While we want to display the status of our default branch (`master`), `ci.yml` is currently only configured to run on pull requests, so the badge displays the status of the most recent run across all branches, which is currently a failing run.  In contrast, `cov.yml` runs on every push, which is why a green checkmark is displayed next to commits.

This commit updates `ci.yml` to run on every `push` to `master`.  This includes whenever a pull-request is merged.  By ensuring `ci.yml` runs on the default branch, the CI badge will correctly reflect the current state of `master`.