### PR TITLE
Fix #531: Allow empty graphs in check_well_formed

### DIFF
--- a/graphix/flow/core.py
+++ b/graphix/flow/core.py
@@ -1379,9 +1379,7 @@ def _check_flow_general_properties(flow: PauliFlow[_AM_co]) -> None:
         - The first layer of the partial order layers is :math:`O`, the output nodes of the open graph. This is guaranteed because open graphs without outputs do not have flow.
     """
     if len(flow.og.graph.nodes) == 0:
-
         return
-
 
     if not _check_correction_function_domain(flow.og, flow.correction_function):
         raise FlowGenericError(FlowGenericErrorReason.IncorrectCorrectionFunctionDomain)

--- a/graphix/flow/core.py
+++ b/graphix/flow/core.py
@@ -1378,13 +1378,20 @@ def _check_flow_general_properties(flow: PauliFlow[_AM_co]) -> None:
         - The nodes in the partial order are the nodes in the open graph.
         - The first layer of the partial order layers is :math:`O`, the output nodes of the open graph. This is guaranteed because open graphs without outputs do not have flow.
     """
+    if len(flow.og.graph.nodes) == 0:
+
+        return
+
+
     if not _check_correction_function_domain(flow.og, flow.correction_function):
         raise FlowGenericError(FlowGenericErrorReason.IncorrectCorrectionFunctionDomain)
 
     if not _check_correction_function_image(flow.og, flow.correction_function):
         raise FlowGenericError(FlowGenericErrorReason.IncorrectCorrectionFunctionImage)
 
-    if len(flow.partial_order_layers) == 0:
+    if len(flow.partial_order_layers) == 0 and len(flow.og.graph.nodes) > 0:
+        if not flow.og.graph:
+            return
         raise PartialOrderError(PartialOrderErrorReason.Empty)
 
     first_layer = flow.partial_order_layers[0]

--- a/tests/test_empty_graph_fix.py
+++ b/tests/test_empty_graph_fix.py
@@ -1,0 +1,21 @@
+"""
+Test for issue #531: Allow empty graphs in check_well_formed
+"""
+import networkx as nx
+from graphix.opengraph import OpenGraph
+
+
+def test_empty_graph_well_formed():
+    """
+    Test that empty graphs pass the well-formedness check.
+    This is a regression test for issue #531.
+    """
+    og = OpenGraph(
+        graph=nx.Graph(),
+        input_nodes=[],
+        output_nodes=[],
+        measurements={}
+    )
+    pf = og.extract_causal_flow()
+    pf.check_well_formed()
+    assert True

--- a/tests/test_empty_graph_fix.py
+++ b/tests/test_empty_graph_fix.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import networkx as nx
 
-from graphix.opengraph import OpenGraph[Any]
+from graphix.opengraph import OpenGraph
 
 
 def test_empty_graph_well_formed() -> None:

--- a/tests/test_empty_graph_fix.py
+++ b/tests/test_empty_graph_fix.py
@@ -1,5 +1,7 @@
-from typing import Any
+"""Test empty graph fix."""
 from __future__ import annotations
+
+from typing import Any
 
 import networkx as nx
 
@@ -7,10 +9,7 @@ from graphix.opengraph import OpenGraph
 
 
 def test_empty_graph_well_formed() -> None:
-    """Test that empty graphs pass the well-formedness check.
 
-    This is a regression test for issue #531.
-    """
     og: OpenGraph[Any] = OpenGraph(graph=nx.Graph(), input_nodes=[], output_nodes=[], measurements={})
     pf = og.extract_causal_flow()
     pf.check_well_formed()

--- a/tests/test_empty_graph_fix.py
+++ b/tests/test_empty_graph_fix.py
@@ -6,12 +6,12 @@ import networkx as nx
 from graphix.opengraph import OpenGraph
 
 
-def test_empty_graph_well_formed():
+def test_empty_graph_well_formed() -> None:
     """
     Test that empty graphs pass the well-formedness check.
     This is a regression test for issue #531.
     """
-    og = OpenGraph(graph=nx.Graph(), input_nodes=[], output_nodes=[], measurements={})
+    og: OpenGraph = OpenGraph(graph=nx.Graph(), input_nodes=[], output_nodes=[], measurements={})
     pf = og.extract_causal_flow()
     pf.check_well_formed()
     assert True

--- a/tests/test_empty_graph_fix.py
+++ b/tests/test_empty_graph_fix.py
@@ -1,17 +1,21 @@
-"""Test empty graph fix."""
-
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING
 
 import networkx as nx
 
 from graphix.opengraph import OpenGraph
 
+if TYPE_CHECKING:
+    from graphix.measurement import Measurement
+
 
 def test_empty_graph_well_formed() -> None:
+    """Test that empty graphs pass the well-formedness check.
 
-    og: OpenGraph[Any] = OpenGraph(graph=nx.Graph(), input_nodes=[], output_nodes=[], measurements={})
+    This is a regression test for issue #531.
+    """
+    og: OpenGraph[Measurement] = OpenGraph(graph=nx.Graph(), input_nodes=[], output_nodes=[], measurements={})
     pf = og.extract_causal_flow()
     pf.check_well_formed()
     assert True

--- a/tests/test_empty_graph_fix.py
+++ b/tests/test_empty_graph_fix.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import networkx as nx
 
-from graphix.opengraph import OpenGraph
+from graphix.opengraph import OpenGraph[Any]
 
 
 def test_empty_graph_well_formed() -> None:

--- a/tests/test_empty_graph_fix.py
+++ b/tests/test_empty_graph_fix.py
@@ -7,7 +7,7 @@ import networkx as nx
 from graphix.opengraph import OpenGraph
 
 if TYPE_CHECKING:
-    from graphix.measurement import Measurement
+    from graphix.measurements import Measurement
 
 
 def test_empty_graph_well_formed() -> None:

--- a/tests/test_empty_graph_fix.py
+++ b/tests/test_empty_graph_fix.py
@@ -1,3 +1,4 @@
+from typing import Any
 from __future__ import annotations
 
 import networkx as nx
@@ -10,7 +11,7 @@ def test_empty_graph_well_formed() -> None:
 
     This is a regression test for issue #531.
     """
-    og: OpenGraph = OpenGraph(graph=nx.Graph(), input_nodes=[], output_nodes=[], measurements={})
+    og: OpenGraph[Any] = OpenGraph(graph=nx.Graph(), input_nodes=[], output_nodes=[], measurements={})
     pf = og.extract_causal_flow()
     pf.check_well_formed()
     assert True

--- a/tests/test_empty_graph_fix.py
+++ b/tests/test_empty_graph_fix.py
@@ -1,6 +1,7 @@
 """
 Test for issue #531: Allow empty graphs in check_well_formed
 """
+
 import networkx as nx
 from graphix.opengraph import OpenGraph
 
@@ -10,12 +11,7 @@ def test_empty_graph_well_formed():
     Test that empty graphs pass the well-formedness check.
     This is a regression test for issue #531.
     """
-    og = OpenGraph(
-        graph=nx.Graph(),
-        input_nodes=[],
-        output_nodes=[],
-        measurements={}
-    )
+    og = OpenGraph(graph=nx.Graph(), input_nodes=[], output_nodes=[], measurements={})
     pf = og.extract_causal_flow()
     pf.check_well_formed()
     assert True

--- a/tests/test_empty_graph_fix.py
+++ b/tests/test_empty_graph_fix.py
@@ -1,4 +1,5 @@
 """Test empty graph fix."""
+
 from __future__ import annotations
 
 from typing import Any

--- a/tests/test_empty_graph_fix.py
+++ b/tests/test_empty_graph_fix.py
@@ -1,14 +1,13 @@
-"""
-Test for issue #531: Allow empty graphs in check_well_formed
-"""
+from __future__ import annotations
 
 import networkx as nx
+
 from graphix.opengraph import OpenGraph
 
 
 def test_empty_graph_well_formed() -> None:
-    """
-    Test that empty graphs pass the well-formedness check.
+    """Test that empty graphs pass the well-formedness check.
+
     This is a regression test for issue #531.
     """
     og: OpenGraph = OpenGraph(graph=nx.Graph(), input_nodes=[], output_nodes=[], measurements={})

--- a/tests/test_issue_531.py
+++ b/tests/test_issue_531.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
+
 import networkx as nx
 
 from graphix.opengraph import OpenGraph
@@ -11,6 +12,7 @@ def test_empty_graph() -> None:
     pf = og.extract_causal_flow()
     pf.check_well_formed()  # This should NOT raise PartialOrderError anymore
     print("✅ Test passed! Empty graph is now well-formed.")
+
 
 if __name__ == "__main__":
     test_empty_graph()

--- a/tests/test_issue_531.py
+++ b/tests/test_issue_531.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+from typing import Any
 import networkx as nx
 
 from graphix.opengraph import OpenGraph
 
 
-def test_empty_graph():
-    og = OpenGraph(graph=nx.Graph(), input_nodes=[], output_nodes=[], measurements={})
+def test_empty_graph() -> None:
+    og: OpenGraph[Any] = OpenGraph(graph=nx.Graph(), input_nodes=[], output_nodes=[], measurements={})
     pf = og.extract_causal_flow()
     pf.check_well_formed()  # This should NOT raise PartialOrderError anymore
     print("✅ Test passed! Empty graph is now well-formed.")

--- a/tests/test_issue_531.py
+++ b/tests/test_issue_531.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
 
 import networkx as nx
+
 from graphix.opengraph import OpenGraph
+
 
 def test_empty_graph():
     og = OpenGraph(graph=nx.Graph(), input_nodes=[], output_nodes=[], measurements={})

--- a/tests/test_issue_531.py
+++ b/tests/test_issue_531.py
@@ -1,0 +1,12 @@
+
+import networkx as nx
+from graphix.opengraph import OpenGraph
+
+def test_empty_graph():
+    og = OpenGraph(graph=nx.Graph(), input_nodes=[], output_nodes=[], measurements={})
+    pf = og.extract_causal_flow()
+    pf.check_well_formed()  # This should NOT raise PartialOrderError anymore
+    print("✅ Test passed! Empty graph is now well-formed.")
+
+if __name__ == "__main__":
+    test_empty_graph()

--- a/tests/test_tnsim.py
+++ b/tests/test_tnsim.py
@@ -356,7 +356,7 @@ class TestTN:
         for qargs in itertools.permutations(input_list):
             value1 = state.expectation_value(random_op3, list(qargs))
             value2 = tn_mbqc.expectation_value(random_op3, list(qargs))
-            assert value1 == pytest.approx(value2)
+            assert value1 == pytest.approx(value2)  # pyright: ignore[reportUnknownMemberType]
 
     @pytest.mark.parametrize("jumps", range(1, 11))
     def test_coef_state(self, fx_bg: PCG64, jumps: int, fx_rng: Generator) -> None:
@@ -373,7 +373,7 @@ class TestTN:
             coef_tn = tn.basis_coefficient(number)
             coef_sv = statevec_ref.flatten()[number]
 
-            assert abs(coef_tn) == pytest.approx(abs(coef_sv))
+            assert abs(coef_tn) == pytest.approx(abs(coef_sv))  # pyright: ignore[reportUnknownMemberType]
 
     @pytest.mark.parametrize(("nqubits", "jumps"), itertools.product(range(2, 6), range(1, 6)))
     def test_to_statevector(self, fx_bg: PCG64, nqubits: int, jumps: int, fx_rng: Generator) -> None:
@@ -408,4 +408,4 @@ class TestTN:
         expval_tn = tn_mbqc.expectation_value(random_op3_exp, [0, 1, 2])
         expval_ref = state.expectation_value(random_op3_exp, [0, 1, 2])
 
-        assert expval_tn == pytest.approx(expval_ref)
+        assert expval_tn == pytest.approx(expval_ref)  # pyright: ignore[reportUnknownMemberType]


### PR DESCRIPTION
Before submitting, please check the following:

- Make sure you have tests for the new code and that test passes (run `nox`)
- If applicable, add a line to the [unreleased] part of CHANGELOG.md, following [keep-a-changelog](https://keepachangelog.com/en/1.0.0/).
- Format added code by `ruff`
  - See `CONTRIBUTING.md` for more details
- Make sure the checks (github actions) pass.

Then, please fill in below:

**Context (if applicable):** Fixes issue #531 where empty graphs were incorrectly rejected by check_well_formed()



**Description of the change:** - Added early return for empty graphs in _check_flow_general_properties
- Modified partial order check to allow empty graphs
- Test case from issue #531 now passes



**Related issue:**
