### PR TITLE
Add amplitude damping noise model

### DIFF
--- a/graphix/__init__.py
+++ b/graphix/__init__.py
@@ -13,7 +13,7 @@ from graphix.fundamentals import ANGLE_PI, Axis, Plane, Sign, angle_to_rad, rad_
 from graphix.graphsim import GraphState
 from graphix.instruction import Instruction
 from graphix.measurements import BlochMeasurement, Measurement, PauliMeasurement
-from graphix.noise_models import DepolarisingNoiseModel, NoiseModel
+from graphix.noise_models import AmplitudeDampingNoiseModel, DepolarisingNoiseModel, NoiseModel
 from graphix.opengraph import OpenGraph
 from graphix.optimization import StandardizedPattern
 from graphix.parameter import Placeholder
@@ -27,6 +27,7 @@ from graphix.transpiler import Circuit
 
 __all__ = [
     "ANGLE_PI",
+    "AmplitudeDampingNoiseModel",
     "Axis",
     "BasicStates",
     "BlochMeasurement",

--- a/graphix/channels.py
+++ b/graphix/channels.py
@@ -200,6 +200,51 @@ def depolarising_channel(prob: float) -> KrausChannel:
     )
 
 
+def amplitude_damping_channel(prob: float) -> KrausChannel:
+    r"""Single-qubit amplitude damping channel.
+
+    .. math::
+        K_0 = \begin{pmatrix}1 & 0 \\ 0 & \sqrt{1-p}\end{pmatrix},
+        K_1 = \begin{pmatrix}0 & \sqrt{p} \\ 0 & 0\end{pmatrix}
+
+    Parameters
+    ----------
+    prob : float
+        The probability associated to the channel.
+
+    Returns
+    -------
+    :class:`graphix.channels.KrausChannel` object
+        containing the corresponding Kraus operators.
+    """
+    return KrausChannel(
+        [
+            KrausData(1.0, np.array([[1.0, 0.0], [0.0, np.sqrt(1 - prob)]])),
+            KrausData(1.0, np.array([[0.0, np.sqrt(prob)], [0.0, 0.0]])),
+        ]
+    )
+
+
+def two_qubit_amplitude_damping_channel(prob: float) -> KrausChannel:
+    r"""Two-qubit tensor channel of single-qubit amplitude damping channels.
+
+    Parameters
+    ----------
+    prob : float
+        The probability associated to each single-qubit amplitude damping channel.
+
+    Returns
+    -------
+    :class:`graphix.channels.KrausChannel` object
+        containing the corresponding Kraus operators.
+    """
+    operators = [
+        np.array([[1.0, 0.0], [0.0, np.sqrt(1 - prob)]]),
+        np.array([[0.0, np.sqrt(prob)], [0.0, 0.0]]),
+    ]
+    return KrausChannel([KrausData(1.0, np.kron(left, right)) for left in operators for right in operators])
+
+
 def pauli_channel(px: float, py: float, pz: float) -> KrausChannel:
     r"""Single-qubit Pauli channel.
 

--- a/graphix/noise_models/__init__.py
+++ b/graphix/noise_models/__init__.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from graphix.noise_models.amplitude_damping import (
+    AmplitudeDampingNoise,
+    AmplitudeDampingNoiseModel,
+    TwoQubitAmplitudeDampingNoise,
+)
 from graphix.noise_models.depolarising import DepolarisingNoise, DepolarisingNoiseModel, TwoQubitDepolarisingNoise
 from graphix.noise_models.noise_model import (
     ApplyNoise,
@@ -16,11 +21,14 @@ if TYPE_CHECKING:
     from graphix.noise_models.noise_model import CommandOrNoise as CommandOrNoise
 
 __all__ = [
+    "AmplitudeDampingNoise",
+    "AmplitudeDampingNoiseModel",
     "ApplyNoise",
     "ComposeNoiseModel",
     "DepolarisingNoise",
     "DepolarisingNoiseModel",
     "Noise",
     "NoiseModel",
+    "TwoQubitAmplitudeDampingNoise",
     "TwoQubitDepolarisingNoise",
 ]

--- a/graphix/noise_models/amplitude_damping.py
+++ b/graphix/noise_models/amplitude_damping.py
@@ -1,0 +1,147 @@
+"""Amplitude damping noise model."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import typing_extensions
+
+from graphix.channels import KrausChannel, amplitude_damping_channel, two_qubit_amplitude_damping_channel
+from graphix.command import BaseM, CommandKind
+from graphix.measurements import toggle_outcome
+from graphix.noise_models.noise_model import ApplyNoise, Noise, NoiseModel
+from graphix.rng import ensure_rng
+from graphix.utils import Probability
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from numpy.random import Generator
+
+    from graphix.measurements import Outcome
+    from graphix.noise_models.noise_model import CommandOrNoise
+
+
+class AmplitudeDampingNoise(Noise):
+    """One-qubit amplitude damping noise with probability ``prob``."""
+
+    prob = Probability()
+
+    def __init__(self, prob: float) -> None:
+        """Initialize one-qubit amplitude damping noise.
+
+        Parameters
+        ----------
+        prob : float
+            Probability parameter of the noise, between 0 and 1.
+        """
+        self.prob = prob
+
+    @property
+    @typing_extensions.override
+    def nqubits(self) -> int:
+        """Return the number of qubits targetted by the noise element."""
+        return 1
+
+    @typing_extensions.override
+    def to_kraus_channel(self) -> KrausChannel:
+        """Return the Kraus channel describing the noise element."""
+        return amplitude_damping_channel(self.prob)
+
+
+class TwoQubitAmplitudeDampingNoise(Noise):
+    """Two-qubit amplitude damping noise with probability ``prob``."""
+
+    prob = Probability()
+
+    def __init__(self, prob: float) -> None:
+        """Initialize two-qubit amplitude damping noise.
+
+        Parameters
+        ----------
+        prob : float
+            Probability parameter of the noise, between 0 and 1.
+        """
+        self.prob = prob
+
+    @property
+    @typing_extensions.override
+    def nqubits(self) -> int:
+        """Return the number of qubits targetted by the noise element."""
+        return 2
+
+    @typing_extensions.override
+    def to_kraus_channel(self) -> KrausChannel:
+        """Return the Kraus channel describing the noise element."""
+        return two_qubit_amplitude_damping_channel(self.prob)
+
+
+class AmplitudeDampingNoiseModel(NoiseModel):
+    """Amplitude damping noise model."""
+
+    def __init__(
+        self,
+        prepare_error_prob: float = 0.0,
+        x_error_prob: float = 0.0,
+        z_error_prob: float = 0.0,
+        entanglement_error_prob: float = 0.0,
+        measure_channel_prob: float = 0.0,
+        measure_error_prob: float = 0.0,
+    ) -> None:
+        self.prepare_error_prob = prepare_error_prob
+        self.x_error_prob = x_error_prob
+        self.z_error_prob = z_error_prob
+        self.entanglement_error_prob = entanglement_error_prob
+        self.measure_error_prob = measure_error_prob
+        self.measure_channel_prob = measure_channel_prob
+
+    @typing_extensions.override
+    def input_nodes(
+        self, nodes: Iterable[int], rng: Generator | None = None, *, stacklevel: int = 1
+    ) -> list[CommandOrNoise]:
+        """Return the noise to apply to input nodes."""
+        return [ApplyNoise(noise=AmplitudeDampingNoise(self.prepare_error_prob), nodes=[node]) for node in nodes]
+
+    @typing_extensions.override
+    def command(
+        self, cmd: CommandOrNoise, rng: Generator | None = None, *, stacklevel: int = 1
+    ) -> list[CommandOrNoise]:
+        """Return the noise to apply to the command ``cmd``."""
+        match cmd.kind:
+            case CommandKind.N:
+                return [cmd, ApplyNoise(noise=AmplitudeDampingNoise(self.prepare_error_prob), nodes=[cmd.node])]
+            case CommandKind.E:
+                return [
+                    cmd,
+                    ApplyNoise(
+                        noise=TwoQubitAmplitudeDampingNoise(self.entanglement_error_prob), nodes=list(cmd.nodes)
+                    ),
+                ]
+            case CommandKind.M:
+                return [ApplyNoise(noise=AmplitudeDampingNoise(self.measure_channel_prob), nodes=[cmd.node]), cmd]
+            case CommandKind.X:
+                return [
+                    cmd,
+                    ApplyNoise(noise=AmplitudeDampingNoise(self.x_error_prob), nodes=[cmd.node], domain=cmd.domain),
+                ]
+            case CommandKind.Z:
+                return [
+                    cmd,
+                    ApplyNoise(noise=AmplitudeDampingNoise(self.z_error_prob), nodes=[cmd.node], domain=cmd.domain),
+                ]
+            case CommandKind.C | CommandKind.T | CommandKind.ApplyNoise:
+                return [cmd]
+            case CommandKind.S:
+                raise ValueError("Unexpected signal!")
+            case _:
+                typing_extensions.assert_never(cmd.kind)
+
+    @typing_extensions.override
+    def confuse_result(
+        self, cmd: BaseM, result: Outcome, rng: Generator | None = None, *, stacklevel: int = 1
+    ) -> Outcome:
+        """Assign wrong measurement result cmd = "M"."""
+        rng = ensure_rng(rng, stacklevel=stacklevel + 1)
+        if rng.uniform() < self.measure_error_prob:
+            return toggle_outcome(result)
+        return result

--- a/tests/test_kraus.py
+++ b/tests/test_kraus.py
@@ -9,8 +9,10 @@ import graphix.random_objects as randobj
 from graphix.channels import (
     KrausChannel,
     KrausData,
+    amplitude_damping_channel,
     dephasing_channel,
     depolarising_channel,
+    two_qubit_amplitude_damping_channel,
     two_qubit_depolarising_channel,
     two_qubit_depolarising_tensor_channel,
 )
@@ -118,6 +120,41 @@ class TestChannel:
         for i in range(len(depol_channel)):
             assert np.allclose(depol_channel[i].coef, data[i].coef)
             assert np.allclose(depol_channel[i].operator, data[i].operator)
+
+    def test_amplitude_damping_channel(self, fx_rng: Generator) -> None:
+        prob = fx_rng.uniform()
+        data = [
+            KrausData(1.0, np.array([[1.0, 0.0], [0.0, np.sqrt(1 - prob)]])),
+            KrausData(1.0, np.array([[0.0, np.sqrt(prob)], [0.0, 0.0]])),
+        ]
+
+        channel = amplitude_damping_channel(prob)
+
+        assert isinstance(channel, KrausChannel)
+        assert channel.nqubit == 1
+        assert len(channel) == 2
+
+        for i in range(len(channel)):
+            assert np.allclose(channel[i].coef, data[i].coef)
+            assert np.allclose(channel[i].operator, data[i].operator)
+
+    def test_2_qubit_amplitude_damping_channel(self, fx_rng: Generator) -> None:
+        prob = fx_rng.uniform()
+        operators = [
+            np.array([[1.0, 0.0], [0.0, np.sqrt(1 - prob)]]),
+            np.array([[0.0, np.sqrt(prob)], [0.0, 0.0]]),
+        ]
+        data = [KrausData(1.0, np.kron(left, right)) for left in operators for right in operators]
+
+        channel = two_qubit_amplitude_damping_channel(prob)
+
+        assert isinstance(channel, KrausChannel)
+        assert channel.nqubit == 2
+        assert len(channel) == 4
+
+        for i in range(len(channel)):
+            assert np.allclose(channel[i].coef, data[i].coef)
+            assert np.allclose(channel[i].operator, data[i].operator)
 
     def test_2_qubit_depolarising_channel(self, fx_rng: Generator) -> None:
         prob = fx_rng.uniform()

--- a/tests/test_noise_model.py
+++ b/tests/test_noise_model.py
@@ -8,10 +8,13 @@ import pytest
 from graphix import Pattern
 from graphix.command import CommandKind, M, N
 from graphix.noise_models import (
+    AmplitudeDampingNoise,
+    AmplitudeDampingNoiseModel,
     ApplyNoise,
     ComposeNoiseModel,
     DepolarisingNoise,
     DepolarisingNoiseModel,
+    TwoQubitAmplitudeDampingNoise,
     TwoQubitDepolarisingNoise,
 )
 from graphix.noise_models.noise_model import NoiselessNoiseModel
@@ -84,6 +87,44 @@ def test_compose_noise_model_transpile(fx_rng: Generator) -> None:
             case CommandKind.Z:
                 check_noise_command(next(iterator), 0.5, False)
                 check_noise_command(next(iterator), 0, False)
+
+
+def test_amplitude_damping_noise_model_transpile(fx_rng: Generator) -> None:
+    nqubits = 5
+    depth = 5
+    circuit = rand_circuit(nqubits, depth, rng=fx_rng)
+    pattern = circuit.transpile().pattern
+    noise_model = AmplitudeDampingNoiseModel(
+        prepare_error_prob=0.1,
+        x_error_prob=0.2,
+        z_error_prob=0.3,
+        entanglement_error_prob=0.4,
+        measure_channel_prob=0.5,
+    )
+    noisy_pattern = noise_model.transpile(pattern, rng=fx_rng)
+    iterator = iter(noisy_pattern)
+
+    def check_noise_command(cmd: CommandOrNoise, prob: float, two_qubits: bool) -> None:
+        assert isinstance(cmd, ApplyNoise)
+        if two_qubits:
+            assert isinstance(cmd.noise, TwoQubitAmplitudeDampingNoise)
+        else:
+            assert isinstance(cmd.noise, AmplitudeDampingNoise)
+        assert cmd.noise.prob == prob
+
+    for cmd in pattern:
+        if cmd.kind == CommandKind.M:
+            check_noise_command(next(iterator), 0.5, False)
+        assert next(iterator) == cmd
+        match cmd.kind:
+            case CommandKind.N:
+                check_noise_command(next(iterator), 0.1, False)
+            case CommandKind.E:
+                check_noise_command(next(iterator), 0.4, True)
+            case CommandKind.X:
+                check_noise_command(next(iterator), 0.2, False)
+            case CommandKind.Z:
+                check_noise_command(next(iterator), 0.3, False)
 
 
 def test_compose_noise_model_simulation(fx_rng: Generator) -> None:

--- a/tests/test_noisy_density_matrix.py
+++ b/tests/test_noisy_density_matrix.py
@@ -196,22 +196,21 @@ class TestNoisyDensityMatrixBackend:
         )
 
         assert isinstance(res, DensityMatrix)
-        if outcome == 0:
-            assert np.allclose(res.rho, np.array([[1.0, 0.0], [0.0, 0.0]]))
-        else:
-            assert np.allclose(res.rho, np.array([[x_error_pr, 0.0], [0.0, 1 - x_error_pr]]))
+        assert np.allclose(res.rho, np.array([[1.0, 0.0], [0.0, 0.0]]))
 
-    def test_amplitude_damping_preparation_hadamard(self, fx_rng: Generator) -> None:
+    @pytest.mark.parametrize("outcome", [0, 1])
+    def test_amplitude_damping_preparation_hadamard(self, fx_rng: Generator, outcome: Outcome) -> None:
         hadamardpattern = hpat()
-        prepare_error_pr = fx_rng.random()
         res = hadamardpattern.simulate_pattern(
             backend="densitymatrix",
-            noise_model=AmplitudeDampingNoiseModel(prepare_error_prob=prepare_error_pr),
+            noise_model=AmplitudeDampingNoiseModel(prepare_error_prob=1.0),
+            branch_selector=ConstBranchSelector(outcome),
             rng=fx_rng,
         )
 
         assert isinstance(res, DensityMatrix)
-        assert np.allclose(res.rho, np.array([[1.0, 0.0], [0.0, 0.0]]))
+        expected = np.array([[1.0, 0.0], [0.0, 0.0]]) if outcome == 0 else np.array([[0.0, 0.0], [0.0, 1.0]])
+        assert np.allclose(res.rho, expected)
 
     # Test rz gate
 

--- a/tests/test_noisy_density_matrix.py
+++ b/tests/test_noisy_density_matrix.py
@@ -9,7 +9,7 @@ import pytest
 from graphix.branch_selector import ConstBranchSelector, FixedBranchSelector
 from graphix.command import CommandKind
 from graphix.fundamentals import angle_to_rad
-from graphix.noise_models import DepolarisingNoiseModel
+from graphix.noise_models import AmplitudeDampingNoiseModel, DepolarisingNoiseModel
 from graphix.noise_models.noise_model import NoiselessNoiseModel
 from graphix.ops import Ops
 from graphix.sim.density_matrix import DensityMatrix
@@ -183,6 +183,35 @@ class TestNoisyDensityMatrixBackend:
             res.rho,
             np.array([[1 - 2 * prepare_error_pr / 3.0, 0.0], [0.0, 2 * prepare_error_pr / 3.0]]),
         )
+
+    @pytest.mark.parametrize("outcome", [0, 1])
+    def test_amplitude_damping_x_hadamard(self, fx_rng: Generator, outcome: Outcome) -> None:
+        hadamardpattern = hpat()
+        x_error_pr = fx_rng.random()
+        res = hadamardpattern.simulate_pattern(
+            backend="densitymatrix",
+            noise_model=AmplitudeDampingNoiseModel(x_error_prob=x_error_pr),
+            branch_selector=ConstBranchSelector(outcome),
+            rng=fx_rng,
+        )
+
+        assert isinstance(res, DensityMatrix)
+        if outcome == 0:
+            assert np.allclose(res.rho, np.array([[1.0, 0.0], [0.0, 0.0]]))
+        else:
+            assert np.allclose(res.rho, np.array([[x_error_pr, 0.0], [0.0, 1 - x_error_pr]]))
+
+    def test_amplitude_damping_preparation_hadamard(self, fx_rng: Generator) -> None:
+        hadamardpattern = hpat()
+        prepare_error_pr = fx_rng.random()
+        res = hadamardpattern.simulate_pattern(
+            backend="densitymatrix",
+            noise_model=AmplitudeDampingNoiseModel(prepare_error_prob=prepare_error_pr),
+            rng=fx_rng,
+        )
+
+        assert isinstance(res, DensityMatrix)
+        assert np.allclose(res.rho, np.array([[1.0, 0.0], [0.0, 0.0]]))
 
     # Test rz gate
 


### PR DESCRIPTION
## Summary
- Add single- and two-qubit amplitude damping Kraus channels.
- Add AmplitudeDampingNoiseModel matching the existing depolarising model hooks for preparation, entanglement, measurement-channel, conditional X/Z correction noise, and measurement-result flips.
- Export the new model and add focused channel/noise-model/density-matrix tests.

## Verification
- python -m py_compile graphix\\channels.py graphix\\noise_models\\amplitude_damping.py graphix\\noise_models\\__init__.py graphix\\__init__.py tests\\test_kraus.py tests\\test_noise_model.py tests\\test_noisy_density_matrix.py passed locally.
- uff check graphix\\channels.py graphix\\noise_models\\amplitude_damping.py graphix\\noise_models\\__init__.py graphix\\__init__.py tests\\test_kraus.py tests\\test_noise_model.py tests\\test_noisy_density_matrix.py passed locally.
- uff format --check graphix\\channels.py graphix\\noise_models\\amplitude_damping.py graphix\\noise_models\\__init__.py graphix\\__init__.py tests\\test_kraus.py tests\\test_noise_model.py tests\\test_noisy_density_matrix.py passed locally.
- Full focused pytest could not complete in my local Codex runtime because importing quimb hangs before test collection. I aligned quimb to the repo lockfile version (1.13.0 for Python >=3.11), but import quimb still timed out locally. I am leaving this explicit for CI/maintainer visibility rather than claiming a pytest pass I did not get.

Assisted by OpenAI Codex.