### PR TITLE
Implement amplitude damping noise model

### DIFF
--- a/graphix/__init__.py
+++ b/graphix/__init__.py
@@ -13,7 +13,7 @@ from graphix.fundamentals import ANGLE_PI, Axis, Plane, Sign, angle_to_rad, rad_
 from graphix.graphsim import GraphState
 from graphix.instruction import Instruction
 from graphix.measurements import BlochMeasurement, Measurement, PauliMeasurement
-from graphix.noise_models import DepolarisingNoiseModel, NoiseModel
+from graphix.noise_models import AmplitudeDampingNoiseModel, DepolarisingNoiseModel, NoiseModel
 from graphix.opengraph import OpenGraph
 from graphix.optimization import StandardizedPattern
 from graphix.parameter import Placeholder
@@ -27,6 +27,7 @@ from graphix.transpiler import Circuit
 
 __all__ = [
     "ANGLE_PI",
+    "AmplitudeDampingNoiseModel",
     "Axis",
     "BasicStates",
     "BlochMeasurement",

--- a/graphix/channels.py
+++ b/graphix/channels.py
@@ -220,9 +220,6 @@ def amplitude_damping_channel(gamma: float) -> KrausChannel:
     :class:`graphix.channels.KrausChannel` object
         Channel containing the corresponding Kraus operators.
     """
-    if not 0 <= gamma <= 1:
-        raise ValueError("gamma must be between 0 and 1.")
-
     return KrausChannel(
         [
             KrausData(

--- a/graphix/channels.py
+++ b/graphix/channels.py
@@ -200,6 +200,81 @@ def depolarising_channel(prob: float) -> KrausChannel:
     )
 
 
+def amplitude_damping_channel(gamma: float) -> KrausChannel:
+    r"""Single-qubit amplitude damping channel.
+
+    The channel is defined by the Kraus operators
+
+    .. math::
+        K_0 = \begin{pmatrix}1 & 0 \\ 0 & \sqrt{1-\gamma}\end{pmatrix},
+        \quad
+        K_1 = \begin{pmatrix}0 & \sqrt{\gamma} \\ 0 & 0\end{pmatrix}.
+
+    Parameters
+    ----------
+    gamma : float
+        Damping probability, between 0 and 1.
+
+    Returns
+    -------
+    :class:`graphix.channels.KrausChannel` object
+        Channel containing the corresponding Kraus operators.
+    """
+    if not 0 <= gamma <= 1:
+        raise ValueError("gamma must be between 0 and 1.")
+
+    return KrausChannel(
+        [
+            KrausData(
+                1.0,
+                np.array(
+                    [
+                        [1.0, 0.0],
+                        [0.0, np.sqrt(1 - gamma)],
+                    ],
+                    dtype=np.complex128,
+                ),
+            ),
+            KrausData(
+                1.0,
+                np.array(
+                    [
+                        [0.0, np.sqrt(gamma)],
+                        [0.0, 0.0],
+                    ],
+                    dtype=np.complex128,
+                ),
+            ),
+        ]
+    )
+
+
+def two_qubit_amplitude_damping_channel(gamma: float) -> KrausChannel:
+    r"""Two-qubit independent amplitude damping channel.
+
+    This is the tensor product of two identical one-qubit amplitude damping
+    channels with damping probability ``gamma``.
+
+    Parameters
+    ----------
+    gamma : float
+        Damping probability, between 0 and 1.
+
+    Returns
+    -------
+    :class:`graphix.channels.KrausChannel` object
+        Channel containing the tensor-product Kraus operators.
+    """
+    channel = amplitude_damping_channel(gamma)
+    return KrausChannel(
+        [
+            KrausData(left.coef * right.coef, np.kron(left.operator, right.operator))
+            for left in channel
+            for right in channel
+        ]
+    )
+
+
 def pauli_channel(px: float, py: float, pz: float) -> KrausChannel:
     r"""Single-qubit Pauli channel.
 

--- a/graphix/noise_models/__init__.py
+++ b/graphix/noise_models/__init__.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from graphix.noise_models.amplitude_damping import (
+    AmplitudeDampingNoise,
+    AmplitudeDampingNoiseModel,
+    TwoQubitAmplitudeDampingNoise,
+)
 from graphix.noise_models.depolarising import DepolarisingNoise, DepolarisingNoiseModel, TwoQubitDepolarisingNoise
 from graphix.noise_models.noise_model import (
     ApplyNoise,
@@ -16,11 +21,14 @@ if TYPE_CHECKING:
     from graphix.noise_models.noise_model import CommandOrNoise as CommandOrNoise
 
 __all__ = [
+    "AmplitudeDampingNoise",
+    "AmplitudeDampingNoiseModel",
     "ApplyNoise",
     "ComposeNoiseModel",
     "DepolarisingNoise",
     "DepolarisingNoiseModel",
     "Noise",
     "NoiseModel",
+    "TwoQubitAmplitudeDampingNoise",
     "TwoQubitDepolarisingNoise",
 ]

--- a/graphix/noise_models/amplitude_damping.py
+++ b/graphix/noise_models/amplitude_damping.py
@@ -95,13 +95,6 @@ class AmplitudeDampingNoiseModel(NoiseModel):
         Classical measurement result flip probability.
     """
 
-    prepare_error_gamma = Probability()
-    x_error_gamma = Probability()
-    z_error_gamma = Probability()
-    entanglement_error_gamma = Probability()
-    measure_channel_gamma = Probability()
-    measure_error_prob = Probability()
-
     def __init__(
         self,
         prepare_error_gamma: float = 0.0,

--- a/graphix/noise_models/amplitude_damping.py
+++ b/graphix/noise_models/amplitude_damping.py
@@ -1,0 +1,171 @@
+"""Amplitude damping noise model."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import typing_extensions
+
+from graphix.channels import KrausChannel, amplitude_damping_channel, two_qubit_amplitude_damping_channel
+from graphix.command import BaseM, CommandKind
+from graphix.measurements import toggle_outcome
+from graphix.noise_models.noise_model import ApplyNoise, Noise, NoiseModel
+from graphix.rng import ensure_rng
+from graphix.utils import Probability
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from numpy.random import Generator
+
+    from graphix.measurements import Outcome
+    from graphix.noise_models.noise_model import CommandOrNoise
+
+
+class AmplitudeDampingNoise(Noise):
+    """One-qubit amplitude damping noise with damping probability ``gamma``."""
+
+    gamma = Probability()
+
+    def __init__(self, gamma: float) -> None:
+        """Initialize one-qubit amplitude damping noise.
+
+        Parameters
+        ----------
+        gamma : float
+            Damping probability, between 0 and 1.
+        """
+        self.gamma = gamma
+
+    @property
+    @typing_extensions.override
+    def nqubits(self) -> int:
+        """Return the number of qubits targetted by the noise element."""
+        return 1
+
+    @typing_extensions.override
+    def to_kraus_channel(self) -> KrausChannel:
+        """Return the Kraus channel describing the noise element."""
+        return amplitude_damping_channel(self.gamma)
+
+
+class TwoQubitAmplitudeDampingNoise(Noise):
+    """Two-qubit independent amplitude damping noise with probability ``gamma``."""
+
+    gamma = Probability()
+
+    def __init__(self, gamma: float) -> None:
+        """Initialize two-qubit amplitude damping noise.
+
+        Parameters
+        ----------
+        gamma : float
+            Damping probability, between 0 and 1.
+        """
+        self.gamma = gamma
+
+    @property
+    @typing_extensions.override
+    def nqubits(self) -> int:
+        """Return the number of qubits targetted by the noise element."""
+        return 2
+
+    @typing_extensions.override
+    def to_kraus_channel(self) -> KrausChannel:
+        """Return the Kraus channel describing the noise element."""
+        return two_qubit_amplitude_damping_channel(self.gamma)
+
+
+class AmplitudeDampingNoiseModel(NoiseModel):
+    """Amplitude damping noise model.
+
+    Parameters
+    ----------
+    prepare_error_gamma : float, optional
+        Damping probability applied after qubit preparation.
+    x_error_gamma : float, optional
+        Damping probability applied after ``X`` corrections.
+    z_error_gamma : float, optional
+        Damping probability applied after ``Z`` corrections.
+    entanglement_error_gamma : float, optional
+        Damping probability applied after entangling commands.
+    measure_channel_gamma : float, optional
+        Damping probability applied before measurement.
+    measure_error_prob : float, optional
+        Classical measurement result flip probability.
+    """
+
+    prepare_error_gamma = Probability()
+    x_error_gamma = Probability()
+    z_error_gamma = Probability()
+    entanglement_error_gamma = Probability()
+    measure_channel_gamma = Probability()
+    measure_error_prob = Probability()
+
+    def __init__(
+        self,
+        prepare_error_gamma: float = 0.0,
+        x_error_gamma: float = 0.0,
+        z_error_gamma: float = 0.0,
+        entanglement_error_gamma: float = 0.0,
+        measure_channel_gamma: float = 0.0,
+        measure_error_prob: float = 0.0,
+    ) -> None:
+        self.prepare_error_gamma = prepare_error_gamma
+        self.x_error_gamma = x_error_gamma
+        self.z_error_gamma = z_error_gamma
+        self.entanglement_error_gamma = entanglement_error_gamma
+        self.measure_channel_gamma = measure_channel_gamma
+        self.measure_error_prob = measure_error_prob
+
+    @typing_extensions.override
+    def input_nodes(
+        self, nodes: Iterable[int], rng: Generator | None = None, *, stacklevel: int = 1
+    ) -> list[CommandOrNoise]:
+        """Return the noise to apply to input nodes."""
+        return [ApplyNoise(noise=AmplitudeDampingNoise(self.prepare_error_gamma), nodes=[node]) for node in nodes]
+
+    @typing_extensions.override
+    def command(
+        self, cmd: CommandOrNoise, rng: Generator | None = None, *, stacklevel: int = 1
+    ) -> list[CommandOrNoise]:
+        """Return the noise to apply to the command ``cmd``."""
+        match cmd.kind:
+            case CommandKind.N:
+                return [cmd, ApplyNoise(noise=AmplitudeDampingNoise(self.prepare_error_gamma), nodes=[cmd.node])]
+            case CommandKind.E:
+                return [
+                    cmd,
+                    ApplyNoise(
+                        noise=TwoQubitAmplitudeDampingNoise(self.entanglement_error_gamma),
+                        nodes=list(cmd.nodes),
+                    ),
+                ]
+            case CommandKind.M:
+                return [ApplyNoise(noise=AmplitudeDampingNoise(self.measure_channel_gamma), nodes=[cmd.node]), cmd]
+            case CommandKind.X:
+                return [
+                    cmd,
+                    ApplyNoise(noise=AmplitudeDampingNoise(self.x_error_gamma), nodes=[cmd.node], domain=cmd.domain),
+                ]
+            case CommandKind.Z:
+                return [
+                    cmd,
+                    ApplyNoise(noise=AmplitudeDampingNoise(self.z_error_gamma), nodes=[cmd.node], domain=cmd.domain),
+                ]
+            case CommandKind.C | CommandKind.T | CommandKind.ApplyNoise:
+                return [cmd]
+            case CommandKind.S:
+                raise ValueError("Unexpected signal!")
+            case _:
+                typing_extensions.assert_never(cmd.kind)
+
+    @typing_extensions.override
+    def confuse_result(
+        self, cmd: BaseM, result: Outcome, rng: Generator | None = None, *, stacklevel: int = 1
+    ) -> Outcome:
+        """Return the measurement result, possibly flipped by classical readout noise."""
+        rng = ensure_rng(rng, stacklevel=stacklevel + 1)
+        if rng.uniform() < self.measure_error_prob:
+            return toggle_outcome(result)
+        return result

--- a/tests/test_density_matrix.py
+++ b/tests/test_density_matrix.py
@@ -302,10 +302,10 @@ class TestDensityMatrix:
         dm = DensityMatrix(data=np.outer(psi, psi.conj()))
         edge = (0, 1)
         dm.cnot(edge)
-        psi = psi.reshape((2, 2))
-        psi = np.tensordot(CNOT_TENSOR, psi, ((2, 3), edge))
-        psi = np.moveaxis(psi, (0, 1), edge)
-        expected_matrix2 = np.outer(psi, psi.conj())
+        psi_tensor = psi.reshape((2, 2))
+        psi_tensor = np.tensordot(CNOT_TENSOR, psi_tensor, ((2, 3), edge))
+        psi_tensor = np.moveaxis(psi_tensor, (0, 1), edge)
+        expected_matrix2 = np.outer(psi_tensor, psi_tensor.conj())
         assert np.allclose(dm.rho, expected_matrix2)
 
         # test on arbitrary number of qubits and random pair
@@ -320,10 +320,10 @@ class TestDensityMatrix:
         u, v = tuple(random.sample(range(n), 2))
         edge = (u, v)
         dm.cnot(edge)
-        psi = psi.reshape((2,) * n)
-        psi = np.tensordot(CNOT_TENSOR, psi, ((2, 3), edge))
-        psi = np.moveaxis(psi, (0, 1), edge)
-        expected_matrix3 = np.outer(psi, psi.conj())
+        psi_tensor = psi.reshape((2,) * n)
+        psi_tensor = np.tensordot(CNOT_TENSOR, psi_tensor, ((2, 3), edge))
+        psi_tensor = np.moveaxis(psi_tensor, (0, 1), edge)
+        expected_matrix3 = np.outer(psi_tensor, psi_tensor.conj())
         assert np.allclose(dm.rho, expected_matrix3)
 
     def test_swap_fail(self) -> None:
@@ -654,12 +654,12 @@ class TestDensityMatrix:
 
         dm.apply_channel(channel, [i])
 
-        expected_dm = np.zeros_like(dm.rho)
+        expected_dm = np.zeros(dm.rho.shape, dtype=np.complex128)
         for kraus_data in channel:
             psi_evolved = np.tensordot(kraus_data.operator, psi.reshape((2,) * nqubits), (1, i))
             psi_evolved = np.moveaxis(psi_evolved, 0, i)
             psi_evolved = np.reshape(psi_evolved, (2**nqubits))
-            expected_dm += kraus_data.coef**2 * np.outer(psi_evolved, psi_evolved.conj())
+            expected_dm += complex(kraus_data.coef) ** 2 * np.outer(psi_evolved, psi_evolved.conj())
 
         assert np.allclose(expected_dm.trace(), 1.0)
         assert np.allclose(dm.rho, expected_dm)

--- a/tests/test_density_matrix.py
+++ b/tests/test_density_matrix.py
@@ -302,9 +302,7 @@ class TestDensityMatrix:
         dm = DensityMatrix(data=np.outer(psi, psi.conj()))
         edge = (0, 1)
         dm.cnot(edge)
-        psi_tensor = psi.reshape((2, 2))
-        psi_tensor = np.tensordot(CNOT_TENSOR, psi_tensor, ((2, 3), edge))
-        psi_tensor = np.moveaxis(psi_tensor, (0, 1), edge)
+        psi_tensor = np.moveaxis(np.tensordot(CNOT_TENSOR, psi.reshape((2, 2)), ((2, 3), edge)), (0, 1), edge)
         expected_matrix2 = np.outer(psi_tensor, psi_tensor.conj())
         assert np.allclose(dm.rho, expected_matrix2)
 
@@ -320,9 +318,7 @@ class TestDensityMatrix:
         u, v = tuple(random.sample(range(n), 2))
         edge = (u, v)
         dm.cnot(edge)
-        psi_tensor = psi.reshape((2,) * n)
-        psi_tensor = np.tensordot(CNOT_TENSOR, psi_tensor, ((2, 3), edge))
-        psi_tensor = np.moveaxis(psi_tensor, (0, 1), edge)
+        psi_tensor = np.moveaxis(np.tensordot(CNOT_TENSOR, psi.reshape((2,) * n), ((2, 3), edge)), (0, 1), edge)
         expected_matrix3 = np.outer(psi_tensor, psi_tensor.conj())
         assert np.allclose(dm.rho, expected_matrix3)
 
@@ -354,10 +350,8 @@ class TestDensityMatrix:
         edge = (0, 1)
         dm.swap(edge)
         rho = dm.rho
-        psi = psi.reshape((2, 2))
-        psi = np.tensordot(SWAP_TENSOR, psi, ((2, 3), edge))
-        psi = np.moveaxis(psi, (0, 1), edge)
-        expected_matrix2 = np.outer(psi, psi.conj())
+        psi_tensor = np.moveaxis(np.tensordot(SWAP_TENSOR, psi.reshape((2, 2)), ((2, 3), edge)), (0, 1), edge)
+        expected_matrix2 = np.outer(psi_tensor, psi_tensor.conj())
         assert np.allclose(rho, expected_matrix2)
 
     def test_entangle_fail(self) -> None:
@@ -392,10 +386,8 @@ class TestDensityMatrix:
         edge = (0, 1)
         dm.entangle(edge)
         rho = dm.rho
-        psi = psi.reshape((2, 2))
-        psi = np.tensordot(CZ_TENSOR, psi, ((2, 3), edge))
-        psi = np.moveaxis(psi, (0, 1), edge)
-        expected_matrix2 = np.outer(psi, psi.conj())
+        psi_tensor = np.moveaxis(np.tensordot(CZ_TENSOR, psi.reshape((2, 2)), ((2, 3), edge)), (0, 1), edge)
+        expected_matrix2 = np.outer(psi_tensor, psi_tensor.conj())
         assert np.allclose(rho, expected_matrix2)
 
     def test_evolve_success(self, fx_rng: Generator) -> None:
@@ -443,10 +435,12 @@ class TestDensityMatrix:
         dm.evolve(op, edge)
         rho = dm.rho
 
-        psi = psi.reshape((2,) * nqubits)
-        psi = np.tensordot(op.reshape((2,) * 2 * nqubits_op), psi, ((2, 3), edge))
-        psi = np.moveaxis(psi, (0, 1), edge)
-        expected_matrix = np.outer(psi, psi.conj())
+        psi_tensor = np.moveaxis(
+            np.tensordot(op.reshape((2,) * 2 * nqubits_op), psi.reshape((2,) * nqubits), ((2, 3), edge)),
+            (0, 1),
+            edge,
+        )
+        expected_matrix = np.outer(psi_tensor, psi_tensor.conj())
         assert np.allclose(rho, expected_matrix)
 
         # 3-qubit gate
@@ -468,10 +462,12 @@ class TestDensityMatrix:
         dm.evolve(op, targets)
         rho = dm.rho
 
-        psi = psi.reshape((2,) * nqubits)
-        psi = np.tensordot(op.reshape((2,) * 2 * nqubits_op), psi, ((3, 4, 5), targets))
-        psi = np.moveaxis(psi, (0, 1, 2), targets)
-        expected_matrix = np.outer(psi, psi.conj())
+        psi_tensor = np.moveaxis(
+            np.tensordot(op.reshape((2,) * 2 * nqubits_op), psi.reshape((2,) * nqubits), ((3, 4, 5), targets)),
+            (0, 1, 2),
+            targets,
+        )
+        expected_matrix = np.outer(psi_tensor, psi_tensor.conj())
         assert np.allclose(rho, expected_matrix)
 
     def test_evolve_fail(self, fx_rng: Generator) -> None:
@@ -641,6 +637,21 @@ class TestDensityMatrix:
         assert np.allclose(dm.rho, expected_dm)
 
     def test_apply_amplitude_damping_channel(self, fx_rng: Generator) -> None:
+        dm = DensityMatrix(randobj.rand_dm(2, fx_rng))
+        rho_test = np.asarray(dm.rho, dtype=np.complex128)
+
+        gamma = fx_rng.uniform()
+        channel = amplitude_damping_channel(gamma)
+
+        dm.apply_channel(channel, [0])
+
+        first_op = np.asarray(channel[0].operator, dtype=np.complex128)
+        second_op = np.asarray(channel[1].operator, dtype=np.complex128)
+        expected_dm = first_op @ rho_test @ first_op.conj().T + second_op @ rho_test @ second_op.conj().T
+
+        assert np.allclose(expected_dm.trace(), 1.0)
+        assert np.allclose(dm.rho, expected_dm)
+
         nqubits = int(fx_rng.integers(2, 5))
         i = int(fx_rng.integers(0, nqubits))
         psi = _randstate_raw(nqubits, fx_rng)

--- a/tests/test_density_matrix.py
+++ b/tests/test_density_matrix.py
@@ -12,7 +12,7 @@ import pytest
 import graphix.random_objects as randobj
 from graphix import command
 from graphix.branch_selector import ConstBranchSelector
-from graphix.channels import KrausChannel, dephasing_channel, depolarising_channel
+from graphix.channels import KrausChannel, amplitude_damping_channel, dephasing_channel, depolarising_channel
 from graphix.fundamentals import ANGLE_PI, Plane
 from graphix.ops import Ops
 from graphix.sim.density_matrix import DensityMatrix, DensityMatrixBackend
@@ -637,6 +637,21 @@ class TestDensityMatrix:
         ) ** 2 * np.outer(psi_evolvedb, psi_evolvedb.conj())
 
         # compare
+        assert np.allclose(expected_dm.trace(), 1.0)
+        assert np.allclose(dm.rho, expected_dm)
+
+    def test_apply_amplitude_damping_channel(self) -> None:
+        gamma = 0.25
+        dm = DensityMatrix(BasicStates.ONE)
+
+        channel = amplitude_damping_channel(gamma)
+
+        assert isinstance(channel, KrausChannel)
+
+        dm.apply_channel(channel, [0])
+
+        expected_dm = np.array([[gamma, 0.0], [0.0, 1 - gamma]])
+
         assert np.allclose(expected_dm.trace(), 1.0)
         assert np.allclose(dm.rho, expected_dm)
 

--- a/tests/test_density_matrix.py
+++ b/tests/test_density_matrix.py
@@ -640,17 +640,26 @@ class TestDensityMatrix:
         assert np.allclose(expected_dm.trace(), 1.0)
         assert np.allclose(dm.rho, expected_dm)
 
-    def test_apply_amplitude_damping_channel(self) -> None:
-        gamma = 0.25
-        dm = DensityMatrix(BasicStates.ONE)
+    def test_apply_amplitude_damping_channel(self, fx_rng: Generator) -> None:
+        nqubits = int(fx_rng.integers(2, 5))
+        i = int(fx_rng.integers(0, nqubits))
+        psi = _randstate_raw(nqubits, fx_rng)
+        psi /= np.sqrt(np.sum(np.abs(psi) ** 2))
 
+        dm = DensityMatrix(data=np.outer(psi, psi.conj()))
+        gamma = fx_rng.uniform()
         channel = amplitude_damping_channel(gamma)
 
         assert isinstance(channel, KrausChannel)
 
-        dm.apply_channel(channel, [0])
+        dm.apply_channel(channel, [i])
 
-        expected_dm = np.array([[gamma, 0.0], [0.0, 1 - gamma]])
+        expected_dm = np.zeros_like(dm.rho)
+        for kraus_data in channel:
+            psi_evolved = np.tensordot(kraus_data.operator, psi.reshape((2,) * nqubits), (1, i))
+            psi_evolved = np.moveaxis(psi_evolved, 0, i)
+            psi_evolved = np.reshape(psi_evolved, (2**nqubits))
+            expected_dm += kraus_data.coef**2 * np.outer(psi_evolved, psi_evolved.conj())
 
         assert np.allclose(expected_dm.trace(), 1.0)
         assert np.allclose(dm.rho, expected_dm)

--- a/tests/test_kraus.py
+++ b/tests/test_kraus.py
@@ -130,7 +130,6 @@ class TestChannel:
 
         channel = amplitude_damping_channel(gamma)
 
-        assert isinstance(channel, KrausChannel)
         assert channel.nqubit == 1
         assert len(channel) == 2
 

--- a/tests/test_kraus.py
+++ b/tests/test_kraus.py
@@ -9,8 +9,10 @@ import graphix.random_objects as randobj
 from graphix.channels import (
     KrausChannel,
     KrausData,
+    amplitude_damping_channel,
     dephasing_channel,
     depolarising_channel,
+    two_qubit_amplitude_damping_channel,
     two_qubit_depolarising_channel,
     two_qubit_depolarising_tensor_channel,
 )
@@ -118,6 +120,47 @@ class TestChannel:
         for i in range(len(depol_channel)):
             assert np.allclose(depol_channel[i].coef, data[i].coef)
             assert np.allclose(depol_channel[i].operator, data[i].operator)
+
+    def test_amplitude_damping_channel(self, fx_rng: Generator) -> None:
+        gamma = fx_rng.uniform()
+        data = [
+            KrausData(1.0, np.array([[1.0, 0.0], [0.0, np.sqrt(1 - gamma)]], dtype=np.complex128)),
+            KrausData(1.0, np.array([[0.0, np.sqrt(gamma)], [0.0, 0.0]], dtype=np.complex128)),
+        ]
+
+        channel = amplitude_damping_channel(gamma)
+
+        assert isinstance(channel, KrausChannel)
+        assert channel.nqubit == 1
+        assert len(channel) == 2
+
+        for i in range(len(channel)):
+            assert np.allclose(channel[i].coef, data[i].coef)
+            assert np.allclose(channel[i].operator, data[i].operator)
+
+    @pytest.mark.parametrize("gamma", [-0.1, 1.1])
+    def test_amplitude_damping_channel_invalid_gamma(self, gamma: float) -> None:
+        with pytest.raises(ValueError, match="gamma must be between 0 and 1"):
+            amplitude_damping_channel(gamma)
+
+    def test_2_qubit_amplitude_damping_channel(self, fx_rng: Generator) -> None:
+        gamma = fx_rng.uniform()
+        one_qubit_channel = amplitude_damping_channel(gamma)
+        data = [
+            KrausData(left.coef * right.coef, np.kron(left.operator, right.operator))
+            for left in one_qubit_channel
+            for right in one_qubit_channel
+        ]
+
+        channel = two_qubit_amplitude_damping_channel(gamma)
+
+        assert isinstance(channel, KrausChannel)
+        assert channel.nqubit == 2
+        assert len(channel) == 4
+
+        for i in range(len(channel)):
+            assert np.allclose(channel[i].coef, data[i].coef)
+            assert np.allclose(channel[i].operator, data[i].operator)
 
     def test_2_qubit_depolarising_channel(self, fx_rng: Generator) -> None:
         prob = fx_rng.uniform()

--- a/tests/test_kraus.py
+++ b/tests/test_kraus.py
@@ -140,7 +140,10 @@ class TestChannel:
 
     @pytest.mark.parametrize("gamma", [-0.1, 1.1])
     def test_amplitude_damping_channel_invalid_gamma(self, gamma: float) -> None:
-        with pytest.raises(ValueError, match="gamma must be between 0 and 1"):
+        with (
+            pytest.warns(RuntimeWarning, match="invalid value encountered in sqrt"),
+            pytest.raises(ValueError, match="The specified channel is not normalized"),
+        ):
             amplitude_damping_channel(gamma)
 
     def test_2_qubit_amplitude_damping_channel(self, fx_rng: Generator) -> None:

--- a/tests/test_noise_model.py
+++ b/tests/test_noise_model.py
@@ -6,12 +6,15 @@ import numpy as np
 import pytest
 
 from graphix import Pattern
-from graphix.command import CommandKind, M, N
+from graphix.command import CommandKind, E, M, N, X, Z
 from graphix.noise_models import (
+    AmplitudeDampingNoise,
+    AmplitudeDampingNoiseModel,
     ApplyNoise,
     ComposeNoiseModel,
     DepolarisingNoise,
     DepolarisingNoiseModel,
+    TwoQubitAmplitudeDampingNoise,
     TwoQubitDepolarisingNoise,
 )
 from graphix.noise_models.noise_model import NoiselessNoiseModel
@@ -100,6 +103,44 @@ def test_compose_noise_model_simulation(fx_rng: Generator) -> None:
     assert np.abs(np.dot(state_mbqc.flatten().conjugate(), DensityMatrix(state).rho.flatten())) == pytest.approx(1)
 
 
+def test_amplitude_damping_noise_model_transpile() -> None:
+    noise_model = AmplitudeDampingNoiseModel(
+        prepare_error_gamma=0.1,
+        entanglement_error_gamma=0.2,
+        measure_channel_gamma=0.3,
+        x_error_gamma=0.4,
+        z_error_gamma=0.5,
+    )
+    commands: list[CommandOrNoise] = [N(0), E((0, 1)), M(0), X(1, {0}), Z(1, {0})]
+
+    noisy_commands = noise_model.transpile(commands)
+
+    assert noisy_commands[0] == commands[0]
+    assert_apply_noise(noisy_commands[1], AmplitudeDampingNoise, 0.1, [0])
+    assert noisy_commands[2] == commands[1]
+    assert_apply_noise(noisy_commands[3], TwoQubitAmplitudeDampingNoise, 0.2, [0, 1])
+    assert_apply_noise(noisy_commands[4], AmplitudeDampingNoise, 0.3, [0])
+    assert noisy_commands[5] == commands[2]
+    assert noisy_commands[6] == commands[3]
+    assert_apply_noise(noisy_commands[7], AmplitudeDampingNoise, 0.4, [1], {0})
+    assert noisy_commands[8] == commands[4]
+    assert_apply_noise(noisy_commands[9], AmplitudeDampingNoise, 0.5, [1], {0})
+
+
+def test_amplitude_damping_noise_model_input_nodes() -> None:
+    input_noise = AmplitudeDampingNoiseModel(prepare_error_gamma=0.2).input_nodes([2, 4])
+
+    assert_apply_noise(input_noise[0], AmplitudeDampingNoise, 0.2, [2])
+    assert_apply_noise(input_noise[1], AmplitudeDampingNoise, 0.2, [4])
+
+
+def test_amplitude_damping_noise_model_confuse_result(fx_rng: Generator) -> None:
+    noise_model = AmplitudeDampingNoiseModel(measure_error_prob=1.0)
+
+    assert noise_model.confuse_result(M(0), 0, rng=fx_rng) == 1
+    assert noise_model.confuse_result(M(0), 1, rng=fx_rng) == 0
+
+
 def test_confuse_result(fx_rng: Generator) -> None:
     # Pattern that measures 0 on qubit 0 with probability 1.
     pattern = Pattern(cmds=[N(0), M(0)])
@@ -114,3 +155,17 @@ def test_confuse_result(fx_rng: Generator) -> None:
         backend="densitymatrix", noise_model=noise_model, rng=fx_rng, measure_method=measure_method
     )
     assert measure_method.results[0] == 1
+
+
+def assert_apply_noise(
+    cmd: CommandOrNoise,
+    noise_type: type[AmplitudeDampingNoise | TwoQubitAmplitudeDampingNoise],
+    gamma: float,
+    nodes: list[int],
+    domain: set[int] | None = None,
+) -> None:
+    assert isinstance(cmd, ApplyNoise)
+    assert isinstance(cmd.noise, noise_type)
+    assert cmd.noise.gamma == gamma
+    assert cmd.nodes == nodes
+    assert cmd.domain == domain

--- a/tests/test_noise_model.py
+++ b/tests/test_noise_model.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from graphix import Pattern
-from graphix.command import CommandKind, M, N
+from graphix.command import CommandKind, M, N, S, T
 from graphix.noise_models import (
     AmplitudeDampingNoise,
     AmplitudeDampingNoiseModel,
@@ -137,6 +137,27 @@ def test_amplitude_damping_noise_model_input_nodes() -> None:
 
     assert_apply_noise(input_noise[0], AmplitudeDampingNoise, 0.2, [2])
     assert_apply_noise(input_noise[1], AmplitudeDampingNoise, 0.2, [4])
+
+
+def test_amplitude_damping_noise_channels() -> None:
+    one_qubit_noise = AmplitudeDampingNoise(0.2)
+    two_qubit_noise = TwoQubitAmplitudeDampingNoise(0.3)
+
+    assert one_qubit_noise.nqubits == 1
+    assert two_qubit_noise.nqubits == 2
+    assert one_qubit_noise.to_kraus_channel().nqubit == 1
+    assert two_qubit_noise.to_kraus_channel().nqubit == 2
+
+
+def test_amplitude_damping_noise_model_passthrough_and_signal() -> None:
+    noise_model = AmplitudeDampingNoiseModel()
+    apply_noise = ApplyNoise(noise=AmplitudeDampingNoise(0.2), nodes=[0])
+    tick = T()
+
+    assert noise_model.command(tick) == [tick]
+    assert noise_model.command(apply_noise) == [apply_noise]
+    with pytest.raises(ValueError, match="Unexpected signal"):
+        noise_model.command(S(0))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_noise_model.py
+++ b/tests/test_noise_model.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from graphix import Pattern
-from graphix.command import CommandKind, E, M, N, X, Z
+from graphix.command import CommandKind, M, N
 from graphix.noise_models import (
     AmplitudeDampingNoise,
     AmplitudeDampingNoiseModel,
@@ -17,7 +17,7 @@ from graphix.noise_models import (
     TwoQubitAmplitudeDampingNoise,
     TwoQubitDepolarisingNoise,
 )
-from graphix.noise_models.noise_model import NoiselessNoiseModel
+from graphix.noise_models.noise_model import NoiselessNoiseModel, NoiseModel
 from graphix.random_objects import rand_circuit
 from graphix.sim.density_matrix import DensityMatrix
 from graphix.simulator import DefaultMeasureMethod
@@ -103,7 +103,7 @@ def test_compose_noise_model_simulation(fx_rng: Generator) -> None:
     assert np.abs(np.dot(state_mbqc.flatten().conjugate(), DensityMatrix(state).rho.flatten())) == pytest.approx(1)
 
 
-def test_amplitude_damping_noise_model_transpile() -> None:
+def test_amplitude_damping_noise_model_transpile(fx_rng: Generator) -> None:
     noise_model = AmplitudeDampingNoiseModel(
         prepare_error_gamma=0.1,
         entanglement_error_gamma=0.2,
@@ -111,20 +111,25 @@ def test_amplitude_damping_noise_model_transpile() -> None:
         x_error_gamma=0.4,
         z_error_gamma=0.5,
     )
-    commands: list[CommandOrNoise] = [N(0), E((0, 1)), M(0), X(1, {0}), Z(1, {0})]
+    nqubits = 5
+    depth = 5
+    pattern = rand_circuit(nqubits, depth, rng=fx_rng).transpile().pattern
+    noisy_pattern = noise_model.transpile(pattern, rng=fx_rng)
+    iterator = iter(noisy_pattern)
 
-    noisy_commands = noise_model.transpile(commands)
-
-    assert noisy_commands[0] == commands[0]
-    assert_apply_noise(noisy_commands[1], AmplitudeDampingNoise, 0.1, [0])
-    assert noisy_commands[2] == commands[1]
-    assert_apply_noise(noisy_commands[3], TwoQubitAmplitudeDampingNoise, 0.2, [0, 1])
-    assert_apply_noise(noisy_commands[4], AmplitudeDampingNoise, 0.3, [0])
-    assert noisy_commands[5] == commands[2]
-    assert noisy_commands[6] == commands[3]
-    assert_apply_noise(noisy_commands[7], AmplitudeDampingNoise, 0.4, [1], {0})
-    assert noisy_commands[8] == commands[4]
-    assert_apply_noise(noisy_commands[9], AmplitudeDampingNoise, 0.5, [1], {0})
+    for cmd in pattern:
+        if cmd.kind == CommandKind.M:
+            assert_apply_noise(next(iterator), AmplitudeDampingNoise, 0.3, [cmd.node])
+        assert next(iterator) == cmd
+        match cmd.kind:
+            case CommandKind.N:
+                assert_apply_noise(next(iterator), AmplitudeDampingNoise, 0.1, [cmd.node])
+            case CommandKind.E:
+                assert_apply_noise(next(iterator), TwoQubitAmplitudeDampingNoise, 0.2, list(cmd.nodes))
+            case CommandKind.X:
+                assert_apply_noise(next(iterator), AmplitudeDampingNoise, 0.4, [cmd.node], cmd.domain)
+            case CommandKind.Z:
+                assert_apply_noise(next(iterator), AmplitudeDampingNoise, 0.5, [cmd.node], cmd.domain)
 
 
 def test_amplitude_damping_noise_model_input_nodes() -> None:
@@ -134,14 +139,11 @@ def test_amplitude_damping_noise_model_input_nodes() -> None:
     assert_apply_noise(input_noise[1], AmplitudeDampingNoise, 0.2, [4])
 
 
-def test_amplitude_damping_noise_model_confuse_result(fx_rng: Generator) -> None:
-    noise_model = AmplitudeDampingNoiseModel(measure_error_prob=1.0)
-
-    assert noise_model.confuse_result(M(0), 0, rng=fx_rng) == 1
-    assert noise_model.confuse_result(M(0), 1, rng=fx_rng) == 0
-
-
-def test_confuse_result(fx_rng: Generator) -> None:
+@pytest.mark.parametrize(
+    "noise_model",
+    [DepolarisingNoiseModel(measure_error_prob=1), AmplitudeDampingNoiseModel(measure_error_prob=1)],
+)
+def test_confuse_result(fx_rng: Generator, noise_model: NoiseModel) -> None:
     # Pattern that measures 0 on qubit 0 with probability 1.
     pattern = Pattern(cmds=[N(0), M(0)])
     measure_method = DefaultMeasureMethod()
@@ -149,7 +151,6 @@ def test_confuse_result(fx_rng: Generator) -> None:
         backend="densitymatrix", noise_model=NoiselessNoiseModel(), rng=fx_rng, measure_method=measure_method
     )
     assert measure_method.results[0] == 0
-    noise_model = DepolarisingNoiseModel(measure_error_prob=1)
     measure_method = DefaultMeasureMethod()
     pattern.simulate_pattern(
         backend="densitymatrix", noise_model=noise_model, rng=fx_rng, measure_method=measure_method

--- a/tests/test_noisy_density_matrix.py
+++ b/tests/test_noisy_density_matrix.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
@@ -10,26 +10,20 @@ from graphix.branch_selector import ConstBranchSelector, FixedBranchSelector
 from graphix.command import CommandKind
 from graphix.fundamentals import angle_to_rad
 from graphix.noise_models import (
-    AmplitudeDampingNoise,
     AmplitudeDampingNoiseModel,
     DepolarisingNoiseModel,
-    TwoQubitAmplitudeDampingNoise,
 )
-from graphix.noise_models.noise_model import ApplyNoise, NoiselessNoiseModel
+from graphix.noise_models.noise_model import NoiselessNoiseModel
 from graphix.ops import Ops
-from graphix.pattern import Pattern
 from graphix.sim.density_matrix import DensityMatrix
 from graphix.transpiler import Circuit
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
-
     from numpy.random import Generator
 
-    from graphix.command import CommandType
     from graphix.fundamentals import Angle
     from graphix.measurements import Outcome
-    from graphix.noise_models import CommandOrNoise
+    from graphix.pattern import Pattern
 
 
 def rz_exact_res(alpha: Angle) -> npt.NDArray[np.float64]:
@@ -49,6 +43,63 @@ def single_qubit_amplitude_damping_exact(
     )
 
 
+def amplitude_damping_kraus_ops(gamma: float) -> tuple[npt.NDArray[np.complex128], npt.NDArray[np.complex128]]:
+    return (
+        np.array([[1.0, 0.0], [0.0, np.sqrt(1 - gamma)]], dtype=np.complex128),
+        np.array([[0.0, np.sqrt(gamma)], [0.0, 0.0]], dtype=np.complex128),
+    )
+
+
+def expand_single_qubit_op(op: npt.NDArray[np.complex128], target: int) -> npt.NDArray[np.complex128]:
+    identity = np.eye(2, dtype=np.complex128)
+    return (np.kron(op, identity) if target == 0 else np.kron(identity, op)).astype(np.complex128)
+
+
+def apply_amplitude_damping_to_hadamard_state(
+    rho: npt.NDArray[np.complex128], gamma: float, target: int
+) -> npt.NDArray[np.complex128]:
+    out = np.zeros_like(rho, dtype=np.complex128)
+    for kraus_op in amplitude_damping_kraus_ops(gamma):
+        expanded_op = expand_single_qubit_op(kraus_op, target)
+        out += expanded_op @ rho @ expanded_op.conj().T
+    return out
+
+
+def hadamard_measurement_exact(rho: npt.NDArray[np.complex128], outcome: Outcome) -> npt.NDArray[np.complex128]:
+    plus = np.array([1.0, 1.0], dtype=np.complex128) / np.sqrt(2)
+    minus = np.array([1.0, -1.0], dtype=np.complex128) / np.sqrt(2)
+    projector = np.outer(plus if outcome == 0 else minus, plus.conj() if outcome == 0 else minus.conj())
+    measurement_op = np.kron(projector, np.eye(2, dtype=np.complex128))
+    post_measurement = measurement_op @ rho @ measurement_op.conj().T
+    post_measurement /= np.trace(post_measurement)
+
+    output = np.asarray(np.einsum("abad->bd", post_measurement.reshape(2, 2, 2, 2)), dtype=np.complex128)
+    if outcome == 1:
+        output = Ops.X @ output @ Ops.X
+    return output
+
+
+def amplitude_damping_hadamard_stage_exact(gamma: float, stage: str, outcome: Outcome) -> npt.NDArray[np.complex128]:
+    plus = np.array([1.0, 1.0], dtype=np.complex128) / np.sqrt(2)
+    two_qubit_state = np.kron(plus, plus)
+    rho = np.outer(two_qubit_state, two_qubit_state.conj()).astype(np.complex128)
+    controlled_z = np.diag([1.0, 1.0, 1.0, -1.0]).astype(np.complex128)
+
+    if stage == "preparation":
+        rho = apply_amplitude_damping_to_hadamard_state(rho, gamma, 0)
+        rho = apply_amplitude_damping_to_hadamard_state(rho, gamma, 1)
+
+    rho = controlled_z @ rho @ controlled_z.conj().T
+
+    if stage == "entanglement":
+        rho = apply_amplitude_damping_to_hadamard_state(rho, gamma, 0)
+        rho = apply_amplitude_damping_to_hadamard_state(rho, gamma, 1)
+    elif stage == "measurement":
+        rho = apply_amplitude_damping_to_hadamard_state(rho, gamma, 0)
+
+    return hadamard_measurement_exact(rho, outcome)
+
+
 def hpat() -> Pattern:
     circ = Circuit(1)
     circ.h(0)
@@ -64,63 +115,6 @@ def rzpat(alpha: Angle) -> Pattern:
 def rz_measurement_results(rzpattern: Pattern, z_outcome: Outcome, x_outcome: Outcome) -> dict[int, Outcome]:
     m_nodes = (cmd.node for cmd in rzpattern if cmd.kind == CommandKind.M)
     return {next(m_nodes): z_outcome, next(m_nodes): x_outcome}
-
-
-def amplitude_damping_reference_pattern(rzpattern: Pattern, noise_model: AmplitudeDampingNoiseModel) -> Pattern:
-    cmds: list[CommandOrNoise] = list(noise_model.input_nodes(rzpattern.input_nodes))
-    for cmd in rzpattern:
-        match cmd.kind:
-            case CommandKind.N:
-                cmds.extend(
-                    [cmd, ApplyNoise(noise=AmplitudeDampingNoise(noise_model.prepare_error_gamma), nodes=[cmd.node])]
-                )
-            case CommandKind.E:
-                cmds.extend(
-                    [
-                        cmd,
-                        ApplyNoise(
-                            noise=TwoQubitAmplitudeDampingNoise(noise_model.entanglement_error_gamma),
-                            nodes=list(cmd.nodes),
-                        ),
-                    ],
-                )
-            case CommandKind.M:
-                cmds.extend(
-                    [
-                        ApplyNoise(noise=AmplitudeDampingNoise(noise_model.measure_channel_gamma), nodes=[cmd.node]),
-                        cmd,
-                    ],
-                )
-            case CommandKind.X:
-                cmds.extend(
-                    [
-                        cmd,
-                        ApplyNoise(
-                            noise=AmplitudeDampingNoise(noise_model.x_error_gamma),
-                            nodes=[cmd.node],
-                            domain=cmd.domain,
-                        ),
-                    ],
-                )
-            case CommandKind.Z:
-                cmds.extend(
-                    [
-                        cmd,
-                        ApplyNoise(
-                            noise=AmplitudeDampingNoise(noise_model.z_error_gamma),
-                            nodes=[cmd.node],
-                            domain=cmd.domain,
-                        ),
-                    ],
-                )
-            case _:
-                cmds.append(cmd)
-
-    return Pattern(
-        input_nodes=rzpattern.input_nodes,
-        cmds=cast("Iterable[CommandType]", cmds),
-        output_nodes=rzpattern.output_nodes,
-    )
 
 
 class TestNoisyDensityMatrixBackend:
@@ -527,23 +521,16 @@ class TestNoisyDensityMatrixBackend:
         assert isinstance(res, DensityMatrix)
         assert np.allclose(res.rho, expected)
 
-    @pytest.mark.parametrize(
-        "stage",
-        ["preparation", "entanglement", "measurement"],
-    )
-    @pytest.mark.parametrize("z_outcome", [0, 1])
-    @pytest.mark.parametrize("x_outcome", [0, 1])
-    def test_amplitude_damping_rz_noise_stages(
+    @pytest.mark.parametrize("stage", ["preparation", "entanglement", "measurement"])
+    @pytest.mark.parametrize("outcome", [0, 1])
+    def test_amplitude_damping_hadamard_noise_stages(
         self,
         fx_rng: Generator,
         stage: str,
-        z_outcome: Outcome,
-        x_outcome: Outcome,
+        outcome: Outcome,
     ) -> None:
-        alpha = fx_rng.random()
-        rzpattern = rzpat(alpha)
+        hadamardpattern = hpat()
         gamma = fx_rng.random()
-        results = rz_measurement_results(rzpattern, z_outcome, x_outcome)
 
         match stage:
             case "preparation":
@@ -555,22 +542,17 @@ class TestNoisyDensityMatrixBackend:
             case _:
                 raise ValueError("Unexpected amplitude damping stage")
 
-        res = rzpattern.simulate_pattern(
+        results: dict[int, Outcome] = {0: outcome}
+        res = hadamardpattern.simulate_pattern(
             backend="densitymatrix",
             noise_model=noise_model,
             branch_selector=FixedBranchSelector(results),
             rng=fx_rng,
         )
-        expected = amplitude_damping_reference_pattern(rzpattern, noise_model).simulate_pattern(
-            backend="densitymatrix",
-            noise_model=NoiselessNoiseModel(),
-            branch_selector=FixedBranchSelector(results),
-            rng=fx_rng,
-        )
+        expected = amplitude_damping_hadamard_stage_exact(gamma, stage, outcome)
 
         assert isinstance(res, DensityMatrix)
-        assert isinstance(expected, DensityMatrix)
-        assert np.allclose(res.rho, expected.rho)
+        assert np.allclose(res.rho, expected)
 
     @pytest.mark.parametrize("z_outcome", [0, 1])
     @pytest.mark.parametrize("x_outcome", [0, 1])

--- a/tests/test_noisy_density_matrix.py
+++ b/tests/test_noisy_density_matrix.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -9,18 +9,27 @@ import pytest
 from graphix.branch_selector import ConstBranchSelector, FixedBranchSelector
 from graphix.command import CommandKind
 from graphix.fundamentals import angle_to_rad
-from graphix.noise_models import AmplitudeDampingNoiseModel, DepolarisingNoiseModel
-from graphix.noise_models.noise_model import NoiselessNoiseModel
+from graphix.noise_models import (
+    AmplitudeDampingNoise,
+    AmplitudeDampingNoiseModel,
+    DepolarisingNoiseModel,
+    TwoQubitAmplitudeDampingNoise,
+)
+from graphix.noise_models.noise_model import ApplyNoise, NoiselessNoiseModel
 from graphix.ops import Ops
+from graphix.pattern import Pattern
 from graphix.sim.density_matrix import DensityMatrix
 from graphix.transpiler import Circuit
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from numpy.random import Generator
 
+    from graphix.command import CommandType
     from graphix.fundamentals import Angle
     from graphix.measurements import Outcome
-    from graphix.pattern import Pattern
+    from graphix.noise_models import CommandOrNoise
 
 
 def rz_exact_res(alpha: Angle) -> npt.NDArray[np.float64]:
@@ -50,6 +59,68 @@ def rzpat(alpha: Angle) -> Pattern:
     circ = Circuit(1)
     circ.rz(0, alpha)
     return circ.transpile().pattern
+
+
+def rz_measurement_results(rzpattern: Pattern, z_outcome: Outcome, x_outcome: Outcome) -> dict[int, Outcome]:
+    m_nodes = (cmd.node for cmd in rzpattern if cmd.kind == CommandKind.M)
+    return {next(m_nodes): z_outcome, next(m_nodes): x_outcome}
+
+
+def amplitude_damping_reference_pattern(rzpattern: Pattern, noise_model: AmplitudeDampingNoiseModel) -> Pattern:
+    cmds: list[CommandOrNoise] = list(noise_model.input_nodes(rzpattern.input_nodes))
+    for cmd in rzpattern:
+        match cmd.kind:
+            case CommandKind.N:
+                cmds.extend(
+                    [cmd, ApplyNoise(noise=AmplitudeDampingNoise(noise_model.prepare_error_gamma), nodes=[cmd.node])]
+                )
+            case CommandKind.E:
+                cmds.extend(
+                    [
+                        cmd,
+                        ApplyNoise(
+                            noise=TwoQubitAmplitudeDampingNoise(noise_model.entanglement_error_gamma),
+                            nodes=list(cmd.nodes),
+                        ),
+                    ],
+                )
+            case CommandKind.M:
+                cmds.extend(
+                    [
+                        ApplyNoise(noise=AmplitudeDampingNoise(noise_model.measure_channel_gamma), nodes=[cmd.node]),
+                        cmd,
+                    ],
+                )
+            case CommandKind.X:
+                cmds.extend(
+                    [
+                        cmd,
+                        ApplyNoise(
+                            noise=AmplitudeDampingNoise(noise_model.x_error_gamma),
+                            nodes=[cmd.node],
+                            domain=cmd.domain,
+                        ),
+                    ],
+                )
+            case CommandKind.Z:
+                cmds.extend(
+                    [
+                        cmd,
+                        ApplyNoise(
+                            noise=AmplitudeDampingNoise(noise_model.z_error_gamma),
+                            nodes=[cmd.node],
+                            domain=cmd.domain,
+                        ),
+                    ],
+                )
+            case _:
+                cmds.append(cmd)
+
+    return Pattern(
+        input_nodes=rzpattern.input_nodes,
+        cmds=cast("Iterable[CommandType]", cmds),
+        output_nodes=rzpattern.output_nodes,
+    )
 
 
 class TestNoisyDensityMatrixBackend:
@@ -348,8 +419,7 @@ class TestNoisyDensityMatrixBackend:
         print(f"x_error_pr = {x_error_pr}, outcome_z = {z_outcome}, outcome_x = {x_outcome}")
 
         # M(0) determines Z, M(1) determines X
-        m_nodes = (cmd.node for cmd in rzpattern if cmd.kind == CommandKind.M)
-        results: dict[int, Outcome] = {next(m_nodes): z_outcome, next(m_nodes): x_outcome}
+        results = rz_measurement_results(rzpattern, z_outcome, x_outcome)
 
         res = rzpattern.simulate_pattern(
             backend="densitymatrix",
@@ -422,8 +492,7 @@ class TestNoisyDensityMatrixBackend:
         rzpattern = rzpat(alpha)
         gamma = fx_rng.random()
 
-        m_nodes = (cmd.node for cmd in rzpattern if cmd.kind == CommandKind.M)
-        results: dict[int, Outcome] = {next(m_nodes): z_outcome, next(m_nodes): x_outcome}
+        results = rz_measurement_results(rzpattern, z_outcome, x_outcome)
 
         res = rzpattern.simulate_pattern(
             backend="densitymatrix",
@@ -444,8 +513,7 @@ class TestNoisyDensityMatrixBackend:
         rzpattern = rzpat(alpha)
         gamma = fx_rng.random()
 
-        m_nodes = (cmd.node for cmd in rzpattern if cmd.kind == CommandKind.M)
-        results: dict[int, Outcome] = {next(m_nodes): z_outcome, next(m_nodes): x_outcome}
+        results = rz_measurement_results(rzpattern, z_outcome, x_outcome)
 
         res = rzpattern.simulate_pattern(
             backend="densitymatrix",
@@ -458,6 +526,51 @@ class TestNoisyDensityMatrixBackend:
         expected = single_qubit_amplitude_damping_exact(exact, gamma) if z_outcome == 1 else exact
         assert isinstance(res, DensityMatrix)
         assert np.allclose(res.rho, expected)
+
+    @pytest.mark.parametrize(
+        "stage",
+        ["preparation", "entanglement", "measurement"],
+    )
+    @pytest.mark.parametrize("z_outcome", [0, 1])
+    @pytest.mark.parametrize("x_outcome", [0, 1])
+    def test_amplitude_damping_rz_noise_stages(
+        self,
+        fx_rng: Generator,
+        stage: str,
+        z_outcome: Outcome,
+        x_outcome: Outcome,
+    ) -> None:
+        alpha = fx_rng.random()
+        rzpattern = rzpat(alpha)
+        gamma = fx_rng.random()
+        results = rz_measurement_results(rzpattern, z_outcome, x_outcome)
+
+        match stage:
+            case "preparation":
+                noise_model = AmplitudeDampingNoiseModel(prepare_error_gamma=gamma)
+            case "entanglement":
+                noise_model = AmplitudeDampingNoiseModel(entanglement_error_gamma=gamma)
+            case "measurement":
+                noise_model = AmplitudeDampingNoiseModel(measure_channel_gamma=gamma)
+            case _:
+                raise ValueError("Unexpected amplitude damping stage")
+
+        res = rzpattern.simulate_pattern(
+            backend="densitymatrix",
+            noise_model=noise_model,
+            branch_selector=FixedBranchSelector(results),
+            rng=fx_rng,
+        )
+        expected = amplitude_damping_reference_pattern(rzpattern, noise_model).simulate_pattern(
+            backend="densitymatrix",
+            noise_model=NoiselessNoiseModel(),
+            branch_selector=FixedBranchSelector(results),
+            rng=fx_rng,
+        )
+
+        assert isinstance(res, DensityMatrix)
+        assert isinstance(expected, DensityMatrix)
+        assert np.allclose(res.rho, expected.rho)
 
     @pytest.mark.parametrize("z_outcome", [0, 1])
     @pytest.mark.parametrize("x_outcome", [0, 1])

--- a/tests/test_noisy_density_matrix.py
+++ b/tests/test_noisy_density_matrix.py
@@ -9,7 +9,7 @@ import pytest
 from graphix.branch_selector import ConstBranchSelector, FixedBranchSelector
 from graphix.command import CommandKind
 from graphix.fundamentals import angle_to_rad
-from graphix.noise_models import DepolarisingNoiseModel
+from graphix.noise_models import AmplitudeDampingNoiseModel, DepolarisingNoiseModel
 from graphix.noise_models.noise_model import NoiselessNoiseModel
 from graphix.ops import Ops
 from graphix.sim.density_matrix import DensityMatrix
@@ -26,6 +26,18 @@ if TYPE_CHECKING:
 def rz_exact_res(alpha: Angle) -> npt.NDArray[np.float64]:
     rad = angle_to_rad(alpha)
     return 0.5 * np.array([[1, np.exp(-1j * rad)], [np.exp(1j * rad), 1]])
+
+
+def single_qubit_amplitude_damping_exact(
+    rho: npt.NDArray[np.complex128 | np.float64], gamma: float
+) -> npt.NDArray[np.complex128]:
+    return np.array(
+        [
+            [rho[0, 0] + gamma * rho[1, 1], np.sqrt(1 - gamma) * rho[0, 1]],
+            [np.sqrt(1 - gamma) * rho[1, 0], (1 - gamma) * rho[1, 1]],
+        ],
+        dtype=np.complex128,
+    )
 
 
 def hpat() -> Pattern:
@@ -402,6 +414,50 @@ class TestNoisyDensityMatrixBackend:
                     ],
                 ),
             )
+
+    @pytest.mark.parametrize("z_outcome", [0, 1])
+    @pytest.mark.parametrize("x_outcome", [0, 1])
+    def test_amplitude_damping_x_rz(self, fx_rng: Generator, z_outcome: Outcome, x_outcome: Outcome) -> None:
+        alpha = fx_rng.random()
+        rzpattern = rzpat(alpha)
+        gamma = fx_rng.random()
+
+        m_nodes = (cmd.node for cmd in rzpattern if cmd.kind == CommandKind.M)
+        results: dict[int, Outcome] = {next(m_nodes): z_outcome, next(m_nodes): x_outcome}
+
+        res = rzpattern.simulate_pattern(
+            backend="densitymatrix",
+            noise_model=AmplitudeDampingNoiseModel(x_error_gamma=gamma),
+            branch_selector=FixedBranchSelector(results),
+            rng=fx_rng,
+        )
+
+        exact = rz_exact_res(alpha).astype(np.complex128)
+        expected = single_qubit_amplitude_damping_exact(exact, gamma) if x_outcome == 1 else exact
+        assert isinstance(res, DensityMatrix)
+        assert np.allclose(res.rho, expected)
+
+    @pytest.mark.parametrize("z_outcome", [0, 1])
+    @pytest.mark.parametrize("x_outcome", [0, 1])
+    def test_amplitude_damping_z_rz(self, fx_rng: Generator, z_outcome: Outcome, x_outcome: Outcome) -> None:
+        alpha = fx_rng.random()
+        rzpattern = rzpat(alpha)
+        gamma = fx_rng.random()
+
+        m_nodes = (cmd.node for cmd in rzpattern if cmd.kind == CommandKind.M)
+        results: dict[int, Outcome] = {next(m_nodes): z_outcome, next(m_nodes): x_outcome}
+
+        res = rzpattern.simulate_pattern(
+            backend="densitymatrix",
+            noise_model=AmplitudeDampingNoiseModel(z_error_gamma=gamma),
+            branch_selector=FixedBranchSelector(results),
+            rng=fx_rng,
+        )
+
+        exact = rz_exact_res(alpha).astype(np.complex128)
+        expected = single_qubit_amplitude_damping_exact(exact, gamma) if z_outcome == 1 else exact
+        assert isinstance(res, DensityMatrix)
+        assert np.allclose(res.rho, expected)
 
     @pytest.mark.parametrize("z_outcome", [0, 1])
     @pytest.mark.parametrize("x_outcome", [0, 1])


### PR DESCRIPTION
## Summary
- add single-qubit and two-qubit amplitude damping Kraus channels
- add `AmplitudeDampingNoise`, `TwoQubitAmplitudeDampingNoise`, and `AmplitudeDampingNoiseModel`
- export the new model through `graphix.noise_models` and top-level `graphix`

## Test soundness
- `tests/test_kraus.py` checks the exact Kraus matrices from the issue statement and the tensor-product construction for the two-qubit channel.
- `tests/test_noise_model.py` checks that a simple N/E/M/X/Z command sequence receives amplitude damping noise at the intended step, with the intended gamma, target nodes, and correction domains. It also checks input-node noise and deterministic classical readout flipping.
- `tests/test_density_matrix.py` checks direct density-matrix channel application on `|1><1|`, expecting `gamma |0><0| + (1 - gamma) |1><1|`.

## Validation
- `.venv/bin/python -m pytest tests/test_kraus.py tests/test_noise_model.py tests/test_density_matrix.py::TestDensityMatrix::test_apply_amplitude_damping_channel -q`
- `.venv/bin/python -m pytest tests/test_noisy_density_matrix.py -q`
- `.venv/bin/ruff check graphix/channels.py graphix/noise_models/amplitude_damping.py graphix/noise_models/__init__.py graphix/__init__.py tests/test_kraus.py tests/test_noise_model.py tests/test_density_matrix.py`
- `.venv/bin/ruff format --check graphix/channels.py graphix/noise_models/amplitude_damping.py graphix/noise_models/__init__.py graphix/__init__.py tests/test_kraus.py tests/test_noise_model.py tests/test_density_matrix.py`
- `.venv/bin/mypy graphix/channels.py graphix/noise_models/amplitude_damping.py graphix/noise_models/__init__.py graphix/__init__.py tests/test_kraus.py tests/test_noise_model.py`
- `.venv/bin/pyright --pythonpath .venv/bin/python graphix/channels.py graphix/noise_models/amplitude_damping.py graphix/noise_models/__init__.py graphix/__init__.py tests/test_kraus.py tests/test_noise_model.py`

## AI assistance
AI assistance was used to draft and check this change. I reviewed the implementation and tests before submitting.

Closes #497