### PR TITLE
Ensure RNG persistence during hybrid branch selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - #586: Fixed #584 Swap transpilation of measured qubits.
 
+- #591: `FixedBranchSelector` now passes its RNG parameter to its `default` branch selector.
+
 ### Changed
 
 - #452: Use `uv` for dependency management

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- #591: `FixedBranchSelector` now passes its RNG parameter to its `default` branch selector.
+
 ## [0.4] - 2026-08-18
 
 ### Added
@@ -85,8 +91,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #583, #585: Compatibility with numpy 2.5.
 
 - #586: Fixed #584 Swap transpilation of measured qubits.
-
-- #591: `FixedBranchSelector` now passes its RNG parameter to its `default` branch selector.
 
 ### Changed
 

--- a/graphix/branch_selector.py
+++ b/graphix/branch_selector.py
@@ -134,7 +134,7 @@ class FixedBranchSelector(BranchSelector, Generic[_T]):
         if result is None:
             if self.default is None:
                 raise ValueError(f"Unexpected measurement of qubit {qubit}.")
-            return self.default.measure(qubit, f_expectation0, rng)
+            return self.default.measure(qubit, f_expectation0, rng, stacklevel=stacklevel + 1)
         return result
 
 

--- a/graphix/branch_selector.py
+++ b/graphix/branch_selector.py
@@ -134,7 +134,7 @@ class FixedBranchSelector(BranchSelector, Generic[_T]):
         if result is None:
             if self.default is None:
                 raise ValueError(f"Unexpected measurement of qubit {qubit}.")
-            return self.default.measure(qubit, f_expectation0)
+            return self.default.measure(qubit, f_expectation0, rng)
         return result
 
 

--- a/tests/test_branch_selector.py
+++ b/tests/test_branch_selector.py
@@ -5,6 +5,7 @@ import itertools
 import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+import warnings
 
 import pytest
 from typing_extensions import override
@@ -12,6 +13,7 @@ from typing_extensions import override
 from graphix import Pattern
 from graphix.branch_selector import ConstBranchSelector, FixedBranchSelector, RandomBranchSelector
 from graphix.command import M, N
+from graphix.fundamentals import Angle
 from graphix.measurements import Measurement
 from graphix.simulator import DefaultMeasureMethod
 
@@ -147,6 +149,32 @@ def test_fixed_branch_selector_no_default(backend: _BackendLiteral) -> None:
     measure_method = DefaultMeasureMethod()
     with pytest.raises(ValueError):
         pattern.simulate(backend, branch_selector=branch_selector, measure_method=measure_method)
+
+@pytest.mark.filterwarnings("ignore:Simulating using densitymatrix backend with no noise.")
+@pytest.mark.parametrize(
+    "backend",
+    [
+        "statevector",
+        "densitymatrix",
+        "tensornetwork",
+    ],
+)
+def test_hybrid_branch_selector(fx_rng: Generator, backend: _BackendLiteral) -> None:
+    pattern = Pattern(cmds=[N(0), N(1), M(0, Measurement.XY(0.5)), M(1, Measurement.XY(0.5))])
+    # Enforce measurement of qubit 0 to have result = 0
+    results: dict[int, Outcome] = {0: 0}
+    # Measurement of qubit 1 should have expectation value = 0.5
+    random_bs = CheckedBranchSelector(expected={1: 0.5})
+    hybrid_bs = FixedBranchSelector(results, default=random_bs)
+
+    with warnings.catch_warnings(record=True) as wlist:
+        warnings.simplefilter("always", UserWarning)
+        for _ in range(NB_ROUNDS):
+            measure_method = DefaultMeasureMethod()
+            pattern.simulate(backend, branch_selector=hybrid_bs, measure_method=measure_method, rng=fx_rng)
+            assert measure_method.results[0] == 0
+
+    assert not any(str(w.message).startswith("Default random-number generator is used.") for w in wlist)
 
 
 @pytest.mark.filterwarnings("ignore:Simulating using densitymatrix backend with no noise.")

--- a/tests/test_branch_selector.py
+++ b/tests/test_branch_selector.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import dataclasses
 import itertools
 import math
+import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
-import warnings
 
 import pytest
 from typing_extensions import override
@@ -13,7 +13,6 @@ from typing_extensions import override
 from graphix import Pattern
 from graphix.branch_selector import ConstBranchSelector, FixedBranchSelector, RandomBranchSelector
 from graphix.command import M, N
-from graphix.fundamentals import Angle
 from graphix.measurements import Measurement
 from graphix.simulator import DefaultMeasureMethod
 
@@ -149,6 +148,7 @@ def test_fixed_branch_selector_no_default(backend: _BackendLiteral) -> None:
     measure_method = DefaultMeasureMethod()
     with pytest.raises(ValueError):
         pattern.simulate(backend, branch_selector=branch_selector, measure_method=measure_method)
+
 
 @pytest.mark.filterwarnings("ignore:Simulating using densitymatrix backend with no noise.")
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR fixes a bug where simulating a pattern using a `FixedBranchSelector` on a partial `results` mapping and a `RandomBranchSelector` for the remaining qubits always uses an un-seeded default RNG, even if a seeded one is passed to the  `PatternSimulator`. Consider the following example:
```python
from numpy.random import default_rng
from graphix import Pattern, Measurement, RandomBranchSelector, FixedBranchSelector
from graphix.command import N, M
from graphix.measurements import Outcome

pattern = Pattern(cmds=[N(0), N(1), M(0), M(1, Measurement.XY(0.5))])

results: dict[int, Outcome] = {0: 0}
rbs = RandomBranchSelector()
fbs = FixedBranchSelector(results, default=rbs)
rng_seeded = default_rng(seed=42)

pattern.simulate(branch_selector=fbs, rng=rng_seeded)
```
The above code raises `UserWarning: Default random-number generator is used. Results may not be reproducible.` on `graphix/branch_selector.py:137` where the `FixedBranchSelector` calls 
```python
self.default.measure(qubit, f_expectation0)
```
without passing its `rng` parameter to the `default` branch selector. With this update, we now include the `rng` argument in the function call on this line which ensures that the RNG object provided to the `PatternSimulator` reaches the `RandomBranchSelector`.

In addition, a new test was added to verify this behaviour.