### PR TITLE
Improve the documentation for instructions

### DIFF
--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -84,32 +84,7 @@ This module defines data structures for single-qubit measurements in MBQC.
 This module defines standard data structure for gate seqence (circuit model) used for :class:`graphix.transpiler.Circuit`.
 
 .. automodule:: graphix.instruction
-
-.. currentmodule:: graphix.instruction
-
-.. autoclass:: InstructionKind
-
-.. autoclass:: RX
-
-.. autoclass:: RZ
-
-.. autoclass:: RY
-
-.. autoclass:: M
-
-.. autoclass:: X
-
-.. autoclass:: Y
-
-.. autoclass:: Z
-
-.. autoclass:: S
-
-.. autoclass:: H
-
-.. autoclass:: SWAP
-
-.. autoclass:: CNOT
+    :members:
 
 :mod:`graphix.parameter` module
 +++++++++++++++++++++++++++++++

--- a/graphix/instruction.py
+++ b/graphix/instruction.py
@@ -404,8 +404,8 @@ class RX(_KindChecker, RotationInstruction):
     .. math::
 
       \left[\begin{matrix}
-        \cos \theta & -\mathrm i \sin \theta\\
-        -\mathrm i \sin \theta & \cos \theta
+        \cos \frac \theta 2 & -\mathrm i \sin \frac \theta 2\\
+        -\mathrm i \sin \frac \theta 2 & \cos \frac \theta 2
       \end{matrix}\right]
     """
 
@@ -421,8 +421,8 @@ class RY(_KindChecker, RotationInstruction):
     .. math::
 
       \left[\begin{matrix}
-        \cos \theta & - \sin \theta\\
-        \sin \theta & \cos \theta
+        \cos \frac \theta 2 & - \sin \frac \theta 2\\
+        \sin \frac \theta 2 & \cos \frac \theta 2
       \end{matrix}\right]
     """
 

--- a/graphix/instruction.py
+++ b/graphix/instruction.py
@@ -459,7 +459,7 @@ class J(_KindChecker, RotationInstruction):
         1 & - \mathrm e^{\mathrm i \theta}
       \end{matrix}\right]
 
-    We have :math:`J(\theta) = H \mathrm{RZ}(\theta)`.
+    We have :math:`J(\theta) = \mathrm e^{\mathrm i \theta/2} H \mathrm{RZ}(\theta)`.
     """
 
     kind: ClassVar[Literal[InstructionKind.J]] = field(default=InstructionKind.J, init=False)

--- a/graphix/instruction.py
+++ b/graphix/instruction.py
@@ -118,7 +118,23 @@ class BaseInstruction(ABC, DataclassReprMixin):
 
 @dataclass(repr=False)
 class CCX(_KindChecker, BaseInstruction):
-    """Toffoli circuit instruction."""
+    r"""Toffoli circuit instruction.
+
+    The CCX gate applies the matrix
+
+    .. math::
+
+      \left[\begin{matrix}
+      1 & 0 & 0 & 0 & 0 & 0 & 0 & 0 \\
+      0 & 1 & 0 & 0 & 0 & 0 & 0 & 0 \\
+      0 & 0 & 1 & 0 & 0 & 0 & 0 & 0 \\
+      0 & 0 & 0 & 1 & 0 & 0 & 0 & 0 \\
+      0 & 0 & 0 & 0 & 1 & 0 & 0 & 0 \\
+      0 & 0 & 0 & 0 & 0 & 1 & 0 & 0 \\
+      0 & 0 & 0 & 0 & 0 & 0 & 0 & 1 \\
+      0 & 0 & 0 & 0 & 0 & 0 & 1 & 0 \\
+      \end{matrix}\right]
+    """
 
     target: int
     controls: tuple[int, int]
@@ -138,7 +154,21 @@ class CCX(_KindChecker, BaseInstruction):
 
 @dataclass(repr=False)
 class RZZ(_KindChecker, BaseInstruction):
-    """RZZ circuit instruction."""
+    r"""RZZ circuit instruction.
+
+    The :math:`\mathrm{RZZ}(\theta)` gate applies the matrix
+
+    .. math::
+
+      \left[\begin{matrix}
+        \mathrm e^{-\mathrm i \frac \theta 2} & 0 & 0 & 0\\
+        0 & \mathrm e^{\mathrm i \frac \theta 2} & 0 & 0\\
+        0 & 0 & \mathrm e^{\mathrm i \frac \theta 2} & 0\\
+        0 & 0 & 0 & \mathrm e^{-\mathrm i \frac \theta 2}
+      \end{matrix}\right]
+
+    We have :math:`\mathrm{RZZ}(\theta) = \mathrm{CNOT} (I \otimes \mathrm{RZ}(\theta)) \mathrm{CNOT}`.
+    """
 
     target: int
     control: int
@@ -160,7 +190,19 @@ class RZZ(_KindChecker, BaseInstruction):
 
 @dataclass(repr=False)
 class CNOT(_KindChecker, BaseInstruction):
-    """CNOT circuit instruction."""
+    r"""CNOT circuit instruction.
+
+    The CNOT gate applies the matrix
+
+    .. math::
+
+      \left[\begin{matrix}
+        1 & 0 & 0 & 0\\
+        0 & 1 & 0 & 0\\
+        0 & 0 & 0 & 1\\
+        0 & 0 & 1 & 0
+      \end{matrix}\right]
+    """
 
     target: int
     control: int
@@ -179,7 +221,19 @@ class CNOT(_KindChecker, BaseInstruction):
 
 @dataclass(repr=False)
 class CZ(_KindChecker, BaseInstruction):
-    """CZ circuit instruction."""
+    r"""CZ circuit instruction.
+
+    The CZ gate applies the matrix
+
+    .. math::
+
+      \left[\begin{matrix}
+        1 & 0 & 0 & 0\\
+        0 & 1 & 0 & 0\\
+        0 & 0 & 1 & 0\\
+        0 & 0 & 0 & -1
+      \end{matrix}\right]
+    """
 
     targets: tuple[int, int]
     kind: ClassVar[Literal[InstructionKind.CZ]] = field(default=InstructionKind.CZ, init=False)
@@ -196,7 +250,19 @@ class CZ(_KindChecker, BaseInstruction):
 
 @dataclass(repr=False)
 class SWAP(_KindChecker, BaseInstruction):
-    """SWAP circuit instruction."""
+    r"""SWAP circuit instruction.
+
+    The SWAP gate applies the matrix
+
+    .. math::
+
+      \left[\begin{matrix}
+        1 & 0 & 0 & 0\\
+        0 & 0 & 1 & 0\\
+        0 & 1 & 0 & 0\\
+        0 & 0 & 0 & 1
+      \end{matrix}\right]
+    """
 
     targets: tuple[int, int]
     kind: ClassVar[Literal[InstructionKind.SWAP]] = field(default=InstructionKind.SWAP, init=False)
@@ -228,42 +294,66 @@ class SingleTargetInstruction(BaseInstruction):
 
 @dataclass(repr=False)
 class H(_KindChecker, SingleTargetInstruction):
-    """H circuit instruction."""
+    r"""H circuit instruction.
+
+    The Hadamard gate applies the matrix
+    :math:`\frac 1 {\sqrt 2}\left[\begin{matrix}1 & 1\\1 & -1\end{matrix}\right]`.
+    """
 
     kind: ClassVar[Literal[InstructionKind.H]] = field(default=InstructionKind.H, init=False)
 
 
 @dataclass(repr=False)
 class S(_KindChecker, SingleTargetInstruction):
-    """S circuit instruction."""
+    r"""S circuit instruction.
+
+    The S gate applies the matrix
+    :math:`\left[\begin{matrix}1 & 0\\0 & \mathrm i\end{matrix}\right]`.
+    """
 
     kind: ClassVar[Literal[InstructionKind.S]] = field(default=InstructionKind.S, init=False)
 
 
 @dataclass(repr=False)
 class X(_KindChecker, SingleTargetInstruction):
-    """X circuit instruction."""
+    r"""X circuit instruction.
+
+    The X gate applies the matrix
+    :math:`\left[\begin{matrix}0 & 1\\1 & 0\end{matrix}\right]`.
+    """
 
     kind: ClassVar[Literal[InstructionKind.X]] = field(default=InstructionKind.X, init=False)
 
 
 @dataclass(repr=False)
 class Y(_KindChecker, SingleTargetInstruction):
-    """Y circuit instruction."""
+    r"""Y circuit instruction.
+
+    The Y gate applies the matrix
+    :math:`\left[\begin{matrix}0 & -\mathrm i\\\mathrm i & 0\end{matrix}\right]`.
+    """
 
     kind: ClassVar[Literal[InstructionKind.Y]] = field(default=InstructionKind.Y, init=False)
 
 
 @dataclass(repr=False)
 class Z(_KindChecker, SingleTargetInstruction):
-    """Z circuit instruction."""
+    r"""Z circuit instruction.
+
+    The Z gate applies the matrix
+    :math:`\left[\begin{matrix}1 & 0\\\mathrm 0 & -1\end{matrix}\right]`.
+    """
 
     kind: ClassVar[Literal[InstructionKind.Z]] = field(default=InstructionKind.Z, init=False)
 
 
 @dataclass(repr=False)
 class I(_KindChecker, SingleTargetInstruction):
-    """I circuit instruction."""
+    r"""I circuit instruction.
+
+    The identity gate applies the matrix
+    :math:`\left[\begin{matrix}1 & 0\\\mathrm 0 & 1\end{matrix}\right]`.
+    """
 
     kind: ClassVar[Literal[InstructionKind.I]] = field(default=InstructionKind.I, init=False)
 
@@ -307,28 +397,70 @@ class RotationInstruction(BaseInstruction):
 
 @dataclass(repr=False)
 class RX(_KindChecker, RotationInstruction):
-    """X rotation circuit instruction."""
+    r"""X rotation circuit instruction.
+
+    The :math:`RX(\theta)` gate applies the matrix
+
+    .. math::
+
+      \left[\begin{matrix}
+        \cos \theta & -\mathrm i \sin \theta\\
+        -\mathrm i \sin \theta & \cos \theta
+      \end{matrix}\right]
+    """
 
     kind: ClassVar[Literal[InstructionKind.RX]] = field(default=InstructionKind.RX, init=False)
 
 
 @dataclass(repr=False)
 class RY(_KindChecker, RotationInstruction):
-    """Y rotation circuit instruction."""
+    r"""Y rotation circuit instruction.
+
+    The :math:`RY(\theta)` gate applies the matrix
+
+    .. math::
+
+      \left[\begin{matrix}
+        \cos \theta & - \sin \theta\\
+        \sin \theta & \cos \theta
+      \end{matrix}\right]
+    """
 
     kind: ClassVar[Literal[InstructionKind.RY]] = field(default=InstructionKind.RY, init=False)
 
 
 @dataclass(repr=False)
 class RZ(_KindChecker, RotationInstruction):
-    """Z rotation circuit instruction."""
+    r"""Z rotation circuit instruction.
+
+    The :math:`RZ(\theta)` gate applies the matrix
+
+    .. math::
+
+      \left[\begin{matrix}
+        \mathrm e^{-\mathrm i \frac \theta 2} & 0\\
+        0 & \mathrm e^{\mathrm i \frac \theta 2}
+      \end{matrix}\right]
+    """
 
     kind: ClassVar[Literal[InstructionKind.RZ]] = field(default=InstructionKind.RZ, init=False)
 
 
 @dataclass(repr=False)
 class J(_KindChecker, RotationInstruction):
-    """J circuit instruction."""
+    r"""J circuit instruction.
+
+    The :math:`J(\theta)` gate applies the matrix
+
+    .. math::
+
+      \frac 1 {\sqrt 2} \left[\begin{matrix}
+        1 & \mathrm e^{\mathrm i \theta}\\
+        1 & - \mathrm e^{\mathrm i \theta}
+      \end{matrix}\right]
+
+    We have :math:`J(\theta) = H \mathrm{RZ}(\theta)`.
+    """
 
     kind: ClassVar[Literal[InstructionKind.J]] = field(default=InstructionKind.J, init=False)
 

--- a/graphix/transpiler.py
+++ b/graphix/transpiler.py
@@ -17,7 +17,7 @@ import networkx as nx
 # override introduced in Python 3.12
 from typing_extensions import assert_never, override
 
-from graphix import command, instruction, parameter
+from graphix import Instruction, command, parameter
 from graphix.branch_selector import BranchSelector, RandomBranchSelector
 from graphix.flow.core import CausalFlow, _corrections_to_partial_order_layers
 from graphix.fundamentals import ANGLE_PI, Axis
@@ -126,7 +126,7 @@ class Circuit(InplaceParameterizable):
         ----------
         width : int
             number of logical qubits for the gate network
-        instr : list[instruction.InstructionType] | None
+        instr : list[InstructionType] | None
             Optional. List of initial instructions.
         """
         self.width = width
@@ -185,6 +185,8 @@ class Circuit(InplaceParameterizable):
     def cnot(self, control: int, target: int) -> None:
         """Apply a CNOT gate.
 
+        See :class:`~graphix.instruction.CNOT` for more information.
+
         Parameters
         ----------
         control : int
@@ -195,10 +197,12 @@ class Circuit(InplaceParameterizable):
         assert control in self.active_qubits
         assert target in self.active_qubits
         assert control != target
-        self.instruction.append(instruction.CNOT(control=control, target=target))
+        self.instruction.append(Instruction.CNOT(control=control, target=target))
 
     def swap(self, qubit1: int, qubit2: int) -> None:
         """Apply a SWAP gate.
+
+        See :class:`~graphix.instruction.SWAP` for more information.
 
         Parameters
         ----------
@@ -210,10 +214,12 @@ class Circuit(InplaceParameterizable):
         assert qubit1 in self.active_qubits
         assert qubit2 in self.active_qubits
         assert qubit1 != qubit2
-        self.instruction.append(instruction.SWAP(targets=(qubit1, qubit2)))
+        self.instruction.append(Instruction.SWAP(targets=(qubit1, qubit2)))
 
     def cz(self, qubit1: int, qubit2: int) -> None:
-        """Apply a CNOT gate.
+        """Apply a CZ gate.
+
+        See :class:`~graphix.instruction.CZ` for more information.
 
         Parameters
         ----------
@@ -225,65 +231,77 @@ class Circuit(InplaceParameterizable):
         assert qubit1 in self.active_qubits
         assert qubit2 in self.active_qubits
         assert qubit1 != qubit2
-        self.instruction.append(instruction.CZ(targets=(qubit1, qubit2)))
+        self.instruction.append(Instruction.CZ(targets=(qubit1, qubit2)))
 
     def h(self, qubit: int) -> None:
         """Apply a Hadamard gate.
 
+        See :class:`~graphix.instruction.H` for more information.
+
         Parameters
         ----------
         qubit : int
             target qubit
         """
         assert qubit in self.active_qubits
-        self.instruction.append(instruction.H(target=qubit))
+        self.instruction.append(Instruction.H(target=qubit))
 
     def s(self, qubit: int) -> None:
         """Apply an S gate.
 
+        See :class:`~graphix.instruction.S` for more information.
+
         Parameters
         ----------
         qubit : int
             target qubit
         """
         assert qubit in self.active_qubits
-        self.instruction.append(instruction.S(target=qubit))
+        self.instruction.append(Instruction.S(target=qubit))
 
     def x(self, qubit: int) -> None:
         """Apply a Pauli X gate.
 
+        See :class:`~graphix.instruction.X` for more information.
+
         Parameters
         ----------
         qubit : int
             target qubit
         """
         assert qubit in self.active_qubits
-        self.instruction.append(instruction.X(target=qubit))
+        self.instruction.append(Instruction.X(target=qubit))
 
     def y(self, qubit: int) -> None:
         """Apply a Pauli Y gate.
 
+        See :class:`~graphix.instruction.Y` for more information.
+
         Parameters
         ----------
         qubit : int
             target qubit
         """
         assert qubit in self.active_qubits
-        self.instruction.append(instruction.Y(target=qubit))
+        self.instruction.append(Instruction.Y(target=qubit))
 
     def z(self, qubit: int) -> None:
         """Apply a Pauli Z gate.
 
+        See :class:`~graphix.instruction.Z` for more information.
+
         Parameters
         ----------
         qubit : int
             target qubit
         """
         assert qubit in self.active_qubits
-        self.instruction.append(instruction.Z(target=qubit))
+        self.instruction.append(Instruction.Z(target=qubit))
 
     def rx(self, qubit: int, angle: ParameterizedAngle) -> None:
         """Apply an X rotation gate.
+
+        See :class:`~graphix.instruction.RX` for more information.
 
         Parameters
         ----------
@@ -293,10 +311,12 @@ class Circuit(InplaceParameterizable):
             rotation angle in units of π
         """
         assert qubit in self.active_qubits
-        self.instruction.append(instruction.RX(target=qubit, angle=angle))
+        self.instruction.append(Instruction.RX(target=qubit, angle=angle))
 
     def ry(self, qubit: int, angle: ParameterizedAngle) -> None:
         """Apply a Y rotation gate.
+
+        See :class:`~graphix.instruction.RY` for more information.
 
         Parameters
         ----------
@@ -306,11 +326,13 @@ class Circuit(InplaceParameterizable):
             angle in units of π
         """
         assert qubit in self.active_qubits
-        self.instruction.append(instruction.RY(target=qubit, angle=angle))
+        self.instruction.append(Instruction.RY(target=qubit, angle=angle))
 
     def rz(self, qubit: int, angle: ParameterizedAngle) -> None:
         """Apply a Z rotation gate.
 
+        See :class:`~graphix.instruction.RZ` for more information.
+
         Parameters
         ----------
         qubit : int
@@ -319,11 +341,13 @@ class Circuit(InplaceParameterizable):
             rotation angle in units of π
         """
         assert qubit in self.active_qubits
-        self.instruction.append(instruction.RZ(target=qubit, angle=angle))
+        self.instruction.append(Instruction.RZ(target=qubit, angle=angle))
 
     def j(self, qubit: int, angle: ParameterizedAngle) -> None:
         """Apply a J rotation gate.
 
+        See :class:`~graphix.instruction.J` for more information.
+
         Parameters
         ----------
         qubit : int
@@ -332,7 +356,7 @@ class Circuit(InplaceParameterizable):
             rotation angle in units of π
         """
         assert qubit in self.active_qubits
-        self.instruction.append(instruction.J(target=qubit, angle=angle))
+        self.instruction.append(Instruction.J(target=qubit, angle=angle))
 
     def r(self, qubit: int, axis: Axis, angle: ParameterizedAngle) -> None:
         """Apply a rotation gate on the given axis.
@@ -367,6 +391,8 @@ class Circuit(InplaceParameterizable):
         and realizes rotation expressed by
         :math:`e^{-i \frac{\theta}{2} Z_c Z_t}`.
 
+        See :class:`~graphix.instruction.RZZ` for more information.
+
         Parameters
         ----------
         control : int
@@ -378,13 +404,15 @@ class Circuit(InplaceParameterizable):
         """
         assert control in self.active_qubits
         assert target in self.active_qubits
-        self.instruction.append(instruction.RZZ(control=control, target=target, angle=angle))
+        self.instruction.append(Instruction.RZZ(control=control, target=target, angle=angle))
 
     def ccx(self, control1: int, control2: int, target: int) -> None:
         r"""Apply a CCX (Toffoli) gate.
 
-        Prameters
-        ---------
+        See :class:`~graphix.instruction.CCX` for more information.
+
+        Parameters
+        ----------
         control1 : int
             first control qubit
         control2 : int
@@ -398,10 +426,12 @@ class Circuit(InplaceParameterizable):
         assert control1 != control2
         assert control1 != target
         assert control2 != target
-        self.instruction.append(instruction.CCX(controls=(control1, control2), target=target))
+        self.instruction.append(Instruction.CCX(controls=(control1, control2), target=target))
 
     def i(self, qubit: int) -> None:
         """Apply an identity (teleportation) gate.
+
+        See :class:`~graphix.instruction.I` for more information.
 
         Parameters
         ----------
@@ -409,12 +439,14 @@ class Circuit(InplaceParameterizable):
             target qubit
         """
         assert qubit in self.active_qubits
-        self.instruction.append(instruction.I(target=qubit))
+        self.instruction.append(Instruction.I(target=qubit))
 
     def m(self, qubit: int, axis: Axis) -> None:
         """Measure a quantum qubit.
 
         The measured qubit cannot be used afterwards.
+
+        See :class:`~graphix.instruction.M` for more information.
 
         Parameters
         ----------
@@ -424,7 +456,7 @@ class Circuit(InplaceParameterizable):
             measurement basis
         """
         assert qubit in self.active_qubits
-        self.instruction.append(instruction.M(target=qubit, axis=axis))
+        self.instruction.append(Instruction.M(target=qubit, axis=axis))
         self.active_qubits.remove(qubit)
 
     def transpile_to_causalflow(self) -> TranspiledFlow:
@@ -600,39 +632,39 @@ class Circuit(InplaceParameterizable):
                 _backend.state.evolve(op, [_backend.node_index.index(qarg) for qarg in qargs])
 
             match instr.kind:
-                case instruction.InstructionKind.CNOT:
+                case InstructionKind.CNOT:
                     evolve(Ops.CNOT, [instr.control, instr.target])
-                case instruction.InstructionKind.SWAP:
+                case InstructionKind.SWAP:
                     u, v = instr.targets
                     _backend.state.swap((_backend.node_index.index(u), _backend.node_index.index(v)))
-                case instruction.InstructionKind.CZ:
+                case InstructionKind.CZ:
                     u, v = instr.targets
                     _backend.state.entangle((_backend.node_index.index(u), _backend.node_index.index(v)))
-                case instruction.InstructionKind.I:
+                case InstructionKind.I:
                     pass
-                case instruction.InstructionKind.S:
+                case InstructionKind.S:
                     evolve_single(Ops.S, instr.target)
-                case instruction.InstructionKind.H:
+                case InstructionKind.H:
                     evolve_single(Ops.H, instr.target)
-                case instruction.InstructionKind.X:
+                case InstructionKind.X:
                     evolve_single(Ops.X, instr.target)
-                case instruction.InstructionKind.Y:
+                case InstructionKind.Y:
                     evolve_single(Ops.Y, instr.target)
-                case instruction.InstructionKind.Z:
+                case InstructionKind.Z:
                     evolve_single(Ops.Z, instr.target)
-                case instruction.InstructionKind.RX:
+                case InstructionKind.RX:
                     evolve_single(Ops.rx(instr.angle), instr.target)
-                case instruction.InstructionKind.RY:
+                case InstructionKind.RY:
                     evolve_single(Ops.ry(instr.angle), instr.target)
-                case instruction.InstructionKind.RZ:
+                case InstructionKind.RZ:
                     evolve_single(Ops.rz(instr.angle), instr.target)
-                case instruction.InstructionKind.J:
+                case InstructionKind.J:
                     evolve_single(Ops.j(instr.angle), instr.target)
-                case instruction.InstructionKind.RZZ:
+                case InstructionKind.RZZ:
                     evolve(Ops.rzz(instr.angle), [instr.control, instr.target])
-                case instruction.InstructionKind.CCX:
+                case InstructionKind.CCX:
                     evolve(Ops.CCX, [instr.controls[0], instr.controls[1], instr.target])
-                case instruction.InstructionKind.M:
+                case InstructionKind.M:
                     result = _backend.measure(
                         instr.target, PauliMeasurement(instr.axis), rng=rng, stacklevel=stacklevel + 1
                     )
@@ -743,14 +775,14 @@ class Circuit(InplaceParameterizable):
         for instr in self.instruction:
             match instr.kind:
                 case InstructionKind.J:
-                    new_circuit.add(instruction.RZ(target=instr.target, angle=instr.angle))
-                    new_circuit.add(instruction.H(target=instr.target))
+                    new_circuit.add(Instruction.RZ(target=instr.target, angle=instr.angle))
+                    new_circuit.add(Instruction.H(target=instr.target))
                 case _:
                     new_circuit.add(instr)
         return new_circuit
 
 
-def decompose_rzz(instr: instruction.RZZ) -> Iterator[instruction.CNOT | instruction.RZ]:
+def decompose_rzz(instr: Instruction.RZZ) -> Iterator[Instruction.CNOT | Instruction.RZ]:
     """Yield a decomposition of RZZ(α) gate as CNOT(control, target)·Rz(target, α)·CNOT(control, target).
 
     Parameters
@@ -762,14 +794,14 @@ def decompose_rzz(instr: instruction.RZZ) -> Iterator[instruction.CNOT | instruc
         the decomposition.
 
     """
-    yield instruction.CNOT(target=instr.target, control=instr.control)
-    yield instruction.RZ(instr.target, instr.angle)
-    yield instruction.CNOT(target=instr.target, control=instr.control)
+    yield Instruction.CNOT(target=instr.target, control=instr.control)
+    yield Instruction.RZ(instr.target, instr.angle)
+    yield Instruction.CNOT(target=instr.target, control=instr.control)
 
 
 def decompose_ccx(
-    instr: instruction.CCX,
-) -> Iterator[instruction.H | instruction.CNOT | instruction.RZ]:
+    instr: Instruction.CCX,
+) -> Iterator[Instruction.H | Instruction.CNOT | Instruction.RZ]:
     """Yield a decomposition of the CCX gate into H, CNOT, T and T-dagger gates.
 
     This decomposition of the Toffoli gate can be found in
@@ -788,25 +820,25 @@ def decompose_ccx(
 
     """
     c0, c1, t = instr.controls[0], instr.controls[1], instr.target
-    yield instruction.H(t)
-    yield instruction.CNOT(control=c1, target=t)
-    yield instruction.RZ(t, -ANGLE_PI / 4)
-    yield instruction.CNOT(control=c0, target=t)
-    yield instruction.RZ(t, ANGLE_PI / 4)
-    yield instruction.CNOT(control=c1, target=t)
-    yield instruction.RZ(t, -ANGLE_PI / 4)
-    yield instruction.CNOT(control=c0, target=t)
-    yield instruction.RZ(c1, -ANGLE_PI / 4)
-    yield instruction.RZ(t, ANGLE_PI / 4)
-    yield instruction.CNOT(control=c0, target=c1)
-    yield instruction.H(t)
-    yield instruction.RZ(c1, -ANGLE_PI / 4)
-    yield instruction.CNOT(control=c0, target=c1)
-    yield instruction.RZ(c0, ANGLE_PI / 4)
-    yield instruction.RZ(c1, ANGLE_PI / 2)
+    yield Instruction.H(t)
+    yield Instruction.CNOT(control=c1, target=t)
+    yield Instruction.RZ(t, -ANGLE_PI / 4)
+    yield Instruction.CNOT(control=c0, target=t)
+    yield Instruction.RZ(t, ANGLE_PI / 4)
+    yield Instruction.CNOT(control=c1, target=t)
+    yield Instruction.RZ(t, -ANGLE_PI / 4)
+    yield Instruction.CNOT(control=c0, target=t)
+    yield Instruction.RZ(c1, -ANGLE_PI / 4)
+    yield Instruction.RZ(t, ANGLE_PI / 4)
+    yield Instruction.CNOT(control=c0, target=c1)
+    yield Instruction.H(t)
+    yield Instruction.RZ(c1, -ANGLE_PI / 4)
+    yield Instruction.CNOT(control=c0, target=c1)
+    yield Instruction.RZ(c0, ANGLE_PI / 4)
+    yield Instruction.RZ(c1, ANGLE_PI / 2)
 
 
-def decompose_cnot(instr: instruction.CNOT) -> Iterator[instruction.H | instruction.CZ]:
+def decompose_cnot(instr: Instruction.CNOT) -> Iterator[Instruction.H | Instruction.CZ]:
     """Yield a decomposition of the CNOT gate as H·∧z·H.
 
     Vincent Danos, Elham Kashefi, Prakash Panangaden, The Measurement Calculus, 2007.
@@ -820,12 +852,12 @@ def decompose_cnot(instr: instruction.CNOT) -> Iterator[instruction.H | instruct
         the decomposition.
 
     """
-    yield instruction.H(instr.target)
-    yield instruction.CZ((instr.control, instr.target))
-    yield instruction.H(instr.target)
+    yield Instruction.H(instr.target)
+    yield Instruction.CZ((instr.control, instr.target))
+    yield Instruction.H(instr.target)
 
 
-def decompose_swap(instr: instruction.SWAP) -> Iterator[instruction.CNOT]:
+def decompose_swap(instr: Instruction.SWAP) -> Iterator[Instruction.CNOT]:
     """Yield a decomposition of the SWAP gate as CNOT(0, 1)·CNOT(1, 0)·CNOT(0, 1).
 
     Michael A. Nielsen and Isaac L. Chuang,
@@ -842,12 +874,12 @@ def decompose_swap(instr: instruction.SWAP) -> Iterator[instruction.CNOT]:
         the decomposition.
 
     """
-    yield instruction.CNOT(control=instr.targets[0], target=instr.targets[1])
-    yield instruction.CNOT(control=instr.targets[1], target=instr.targets[0])
-    yield instruction.CNOT(control=instr.targets[0], target=instr.targets[1])
+    yield Instruction.CNOT(control=instr.targets[0], target=instr.targets[1])
+    yield Instruction.CNOT(control=instr.targets[1], target=instr.targets[0])
+    yield Instruction.CNOT(control=instr.targets[0], target=instr.targets[1])
 
 
-def decompose_y(instr: instruction.Y) -> Iterator[instruction.X | instruction.Z]:
+def decompose_y(instr: Instruction.Y) -> Iterator[Instruction.X | Instruction.Z]:
     """Return a decomposition of the Y gate as X·Z.
 
     Parameters
@@ -859,11 +891,11 @@ def decompose_y(instr: instruction.Y) -> Iterator[instruction.X | instruction.Z]
         the decomposition.
 
     """
-    yield instruction.Z(instr.target)
-    yield instruction.X(instr.target)
+    yield Instruction.Z(instr.target)
+    yield Instruction.X(instr.target)
 
 
-def decompose_rx(instr: instruction.RX) -> Iterator[instruction.J]:
+def decompose_rx(instr: Instruction.RX) -> Iterator[Instruction.J]:
     """Yield a J decomposition of the RX gate.
 
     The Rx(α) gate is decomposed into J(α)·H (that is to say, J(α)·J(0)).
@@ -878,11 +910,11 @@ def decompose_rx(instr: instruction.RX) -> Iterator[instruction.J]:
         the decomposition.
 
     """
-    yield instruction.J(instr.target, 0)
-    yield instruction.J(instr.target, instr.angle)
+    yield Instruction.J(instr.target, 0)
+    yield Instruction.J(instr.target, instr.angle)
 
 
-def decompose_ry(instr: instruction.RY) -> Iterator[instruction.J]:
+def decompose_ry(instr: Instruction.RY) -> Iterator[Instruction.J]:
     """Yield a J decomposition of the RY gate.
 
     The Ry(α) gate is decomposed into J(0)·J(π/2)·J(α)·J(-π/2).
@@ -898,13 +930,13 @@ def decompose_ry(instr: instruction.RY) -> Iterator[instruction.J]:
         the decomposition.
 
     """
-    yield instruction.J(target=instr.target, angle=-ANGLE_PI / 2)
-    yield instruction.J(target=instr.target, angle=instr.angle)
-    yield instruction.J(target=instr.target, angle=ANGLE_PI / 2)
-    yield instruction.J(target=instr.target, angle=0)
+    yield Instruction.J(target=instr.target, angle=-ANGLE_PI / 2)
+    yield Instruction.J(target=instr.target, angle=instr.angle)
+    yield Instruction.J(target=instr.target, angle=ANGLE_PI / 2)
+    yield Instruction.J(target=instr.target, angle=0)
 
 
-def decompose_rz(instr: instruction.RZ) -> Iterator[instruction.J]:
+def decompose_rz(instr: Instruction.RZ) -> Iterator[Instruction.J]:
     """Yield a J decomposition of the RZ gate.
 
     The Rz(α) gate is decomposed into H·J(α) (that is to say, J(0)·J(α)).
@@ -919,12 +951,12 @@ def decompose_rz(instr: instruction.RZ) -> Iterator[instruction.J]:
         the decomposition.
 
     """
-    yield instruction.J(target=instr.target, angle=instr.angle)
-    yield instruction.J(target=instr.target, angle=0)
+    yield Instruction.J(target=instr.target, angle=instr.angle)
+    yield Instruction.J(target=instr.target, angle=0)
 
 
-def instructions_to_jcz(instrs: Iterable[InstructionType]) -> Iterator[instruction.J | instruction.CZ | instruction.M]:
-    """Yield a J-∧z decomposition of the instruction.
+def instructions_to_jcz(instrs: Iterable[InstructionType]) -> Iterator[Instruction.J | Instruction.CZ | Instruction.M]:
+    """Yield a J-∧z decomposition of the Instruction.
 
     Parameters
     ----------
@@ -942,15 +974,15 @@ def instructions_to_jcz(instrs: Iterable[InstructionType]) -> Iterator[instructi
             case InstructionKind.I:
                 return
             case InstructionKind.H:
-                yield instruction.J(instr.target, 0)
+                yield Instruction.J(instr.target, 0)
             case InstructionKind.S:
-                yield from decompose_rz(instruction.RZ(instr.target, ANGLE_PI / 2))
+                yield from decompose_rz(Instruction.RZ(instr.target, ANGLE_PI / 2))
             case InstructionKind.X:
-                yield from decompose_rx(instruction.RX(instr.target, ANGLE_PI))
+                yield from decompose_rx(Instruction.RX(instr.target, ANGLE_PI))
             case InstructionKind.Y:
                 yield from instructions_to_jcz(decompose_y(instr))
             case InstructionKind.Z:
-                yield from decompose_rz(instruction.RZ(instr.target, ANGLE_PI))
+                yield from decompose_rz(Instruction.RZ(instr.target, ANGLE_PI))
             case InstructionKind.RX:
                 yield from decompose_rx(instr)
             case InstructionKind.RY:


### PR DESCRIPTION
This commit improves the documentation for instructions by systematically providing their matrices and linking `Circuit` methods to the instruction classes.