### PR TITLE
Fix CI: pnpm & action suggester

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -70,6 +70,6 @@ jobs:
           corepack enable pnpm
           pnpm dlx prettier --write .
 
-      - uses: reviewdog/action-suggester@v1.22.0
+      - uses: reviewdog/action-suggester@v1.24.0
         with:
           tool_name: ":art: text-formatter"

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -59,6 +59,14 @@ jobs:
       - uses: actions/setup-node@v4
 
       - run: |
+          # Pin pnpm to the latest version reported to work
+          #
+          # CI fails with version 11.0.9:
+          # https://github.com/TeamGraphix/graphix/actions/runs/25607609586/job/75172334745
+          #
+          # CI succeeds with version 10.33.4:
+          # https://github.com/TeamGraphix/graphix/actions/runs/25476469782/job/74750924624
+          corepack prepare pnpm@10.33.4 --activate
           corepack enable pnpm
           pnpm dlx prettier --write .
 


### PR DESCRIPTION
This PR fixes the CI failure reported in #498:
- the latest `pnpm` release (v11.0.9) fails during install: https://github.com/TeamGraphix/graphix/actions/runs/25607609586/job/75172334745
- the pinned version of `action-suggester` (v1.22.0) is no longer installable: https://github.com/TeamGraphix/graphix/actions/runs/25607890230/job/75172825261

These commits pin `pnpm` to v10.33.4 (the most recent version that works: https://github.com/TeamGraphix/graphix/actions/runs/25476469782/job/74750924624) and bump `action-suggester` to v1.24.0.

