### PR TITLE
Fix #596: Update `n_node` after Pauli removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - #591: `FixedBranchSelector` now passes its RNG parameter to its `default` branch selector.
+- #596, #597: Pattern's `n_node` property updated after Pauli removal.
 
 ## [0.4] - 2026-08-18
 

--- a/graphix/pattern.py
+++ b/graphix/pattern.py
@@ -1923,6 +1923,7 @@ class Pattern(InplaceParameterizable):
             return pattern
         self.__seq = pattern.__seq
         self.__output_nodes = pattern.__output_nodes
+        self.__n_node = pattern.n_node
         return self
 
     def remove_local_clifford_commands(self, *, copy: bool = False) -> Pattern:

--- a/tests/test_remove_pauli_measurements.py
+++ b/tests/test_remove_pauli_measurements.py
@@ -20,6 +20,7 @@ from graphix import (
     Sign,
     StandardizedPattern,
 )
+from graphix.command import M, N
 from graphix.random_objects import rand_circuit, rand_state_vector
 from graphix.remove_pauli_measurements import PauliPushingCut, _RemovePauliMeasurements, remove_pauli_measurements
 
@@ -330,3 +331,12 @@ def test_isolated_nodes_non_pauli() -> None:
     with pytest.warns(UserWarning, match="Non-Pauli measurement on an isolated node was removed."):
         pattern.remove_pauli_measurements()
     assert list(pattern) == []
+
+
+@pytest.mark.parametrize("copy", [True, False])
+def test_n_nodes(copy: bool) -> None:
+    pattern = Pattern(cmds=[N(0), M(0)])
+
+    p = pattern.remove_pauli_measurements(copy=copy)
+
+    assert len(p.to_opengraph().graph) == p.n_node


### PR DESCRIPTION
One line fix. Failing case reported in #596 is added to the test suite.