### PR TITLE
Fix #553: Handle visualization of empty graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Empty outputs layer removed from flow's partial order.
   - Flow well-formedness check does not trigger false negative for flows on open graphs without outputs.
 
+- #562: Fixed #553. Handle visualization of empty graphs.
+
 ### Changed
 
 - #452: Use `uv` for dependency management

--- a/graphix/visualization.py
+++ b/graphix/visualization.py
@@ -216,14 +216,6 @@ class GraphVisualizer:
         GraphVisualizer
         """
         options = VisualizationOptions(**kwargs)
-        if not og.graph.nodes:
-            return GraphVisualizer(
-                og=og,
-                pos={},
-                edge_paths={},
-                options=options,
-                _source=_Source.OG,
-            )
         pos = _compute_positions(og)
         pos = _scale_positions(pos, options.node_distance)
         edge_paths = _compute_edge_paths(og, pos)
@@ -254,14 +246,6 @@ class GraphVisualizer:
         GraphVisualizer
         """
         options = VisualizationOptions(**kwargs)
-        if not flow.og.graph.nodes:
-            return GraphVisualizer(
-                og=flow.og,
-                pos={},
-                edge_paths={},
-                options=options,
-                _source=_Source.Flow,
-            )
         pos = _compute_positions(flow)
         pos = _scale_positions(pos, options.node_distance)
         edge_paths = _compute_edge_paths(flow.og, pos)
@@ -297,14 +281,6 @@ class GraphVisualizer:
         GraphVisualizer
         """
         options = VisualizationOptions(**kwargs)
-        if not xz_corr.og.graph.nodes:
-            return GraphVisualizer(
-                og=xz_corr.og,
-                pos={},
-                edge_paths={},
-                options=options,
-                _source=_Source.XZCorr,
-            )
         pos = _compute_positions(xz_corr)
         pos = _scale_positions(pos, options.node_distance)
         edge_paths = _compute_edge_paths(xz_corr.og, pos)
@@ -665,6 +641,8 @@ def _(obj: OpenGraph[AbstractMeasurement]) -> dict[int, _Point]:
         X-coordinates represent the layer in the partial order (higher x = earlier layer).
         Y-coordinates represent the vertical position within start node chains.
     """
+    if not obj.graph.nodes:
+        return {}
     layers: dict[int, int] = {}
     connected_components = list(nx.connected_components(obj.graph))
 

--- a/graphix/visualization.py
+++ b/graphix/visualization.py
@@ -215,9 +215,15 @@ class GraphVisualizer:
         -------
         GraphVisualizer
         """
-        if not og.graph.nodes:
-            raise ValueError("Open graph is empty.")
         options = VisualizationOptions(**kwargs)
+        if not og.graph.nodes:
+            return GraphVisualizer(
+                og=og,
+                pos={},
+                edge_paths={},
+                options=options,
+                _source=_Source.OG,
+            )
         pos = _compute_positions(og)
         pos = _scale_positions(pos, options.node_distance)
         edge_paths = _compute_edge_paths(og, pos)
@@ -247,9 +253,15 @@ class GraphVisualizer:
         -------
         GraphVisualizer
         """
-        if not flow.og.graph.nodes:
-            raise ValueError("Open graph is empty.")
         options = VisualizationOptions(**kwargs)
+        if not flow.og.graph.nodes:
+            return GraphVisualizer(
+                og=flow.og,
+                pos={},
+                edge_paths={},
+                options=options,
+                _source=_Source.Flow,
+            )
         pos = _compute_positions(flow)
         pos = _scale_positions(pos, options.node_distance)
         edge_paths = _compute_edge_paths(flow.og, pos)
@@ -284,9 +296,15 @@ class GraphVisualizer:
         -------
         GraphVisualizer
         """
-        if not xz_corr.og.graph.nodes:
-            raise ValueError("Open graph is empty.")
         options = VisualizationOptions(**kwargs)
+        if not xz_corr.og.graph.nodes:
+            return GraphVisualizer(
+                og=xz_corr.og,
+                pos={},
+                edge_paths={},
+                options=options,
+                _source=_Source.XZCorr,
+            )
         pos = _compute_positions(xz_corr)
         pos = _scale_positions(pos, options.node_distance)
         edge_paths = _compute_edge_paths(xz_corr.og, pos)
@@ -350,6 +368,10 @@ class GraphVisualizer:
         for node in self.og.graph.nodes():
             x_pos.add(self.pos[node][0])
             y_pos.add(self.pos[node][1])
+
+        # Empty graphs
+        if not x_pos or not y_pos:
+            return (2.0, 2.0)
 
         width = len(x_pos) * 0.8
         height = len(y_pos)
@@ -566,6 +588,8 @@ class GraphVisualizer:
 
         Legend is customized depending on the object being plotted (flow or XZ-corections) indicated in ``self._source``.
         """
+        if not self.og.graph.nodes:
+            return
         plt.scatter(
             [],
             [],

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -199,6 +199,13 @@ def test_og() -> None:
     pattern.draw(annotations=None)
 
 
+@pytest.mark.usefixtures("mock_plot")
+@pytest.mark.parametrize("annotations", [None, DrawPatternAnnotations.Flow, DrawPatternAnnotations.XZCorrections])
+def test_empty(annotations: DrawPatternAnnotations | None) -> None:
+    pattern = Pattern()
+    pattern.draw(annotations=annotations)
+
+
 # Compare with baseline/test_draw_graph_reference.png
 # Update baseline by running: pytest --mpl-generate-path=tests/baseline
 @pytest.mark.usefixtures("mock_plot")


### PR DESCRIPTION
Visualization methods yield an empty canvas instead of raising a `ValueError` when called on an empty graph.
